### PR TITLE
Amend docstring for files_without_copyright

### DIFF
--- a/src/reuse/report.py
+++ b/src/reuse/report.py
@@ -229,7 +229,7 @@ class ProjectReport:  # pylint: disable=too-many-instance-attributes
 
     @property
     def files_without_copyright(self) -> Iterable[PathLike]:
-        """Iterable of paths that have no license information."""
+        """Iterable of paths that have no copyright information."""
         if self._files_without_copyright is not None:
             return self._files_without_copyright
 


### PR DESCRIPTION
Before this change the docstring for files_without_copyright  talks about license information. After this change it refers to copyright as expected.