### PR TITLE
Dockerize tool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# SPDX-Copyright: 2019 Free Software Foundation Europe e.V.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+FROM alpine:latest
+
+# Dependencies for reuse-tool
+RUN apk --no-cache add python3 git
+
+# Build dependencies
+RUN apk --no-cache --virtual .build-deps add make gcc python3-dev musl-dev
+
+COPY . /reuse-tool/
+
+WORKDIR /reuse-tool/
+
+# Install reuse-tool
+RUN python3 -mvenv venv \
+    && source venv/bin/activate \
+    && make install
+
+# Symlink reuse binary
+RUN ln -s /reuse-tool/venv/bin/reuse /usr/local/bin
+
+# Uninstall build dependencies
+RUN apk del .build-deps
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,21 +7,9 @@ FROM alpine:latest
 # Dependencies for reuse-tool
 RUN apk --no-cache add python3 git
 
-# Build dependencies
-RUN apk --no-cache --virtual .build-deps add make gcc python3-dev musl-dev
-
 COPY . /reuse-tool/
 
-WORKDIR /reuse-tool/
-
 # Install reuse-tool
-RUN python3 -mvenv venv \
-    && source venv/bin/activate \
-    && make install
-
-# Symlink reuse binary
-RUN ln -s /reuse-tool/venv/bin/reuse /usr/local/bin
-
-# Uninstall build dependencies
-RUN apk del .build-deps
-
+RUN cd /reuse-tool \
+    && python3 setup.py install \
+    && rm -rf /reuse-tool


### PR DESCRIPTION
This PR add a Dockerfile to install reuse in a Docker container based on Alpine. This way, it is easy to integrate in CI processes.

I deliberately did not choose to just install via pip to reduce the dependency on this source, and to be able to build the image and publish it to Docker Hub without the need to have a release on pypi.

Downside to far: The image is quite heavy with 325MB. The install via pip in the same base image results in an image size of ~60MB. I tried `make clean` to get rid of build artifacts, but afterwards the binary didn't run any more. Ideas?