### PR TITLE
Fix pep517 error

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,14 +1,9 @@
-# SPDX-Copyright: 2017-2018 Free Software Foundation Europe e.V.
+# SPDX-Copyright: 2017-2019 Free Software Foundation Europe e.V.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 stages:
     - test
-    - deploy
-
-before_script:
-    - apt-get -qq update
-    - apt-get -qq install -y cmake libgit2-dev >> /dev/null
 
 .run_tox: &tox_definition
     stage: test

--- a/Makefile
+++ b/Makefile
@@ -64,11 +64,11 @@ reuse:  ## check with self
 
 .PHONY: test
 test: ## run tests quickly
-	py.test --doctest-modules
+	py.test
 
 .PHONY: coverage
 coverage: ## check code coverage quickly
-	py.test --doctest-modules --cov-report term-missing --cov=src/reuse
+	py.test --cov-report term-missing --cov=src/reuse
 
 _pre-docs: clean-docs
 	sphinx-apidoc --separate -o docs/ src/reuse

--- a/tox.ini
+++ b/tox.ini
@@ -9,9 +9,8 @@ envlist = py{36,37,38}-test, lint, docs
 passenv = HOME
 deps =
     -r{toxinidir}/requirements.txt
-usedevelop = True
 commands =
-    py.test --doctest-modules --cov-report term-missing --cov=src/reuse
+    py.test --cov-report term-missing --cov=src/reuse
 
 
 [testenv:lint]


### PR DESCRIPTION
The tests of #5 currently fail because of some weird stuff introduced in PEP 517. This cleans up the build process (again...) to circumvent the necessity of `python setup.py develop`.