### PR TITLE
Remove Python 3.5 support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,7 +31,7 @@ py37-test:
 
 py38-test:
     <<: *tox_definition
-    image: python:3.8
+    image: python:3.8-rc
     variables:
         TOXENV: py38-test
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,16 +49,3 @@ docs:
     artifacts:
         paths:
             - docs/_build/html
-
-pages:
-    stage: deploy
-    image: python:latest
-    only:
-        - /v[0-9]+.*/
-    dependencies:
-        - docs
-    script:
-        - mv docs/_build/html public
-    artifacts:
-        paths:
-            - public

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,16 +17,6 @@ before_script:
         - tox
     tags:
         - docker
-py35-test:
-    <<: *tox_definition
-    image: python:3.5
-    script:
-        - sed -i '/^black/d' requirements.txt
-        - pip install tox
-        - tox
-    variables:
-        TOXENV: py35-test
-
 py36-test:
     <<: *tox_definition
     image: python:3.6
@@ -38,6 +28,12 @@ py37-test:
     image: python:3.7
     variables:
         TOXENV: py37-test
+
+py38-test:
+    <<: *tox_definition
+    image: python:3.8
+    variables:
+        TOXENV: py38-test
 
 lint:
     <<: *tox_definition

--- a/setup.py
+++ b/setup.py
@@ -50,8 +50,8 @@ if __name__ == "__main__":
             "License :: OSI Approved :: "
             "GNU General Public License v3 or later (GPLv3+)",
             "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.5",
             "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",
+            "Programming Language :: Python :: 3.8",
         ],
     )

--- a/src/reuse/_util.py
+++ b/src/reuse/_util.py
@@ -4,6 +4,8 @@
 
 """Misc. utilities for reuse."""
 
+# pylint: disable=ungrouped-imports
+
 import logging
 import os
 import re
@@ -11,8 +13,9 @@ import shutil
 import subprocess
 from gettext import gettext as _
 from hashlib import sha1
+from os import PathLike
 from pathlib import Path
-from typing import BinaryIO, List, Optional, Set, Union
+from typing import BinaryIO, List, Optional, Set
 
 from debian.copyright import Copyright
 from license_expression import ExpressionError, Licensing
@@ -24,8 +27,6 @@ GIT_EXE = shutil.which("git")
 
 _logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 _LICENSING = Licensing()
-
-PathLike = Union[Path, str]  # pylint: disable=invalid-name
 
 _END_PATTERN = r"(?:\*/)*(?:-->)*$"
 _IDENTIFIER_PATTERN = re.compile(
@@ -79,11 +80,11 @@ def find_root() -> Optional[Path]:
     cwd = Path.cwd()
     if in_git_repo(cwd):
         command = [GIT_EXE, "rev-parse", "--show-toplevel"]
-        result = execute_command(command, _logger, cwd=str(cwd))
+        result = execute_command(command, _logger, cwd=cwd)
 
         if not result.returncode:
             path = result.stdout.decode("utf-8")[:-1]
-            return Path(os.path.relpath(path, str(cwd)))
+            return Path(os.path.relpath(path, cwd))
     return None
 
 
@@ -97,7 +98,7 @@ def in_git_repo(cwd: PathLike = None) -> bool:
 
     if GIT_EXE:
         command = [GIT_EXE, "status"]
-        result = execute_command(command, _logger, cwd=str(cwd))
+        result = execute_command(command, _logger, cwd=cwd)
 
         return not result.returncode
 
@@ -121,7 +122,7 @@ def _all_files_ignored_by_git(root: PathLike) -> Set[str]:
             "--others",
             "--directory",
         ]
-        result = execute_command(command, _logger, cwd=str(root))
+        result = execute_command(command, _logger, cwd=root)
         all_files = result.stdout.decode("utf-8").split("\n")
         return set(all_files)
     return set()

--- a/src/reuse/project.py
+++ b/src/reuse/project.py
@@ -84,7 +84,7 @@ class Project:
             _logger.debug("yielding %s", directory)
             yield directory
 
-        for root, dirs, files in os.walk(str(directory)):
+        for root, dirs, files in os.walk(directory):
             root = Path(root)
             _logger.debug("currently walking in %s", root)
 
@@ -149,7 +149,7 @@ class Project:
         """If the project root is /tmp/project, and *path* is
         /tmp/project/src/file, then return src/file.
         """
-        return Path(os.path.relpath(str(path), start=str(self.root)))
+        return Path(os.path.relpath(path, start=self.root))
 
     def _ignored_by_vcs(self, path: PathLike) -> bool:
         """Is *path* covered by the ignore mechanism of the VCS (e.g.,

--- a/src/reuse/report.py
+++ b/src/reuse/report.py
@@ -9,6 +9,7 @@ import logging
 from gettext import gettext as _
 from hashlib import md5
 from io import StringIO
+from os import PathLike
 from pathlib import Path
 from typing import Iterable, NamedTuple, Set
 from uuid import uuid4
@@ -18,7 +19,7 @@ from spdx.document import License
 from spdx.file import File
 
 from . import __version__
-from ._util import PathLike, _checksum
+from ._util import _checksum
 from .project import Project
 
 _logger = logging.getLogger(__name__)  # pylint: disable=invalid-name

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,7 @@ def pytest_runtest_setup(item):
     """Called before running a test."""
     # pylint: disable=unused-argument
     # Make sure to restore CWD
-    os.chdir(str(CWD))
+    os.chdir(CWD)
 
 
 @pytest.fixture(params=[True, False])
@@ -78,7 +78,7 @@ def fake_repository(tmpdir_factory) -> Path:
         "-License-Identifier: GPL-3.0-or-later WITH Autoconf-exception-3.0"
     )
 
-    os.chdir(str(directory))
+    os.chdir(directory)
     return directory
 
 
@@ -88,7 +88,7 @@ def git_repository(fake_repository: Path, git_exe: Optional[str]) -> Path:
     if not git_exe:
         pytest.skip("cannot run this test without git")
 
-    os.chdir(str(fake_repository))
+    os.chdir(fake_repository)
 
     gitignore = (
         "# SPDX"

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 [tox]
-envlist = py{35,36,37}-test, lint, docs
+envlist = py{36,37,38}-test, lint, docs
 
 [testenv]
 passenv = HOME


### PR DESCRIPTION
Python 3.5 support is difficult to maintain when the project so
extensively uses os.PathLike. Simply dropping it is probably all
right.

If it turns out someone wants Python 3.5 support, just add str
calls _everywhere_.