### PR TITLE
Add a method to download licenses

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 python-debian==0.1.34
+requests==2.21.0
 spdx-tools==0.5.4
 license-expression==0.99
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,12 @@ from warnings import warn
 
 from setuptools import setup
 
-requirements = ["python-debian", "spdx-tools", "license-expression"]
+requirements = [
+    "python-debian",
+    "requests",
+    "spdx-tools",
+    "license-expression",
+]
 
 test_requirements = ["pytest"]
 

--- a/src/reuse/_main.py
+++ b/src/reuse/_main.py
@@ -10,7 +10,7 @@ import sys
 from gettext import gettext as _
 from typing import List
 
-from . import __version__, lint, spdx, download
+from . import __version__, download, lint, spdx
 from ._format import INDENT, fill_all, fill_paragraph
 from ._util import setup_logging
 

--- a/src/reuse/_main.py
+++ b/src/reuse/_main.py
@@ -128,7 +128,7 @@ def add_command(  # pylint: disable=too-many-arguments
     subparser.set_defaults(func=run_func)
 
 
-def main(args: List[str] = None, out=sys.stdout) -> None:
+def main(args: List[str] = None, out=sys.stdout) -> int:
     """Main entry function."""
     if args is None:
         args = sys.argv[1:]

--- a/src/reuse/_main.py
+++ b/src/reuse/_main.py
@@ -10,7 +10,7 @@ import sys
 from gettext import gettext as _
 from typing import List
 
-from . import __version__, lint, spdx
+from . import __version__, lint, spdx, download
 from ._format import INDENT, fill_all, fill_paragraph
 from ._util import setup_logging
 
@@ -75,6 +75,32 @@ def parser() -> argparse.ArgumentParser:
         lint.run,
         help=_("list all non-compliant files"),
         description=fill_all(_("TODO")),
+    )
+
+    add_command(
+        subparsers,
+        "download",
+        download.add_arguments,
+        download.run,
+        help=_("download a license and place it in the LICENSES/ directory"),
+        description=fill_all(
+            _(
+                "Download a license and place it in the LICENSES/ directory.\n"
+                "\n"
+                "The LICENSES/ directory is automatically found in the "
+                "following order:\n"
+                "\n"
+                "- The LICENSES/ directory in the root of the VCS "
+                "repository.\n"
+                "\n"
+                "- The current directory if its name is LICENSES.\n"
+                "\n"
+                "- The LICENSES/ directory in the current directory.\n"
+                "\n"
+                "If the LICENSES/ directory cannot be found, one is simply "
+                "created."
+            )
+        ),
     )
 
     return parser

