### PR TITLE
Remove Valid-License-Identifier

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -51,6 +51,9 @@ Changed
 
 - The list of SPDX licenses has been updated.
 
+- ``Valid-License-Identifier`` is no longer used, and licenses and exceptions
+  can now only live inside of the LICENSES/ directory.
+
 Removed
 ~~~~~~~
 

--- a/src/reuse/_util.py
+++ b/src/reuse/_util.py
@@ -37,9 +37,6 @@ _COPYRIGHT_PATTERNS = [
     re.compile(r"(Copyright .*?)" + _END_PATTERN),
     re.compile(r"(© .*?)" + _END_PATTERN),
 ]
-_VALID_LICENSE_PATTERN = re.compile(
-    r"Valid" "-License-Identifier: (.*?)" + _END_PATTERN, re.MULTILINE
-)
 
 # Amount of bytes that we assume will be big enough to contain the entire
 # comment header (including SPDX tags), so that we don't need to read the
@@ -215,11 +212,6 @@ def extract_spdx_info(text: str) -> None:
                 break
 
     return SpdxInfo(expressions, copyright_matches)
-
-
-def extract_valid_license(text: str) -> Set[str]:
-    """Extract SPDX identifier from a string."""
-    return set(map(str.strip, _VALID_LICENSE_PATTERN.findall(text)))
 
 
 def _checksum(path: PathLike) -> str:

--- a/src/reuse/download.py
+++ b/src/reuse/download.py
@@ -59,15 +59,6 @@ def put_license_in_file(
         licenses_path = find_licenses_directory(root=root)
         licenses_path.mkdir(exist_ok=True)
         destination = licenses_path / "".join((spdx_identifier, ".txt"))
-    else:
-        is_exception = spdx_identifier in EXCEPTION_MAP
-        header = (
-            "Valid-{licexc}-Identifier: {identifier}\n"
-            "{licexc}-Text:\n\n".format(
-                identifier=spdx_identifier,
-                licexc="Exception" if is_exception else "License",
-            )
-        )
 
     destination = Path(destination)
     if destination.exists():

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -126,26 +126,4 @@ def test_put_custom_output(empty_directory, monkeypatch):
     )
     put_license_in_file("0BSD", destination="foo")
 
-    assert (
-        (empty_directory / "foo").read_text()
-        == "Valid-License-Identifier: 0BSD\n"
-        "License-Text:\n"
-        "\n"
-        "hello\n"
-    )
-
-
-def test_put_custom_exception(empty_directory, monkeypatch):
-    """Download the exception into a custom file."""
-    monkeypatch.setattr(
-        requests, "get", lambda _: MockResponse("hello\n", 200)
-    )
-    put_license_in_file("Autoconf-exception-3.0", destination="foo")
-
-    assert (
-        (empty_directory / "foo").read_text()
-        == "Valid-Exception-Identifier: Autoconf-exception-3.0\n"
-        "Exception-Text:\n"
-        "\n"
-        "hello\n"
-    )
+    assert (empty_directory / "foo").read_text() == "hello\n"

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -89,13 +89,6 @@ def test_extract_copyright_variations():
     assert len(lines) == len(result.copyright_lines)
 
 
-def test_extract_valid_license():
-    """Correctly extract valid license identifier tag from file."""
-    text = "Valid-License-Identifier: MIT"
-    result = _util.extract_valid_license(text)
-    assert result == {"MIT"}
-
-
 def test_copyright_from_dep5(copyright):
     """Verify that the glob in the dep5 file is matched."""
     result = _util._copyright_from_dep5("doc/foo.rst", copyright)


### PR DESCRIPTION
In the new spec, Valid-License-Identifier and licenses outside of the
LICENSES/ directory are no longer supported. Instead, the file name of
the license must contain the SPDX identifier followed by an extension.

This commit simply removes a lot of functionality and tests that had to
do with this.

See https://github.com/fsfe/reuse-docs/issues/27