### PR TITLE
fix: encode SPDX file in UTF-8

### DIFF
--- a/src/reuse/spdx.py
+++ b/src/reuse/spdx.py
@@ -24,7 +24,7 @@ def add_arguments(parser) -> None:
 def run(args, out=sys.stdout) -> int:
     """Print the project's bill of materials."""
     if args.output:
-        out = args.output.open("w")
+        out = args.output.open("w", encoding="UTF-8")
         if args.output.suffix != ".spdx":
             # Translators: %s is a file name.
             _LOGGER.warning(_("'%s' does not end with .spdx"), out.name)


### PR DESCRIPTION
According to article 1.6.4 of [SPDX v2.1.1 Specification](https://spdx.github.io/spdx-spec/1-rationale/) encoding should be UTF-8.

Fixes error in `spdx` command when UTF-8 is not system default encoding (like, Windows):
```
Traceback (most recent call last):
  File "c:\root\python\3.6\w64\lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "c:\root\python\3.6\w64\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "c:\r\Python\3.6\w64\Scripts\reuse.exe\__main__.py", line 9, in <module>
  File "c:\root\python\3.6\w64\lib\site-packages\reuse\_main.py", line 146, in main
    return parsed_args.func(parsed_args, out)
  File "c:\root\python\3.6\w64\lib\site-packages\reuse\spdx.py", line 35, in run
    out.write(report.bill_of_materials())
  File "c:\root\python\3.6\w64\lib\encodings\cp1251.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode character '\ufffd' in position 62337: character maps to <undefined>
```