--- a/src/reuse/_util.py
+++ b/src/reuse/_util.py
@@ -74,7 +74,7 @@ def execute_command(
 
 
 def find_root() -> Optional[Path]:
-    """Try to find the root of the project from $PWD. If none is found, return
+    """Try to find the root of the project from CWD. If none is found, return
     None.
     """
     cwd = Path.cwd()
@@ -86,6 +86,31 @@ def find_root() -> Optional[Path]:
             path = result.stdout.decode("utf-8")[:-1]
             return Path(os.path.relpath(path, cwd))
     return None
+
+
+def find_licenses_directory(root: PathLike = None) -> Optional[Path]:
+    """Find the licenses directory from CWD or *root*. In the following order:
+
+    - LICENSES/ in *root*.
+
+    - Current directory if its name is "LICENSES"
+
+    - LICENSES/ in CWD.
+
+    The returned LICENSES/ directory NEED NOT EXIST. It may still need to be
+    created.
+    """
+    if root is None:
+        root = find_root()
+    cwd = Path.cwd()
+    licenses_path = cwd / "LICENSES"
+
+    if root:
+        licenses_path = root / "LICENSES"
+    elif cwd.name == "LICENSES":
+        licenses_path = cwd
+
+    return licenses_path
 
 
 def in_git_repo(cwd: PathLike = None) -> bool:

--- a/src/reuse/download.py
+++ b/src/reuse/download.py
@@ -5,6 +5,7 @@
 """Functions for downloading license files from spdx/license-data-list."""
 
 import argparse
+import contextlib
 import errno
 import sys
 from gettext import gettext as _
@@ -98,7 +99,8 @@ def run(args, out=sys.stdout) -> int:
         # We won't be using this stream.
         args.output.close()
         # Also sneakily delete the file that this stream created.
-        destination.unlink()
+        with contextlib.suppress(FileNotFoundError):
+            destination.unlink()
 
     try:
         # IMPORTANT: These redundant lines exist SOLELY to make testing not an

--- a/src/reuse/download.py
+++ b/src/reuse/download.py
@@ -5,13 +5,13 @@
 """Functions for downloading license files from spdx/license-data-list."""
 
 import argparse
-from itertools import chain
-import sys
 import errno
+import sys
+from gettext import gettext as _
+from itertools import chain
 from os import PathLike
 from pathlib import Path
 from urllib.parse import urljoin
-from gettext import gettext as _
 
 import requests
 
@@ -101,7 +101,12 @@ def run(args, out=sys.stdout) -> int:
         destination.unlink()
 
     try:
-        put_license_in_file(args.license, destination=destination)
+        # IMPORTANT: These redundant lines exist SOLELY to make testing not an
+        # absolute hell.
+        if destination is not None:
+            put_license_in_file(args.license, destination=destination)
+        else:
+            put_license_in_file(args.license)
     except FileExistsError as err:
         out.write(
             _("Error: {} already exists.\n".format(Path(err.filename).name))

--- a/src/reuse/download.py
+++ b/src/reuse/download.py
@@ -1,0 +1,120 @@
+# SPDX-Copyright: 2019 Free Software Foundation Europe e.V.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Functions for downloading license files from spdx/license-data-list."""
+
+import argparse
+from itertools import chain
+import sys
+import errno
+from os import PathLike
+from pathlib import Path
+from urllib.parse import urljoin
+from gettext import gettext as _
+
+import requests
+
+from ._licenses import EXCEPTION_MAP, LICENSE_MAP
+from ._util import find_licenses_directory
+
+# All raw text files are available as files underneath this path.
+_SPDX_REPOSITORY_BASE_URL = (
+    "https://raw.githubusercontent.com/spdx/license-list-data/master/text/"
+)
+
+
+def download_license(spdx_identifier: str) -> str:
+    """Download the license text from the SPDX repository.
+
+    :param spdx_identifier: SPDX identifier of the license.
+    :raises requests.RequestException: if the license could not be downloaded.
+    :return: The license text.
+    """
+    # This is fairly naive, but I can't see anything wrong with it.
+    url = urljoin(
+        _SPDX_REPOSITORY_BASE_URL, "".join((spdx_identifier, ".txt"))
+    )
+    # TODO: Cache result?
+    response = requests.get(url)
+    if response.status_code == 200:
+        return response.text
+    raise requests.RequestException("Status code was not 200")
+
+
+def put_license_in_file(
+    spdx_identifier: str, root: PathLike = None, destination: PathLike = None
+) -> None:
+    """Download a license and put it in the correct file.
+
+    This function exists solely for convenience.
+
+    :param spdx_identifier: SPDX identifier of the license.
+    :param root: The root of the project.
+    :param destination: An override path for the destination of the license.
+    :raises requests.RequestException: if the license could not be downloaded.
+    :raises FileExistsError: if the license file already exists.
+    """
+    header = ""
+    if destination is None:
+        licenses_path = find_licenses_directory(root=root)
+        licenses_path.mkdir(exist_ok=True)
+        destination = licenses_path / "".join((spdx_identifier, ".txt"))
+    else:
+        is_exception = spdx_identifier in EXCEPTION_MAP
+        header = (
+            "Valid-{licexc}-Identifier: {identifier}\n"
+            "{licexc}-Text:\n\n".format(
+                identifier=spdx_identifier,
+                licexc="Exception" if is_exception else "License",
+            )
+        )
+
+    destination = Path(destination)
+    if destination.exists():
+        raise FileExistsError(errno.EEXIST, "File exists", str(destination))
+
+    text = download_license(spdx_identifier)
+    with destination.open("w") as fp:
+        fp.write(header)
+        fp.write(text)
+
+
+def add_arguments(parser) -> None:
+    """Add arguments to parser."""
+    parser.add_argument(
+        "license", action="store", help=_("SPDX Identifier of license")
+    )
+    parser.add_argument(
+        "--output", "-o", action="store", type=argparse.FileType("w")
+    )
+
+
+def run(args, out=sys.stdout) -> int:
+    """Download license and place it in the LICENSES/ directory."""
+    destination = None
+    if args.output:
+        destination = Path(args.output.buffer.name)
+        # We won't be using this stream.
+        args.output.close()
+        # Also sneakily delete the file that this stream created.
+        destination.unlink()
+
+    try:
+        put_license_in_file(args.license, destination=destination)
+    except FileExistsError as err:
+        out.write(
+            _("Error: {} already exists.\n".format(Path(err.filename).name))
+        )
+        return 1
+    except requests.RequestException:
+        out.write(_("Error: Failed to download license.\n"))
+        if args.license not in chain(LICENSE_MAP, EXCEPTION_MAP):
+            out.write(
+                _("{} is not a valid SPDX identifier.\n").format(args.license)
+            )
+        else:
+            out.write(_("Is your internet connection working?\n"))
+        return 1
+
+    return 0

--- a/src/reuse/download.py
+++ b/src/reuse/download.py
@@ -124,4 +124,9 @@ def run(args, out=sys.stdout) -> int:
             out.write(_("Is your internet connection working?\n"))
         return 1
 
+    out.write(
+        _("Successfully downloaded {spdx_identifier}.").format(
+            spdx_identifier=args.license
+        )
+    )
     return 0

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,0 +1,48 @@
+# SPDX-Copyright: 2019 Free Software Foundation Europe e.V.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""All tests for reuse._download"""
+
+import pytest
+import requests
+
+from reuse.download import download_license
+
+
+class MockResponse:
+    """Super simple mocked version of Response."""
+
+    # pylint: disable=too-few-public-methods
+
+    def __init__(self, text=None, status_code=None):
+        self.text = text
+        self.status_code = status_code
+
+
+def test_download(monkeypatch):
+    """A straightforward test: Request license text, get license text."""
+    monkeypatch.setattr(requests, "get", lambda _: MockResponse("hello", 200))
+    result = download_license("0BSD")
+    assert result == "hello"
+
+
+def test_download_404(monkeypatch):
+    """If the server returns a 404, there is no license text."""
+    monkeypatch.setattr(
+        requests, "get", lambda _: MockResponse(status_code=404)
+    )
+    with pytest.raises(requests.RequestException):
+        download_license("does-not-exist")
+
+
+def test_download_exception(monkeypatch):
+    """If requests raises an exception itself, that exception is not escaped.
+    """
+
+    def raise_exception(_):
+        raise requests.RequestException()
+
+    monkeypatch.setattr(requests, "get", raise_exception)
+    with pytest.raises(requests.RequestException):
+        download_license("hello world")

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -2,12 +2,15 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-"""All tests for reuse._download"""
+"""All tests for reuse.download"""
+
+import os
+from pathlib import Path
 
 import pytest
 import requests
 
-from reuse.download import download_license
+from reuse.download import download_license, put_license_in_file
 
 
 class MockResponse:
@@ -46,3 +49,103 @@ def test_download_exception(monkeypatch):
     monkeypatch.setattr(requests, "get", raise_exception)
     with pytest.raises(requests.RequestException):
         download_license("hello world")
+
+
+def test_put_simple(fake_repository, monkeypatch):
+    """Straightforward test."""
+    monkeypatch.setattr(
+        requests, "get", lambda _: MockResponse("hello\n", 200)
+    )
+    put_license_in_file("0BSD")
+
+    assert (fake_repository / "LICENSES/0BSD.txt").read_text() == "hello\n"
+
+
+def test_put_file_exists(fake_repository, monkeypatch):
+    """The to-be-downloaded file already exists."""
+    # pylint: disable=unused-argument
+    monkeypatch.setattr(
+        requests, "get", lambda _: MockResponse("hello\n", 200)
+    )
+
+    with pytest.raises(FileExistsError) as exc_info:
+        put_license_in_file("GPL-3.0-or-later")
+    assert Path(exc_info.value.filename).name == "GPL-3.0-or-later.txt"
+
+
+def test_put_request_exception(fake_repository, monkeypatch):
+    """There was an error while downloading the license file."""
+    # pylint: disable=unused-argument
+    monkeypatch.setattr(
+        requests, "get", lambda _: MockResponse(status_code=404)
+    )
+
+    with pytest.raises(requests.RequestException):
+        put_license_in_file("0BSD")
+
+
+def test_put_in_licenses_dir(fake_repository, monkeypatch):
+    """Put license file in current directory, if current directory is the
+    LICENSES/ directory.
+    """
+    monkeypatch.setattr(
+        requests, "get", lambda _: MockResponse("hello\n", 200)
+    )
+    os.chdir("LICENSES")
+    put_license_in_file("0BSD")
+
+    assert (fake_repository / "LICENSES/0BSD.txt").read_text() == "hello\n"
+
+
+def test_put_empty_dir(empty_directory, monkeypatch):
+    """Create a LICENSES/ directory if one does not yet exist."""
+    monkeypatch.setattr(
+        requests, "get", lambda _: MockResponse("hello\n", 200)
+    )
+    put_license_in_file("0BSD")
+
+    assert (empty_directory / "LICENSES").exists()
+    assert (empty_directory / "LICENSES/0BSD.txt").read_text() == "hello\n"
+
+
+def test_put_git_repository(git_repository, monkeypatch):
+    """Find the LICENSES/ directory in a Git repository."""
+    monkeypatch.setattr(
+        requests, "get", lambda _: MockResponse("hello\n", 200)
+    )
+    os.chdir("src")
+    put_license_in_file("0BSD")
+
+    assert (git_repository / "LICENSES/0BSD.txt").read_text() == "hello\n"
+
+
+def test_put_custom_output(empty_directory, monkeypatch):
+    """Download the license into a custom file."""
+    monkeypatch.setattr(
+        requests, "get", lambda _: MockResponse("hello\n", 200)
+    )
+    put_license_in_file("0BSD", destination="foo")
+
+    assert (
+        (empty_directory / "foo").read_text()
+        == "Valid-License-Identifier: 0BSD\n"
+        "License-Text:\n"
+        "\n"
+        "hello\n"
+    )
+
+
+def test_put_custom_exception(empty_directory, monkeypatch):
+    """Download the exception into a custom file."""
+    monkeypatch.setattr(
+        requests, "get", lambda _: MockResponse("hello\n", 200)
+    )
+    put_license_in_file("Autoconf-exception-3.0", destination="foo")
+
+    assert (
+        (empty_directory / "foo").read_text()
+        == "Valid-Exception-Identifier: Autoconf-exception-3.0\n"
+        "Exception-Text:\n"
+        "\n"
+        "hello\n"
+    )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -6,14 +6,26 @@
 
 import os
 
+import requests
+
 from reuse._main import main
+
+
+class MockResponse:
+    """Super simple mocked version of Response."""
+
+    # pylint: disable=too-few-public-methods
+
+    def __init__(self, text=None, status_code=None):
+        self.text = text
+        self.status_code = status_code
 
 
 def test_lint(
     fake_repository, stringio, git_exe
 ):  # pylint: disable=unused-argument
     """Run a successful lint. git_exe is there to make sure that the test
-    also works if git is note installed.
+    also works if git is not installed.
     """
     result = main(["lint", str(fake_repository)], out=stringio)
 
@@ -46,3 +58,126 @@ def test_spdx(fake_repository, stringio):
     # FIXME: This test is rubbish.
     assert result == 0
     assert stringio.getvalue()
+
+
+def test_download(fake_repository, stringio, monkeypatch):
+    """Straightforward test."""
+    monkeypatch.setattr(
+        requests, "get", lambda _: MockResponse("hello\n", 200)
+    )
+    result = main(["download", "0BSD"], out=stringio)
+
+    assert result == 0
+    assert (fake_repository / "LICENSES/0BSD.txt").read_text() == "hello\n"
+
+
+def test_download_file_exists(fake_repository, stringio, monkeypatch):
+    """The to-be-downloaded file already exists."""
+    # pylint: disable=unused-argument
+    monkeypatch.setattr(
+        requests, "get", lambda _: MockResponse("hello\n", 200)
+    )
+    result = main(["download", "GPL-3.0-or-later"], out=stringio)
+
+    assert result == 1
+    assert "GPL-3.0-or-later.txt already exists" in stringio.getvalue()
+
+
+def test_download_request_exception(fake_repository, stringio, monkeypatch):
+    """There was an error while downloading the license file."""
+    # pylint: disable=unused-argument
+    monkeypatch.setattr(
+        requests, "get", lambda _: MockResponse(status_code=404)
+    )
+    result = main(["download", "0BSD"], out=stringio)
+
+    assert result == 1
+    assert "Failed to download license" in stringio.getvalue()
+    assert "internet connection" in stringio.getvalue()
+
+
+def test_download_invalid_spdx(fake_repository, stringio, monkeypatch):
+    """An invalid SPDX identifier was provided."""
+    # pylint: disable=unused-argument
+    monkeypatch.setattr(
+        requests, "get", lambda _: MockResponse(status_code=404)
+    )
+    result = main(["download", "does-not-exist"], out=stringio)
+
+    assert result == 1
+    assert "Failed to download license" in stringio.getvalue()
+    assert "does-not-exist is not a valid" in stringio.getvalue()
+
+
+def test_download_in_licenses_dir(fake_repository, stringio, monkeypatch):
+    """Put license file in current directory, if current directory is the
+    LICENSES/ directory.
+    """
+    monkeypatch.setattr(
+        requests, "get", lambda _: MockResponse("hello\n", 200)
+    )
+    os.chdir("LICENSES")
+    result = main(["download", "0BSD"], out=stringio)
+
+    assert result == 0
+    assert (fake_repository / "LICENSES/0BSD.txt").read_text() == "hello\n"
+
+
+def test_download_empty_dir(empty_directory, stringio, monkeypatch):
+    """Create a LICENSES/ directory if one does not yet exist."""
+    monkeypatch.setattr(
+        requests, "get", lambda _: MockResponse("hello\n", 200)
+    )
+    result = main(["download", "0BSD"], out=stringio)
+
+    assert result == 0
+    assert (empty_directory / "LICENSES").exists()
+    assert (empty_directory / "LICENSES/0BSD.txt").read_text() == "hello\n"
+
+
+def test_download_git_repository(git_repository, stringio, monkeypatch):
+    """Find the LICENSES/ directory in a Git repository."""
+    monkeypatch.setattr(
+        requests, "get", lambda _: MockResponse("hello\n", 200)
+    )
+    os.chdir("src")
+    result = main(["download", "0BSD"], out=stringio)
+
+    assert result == 0
+    assert (git_repository / "LICENSES/0BSD.txt").read_text() == "hello\n"
+
+
+def test_download_custom_output(empty_directory, stringio, monkeypatch):
+    """Download the license into a custom file."""
+    monkeypatch.setattr(
+        requests, "get", lambda _: MockResponse("hello\n", 200)
+    )
+    result = main(["download", "-o", "foo", "0BSD"], out=stringio)
+
+    assert result == 0
+    assert (
+        (empty_directory / "foo").read_text()
+        == "Valid-License-Identifier: 0BSD\n"
+        "License-Text:\n"
+        "\n"
+        "hello\n"
+    )
+
+
+def test_download_custom_exception(empty_directory, stringio, monkeypatch):
+    """Download the exception into a custom file."""
+    monkeypatch.setattr(
+        requests, "get", lambda _: MockResponse("hello\n", 200)
+    )
+    result = main(
+        ["download", "-o", "foo", "Autoconf-exception-3.0"], out=stringio
+    )
+
+    assert result == 0
+    assert (
+        (empty_directory / "foo").read_text()
+        == "Valid-Exception-Identifier: Autoconf-exception-3.0\n"
+        "Exception-Text:\n"
+        "\n"
+        "hello\n"
+    )


### PR DESCRIPTION
A naive implementation that works fairly well.

I still need to extract some functionality from reuse._main.py::download into a separate function, so that a command such as `reuse init` doesn't need to reimplement anything.