### PR TITLE
Forward a posix-like path to debian.copyright

### DIFF
--- a/src/reuse/_util.py
+++ b/src/reuse/_util.py
@@ -184,7 +184,7 @@ def _determine_license_path(path: PathLike) -> Path:
 
 def _copyright_from_dep5(path: PathLike, copyright: Copyright) -> SpdxInfo:
     """Find the reuse information of *path* in the dep5 Copyright object."""
-    result = copyright.find_files_paragraph(str(path))
+    result = copyright.find_files_paragraph(Path(path).as_posix())
 
     if result is None:
         return SpdxInfo(set(), set())


### PR DESCRIPTION
str(Path) uses `\\` separators instead of `/`. Path.as_posix() returns
the path with separators that are expected by debian.copyright.

Reported-by: Basil Peace

Fixes #22 