### PR TITLE
Clear up some TODOs and FIXMEs

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -17,7 +17,7 @@ jobs=0
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=fixme,redefined-builtin,C0330
+disable=redefined-builtin,C0330
 
 [REPORTS]
 
@@ -49,3 +49,7 @@ single-line-if-stmt=no
 
 # Good variable names which should always be accepted, separated by a comma
 good-names=i,j,k,ex,Run,_,fp
+
+[MISCELLANEOUS]
+
+notes=FIXME,XXX

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ The versions follow [semantic versioning](https://semver.org).
 - When using `reuse addheader` on a file that contains a shebang, the shebang is
   preserved.
 
+- Some publicly visible TODOs were patched away.
+
 ## 0.4.0 - 2019-08-06
 
 This release is a major overhaul and refactoring of the tool. Its

--- a/src/reuse/_main.py
+++ b/src/reuse/_main.py
@@ -138,7 +138,28 @@ def parser() -> argparse.ArgumentParser:
         lint.add_arguments,
         lint.run,
         help=_("list all non-compliant files"),
-        description=fill_all(_("FIXME")),
+        description=fill_all(
+            _(
+                "Lint the directory or project directory for compliance with "
+                "version {reuse_version} of the REUSE Specification. You can "
+                "find the latest version of the specification at "
+                "<https://reuse.software/spec/>.\n"
+                "\n"
+                "Specifically, the following criteria are checked:\n"
+                "\n"
+                "- Are there any bad (unrecognised, not compliant with SPDX) "
+                "licenses in the project?\n"
+                "\n"
+                "- Are any licenses referred to inside of the project, but "
+                "not included in the LICENSES/ directory?\n"
+                "\n"
+                "- Are any licenses included in the LICENSES/ directory that "
+                "are not used inside of the project?\n"
+                "\n"
+                "- Do all files have valid copyright and licensing "
+                "information?\n"
+            )
+        ),
     )
 
     add_command(

--- a/src/reuse/_main.py
+++ b/src/reuse/_main.py
@@ -138,7 +138,7 @@ def parser() -> argparse.ArgumentParser:
         lint.add_arguments,
         lint.run,
         help=_("list all non-compliant files"),
-        description=fill_all(_("TODO")),
+        description=fill_all(_("FIXME")),
     )
 
     add_command(

--- a/src/reuse/_util.py
+++ b/src/reuse/_util.py
@@ -146,7 +146,7 @@ def _all_files_ignored_by_git(root: PathLike) -> Set[str]:
             "--ignored",
             "--others",
             "--directory",
-            # FIXME: This flag is unexpected.  I reported it as a bug in Git.
+            # TODO: This flag is unexpected.  I reported it as a bug in Git.
             # This flag---counter-intuitively---lists untracked directories
             # that contain ignored files.
             "--no-empty-directory",

--- a/src/reuse/download.py
+++ b/src/reuse/download.py
@@ -123,7 +123,7 @@ def run(args, out=sys.stdout) -> int:
 
     if args.all:
         project = create_project()
-        # FIXME: This is fairly inefficient, but gets the job done.
+        # TODO: This is fairly inefficient, but gets the job done.
         report = ProjectReport.generate(project)
         licenses = report.missing_licenses
     elif not args.license:

--- a/src/reuse/header.py
+++ b/src/reuse/header.py
@@ -70,7 +70,7 @@ def create_header(
                 "existing header contains an erroneous SPDX expression"
             ) from err
 
-        # FIXME: This behaviour does not match the docstring.
+        # TODO: This behaviour does not match the docstring.
         spdx_info = SpdxInfo(
             spdx_info.spdx_expressions.union(existing_spdx.spdx_expressions),
             spdx_info.copyright_lines.union(existing_spdx.copyright_lines),

--- a/src/reuse/header.py
+++ b/src/reuse/header.py
@@ -96,7 +96,7 @@ def find_and_replace_header(
 
     *text* is returned with a new header.
 
-    :raises CommentCreateError: TODO FIXME
+    :raises CommentCreateError: if a comment could not be created
     """
     try:
         header = style.comment_at_first_character(text)
@@ -179,9 +179,20 @@ def run(args, out=sys.stdout) -> int:
         with path.open("r") as fp:
             text = fp.read()
 
-        output = find_and_replace_header(text, spdx_info, style=style)
-
-        out.write(_("FIXME"))
+        try:
+            output = find_and_replace_header(text, spdx_info, style=style)
+        except CommentCreateError:
+            out.write(
+                _("Error: Could not create comment for {path}").format(
+                    path=path
+                )
+            )
+            out.write("\n")
+        else:
+            # TODO: This may need to be rephrased more elegantly.
+            out.write(
+                _("Successfully changed header of {path}").format(path=path)
+            )
 
         with path.open("w") as fp:
             fp.write(output)

--- a/src/reuse/header.py
+++ b/src/reuse/header.py
@@ -96,7 +96,7 @@ def find_and_replace_header(
 
     *text* is returned with a new header.
 
-    :raises CommentCreateError: if a comment could not be created
+    :raises CommentCreateError: if a comment could not be created.
     """
     try:
         header = style.comment_at_first_character(text)

--- a/src/reuse/header.py
+++ b/src/reuse/header.py
@@ -181,7 +181,7 @@ def run(args, out=sys.stdout) -> int:
 
         output = find_and_replace_header(text, spdx_info, style=style)
 
-        out.write(_("TODO"))
+        out.write(_("FIXME"))
 
         with path.open("w") as fp:
             fp.write(output)

--- a/src/reuse/lint.py
+++ b/src/reuse/lint.py
@@ -40,7 +40,7 @@ def lint(report: ProjectReport, out=sys.stdout) -> bool:
             bad_licenses_result,
             missing_licenses_result,
             read_errors_result,
-            # FIXME: Should this be a separate entry if it's already in the
+            # TODO: Should this be a separate entry if it's already in the
             # summary?
             report.unused_licenses,
         )
@@ -135,7 +135,7 @@ def lint_files_without_copyright_and_licensing(
     report: ProjectReport, out=sys.stdout
 ) -> Iterable[str]:
     """Lint for files that do not have copyright or licensing information."""
-    # FIXME: The below three operations can probably be optimised.
+    # TODO: The below three operations can probably be optimised.
     both = set(report.files_without_copyright) & set(
         report.files_without_licenses
     )

--- a/src/reuse/project.py
+++ b/src/reuse/project.py
@@ -58,7 +58,7 @@ class Project:
             self._all_ignored_files = _all_files_ignored_by_git(self._root)
 
         self.license_map = LICENSE_MAP.copy()
-        # FIXME: Is this correct?
+        # TODO: Is this correct?
         self.license_map.update(EXCEPTION_MAP)
         self.licenses = self._licenses()
         # Use '0' as None, because None is a valid value...

--- a/src/reuse/report.py
+++ b/src/reuse/report.py
@@ -311,7 +311,9 @@ class FileReport:
                 report.spdxfile.licenses_in_file.append(identifier)
 
         # Copyright text
-        report.spdxfile.copyright = "\n".join(spdx_info.copyright_lines)
+        report.spdxfile.copyright = "\n".join(
+            sorted(spdx_info.copyright_lines)
+        )
 
         return FileReportInfo(report, bad_licenses, missing_licenses)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -62,7 +62,7 @@ def test_spdx(fake_repository, stringio):
     os.chdir(str(fake_repository))
     result = main(["spdx"], out=stringio)
 
-    # FIXME: This test is rubbish.
+    # TODO: This test is rubbish.
     assert result == 0
     assert stringio.getvalue()
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -145,7 +145,7 @@ def test_download_custom_output_too_many(
         )
 
 
-# FIXME: Replace this test with a monkeypatched test
+# TODO: Replace this test with a monkeypatched test
 def test_addheader_simple(fake_repository, stringio):
     """Add a header to a file that does not have one."""
     simple_file = fake_repository / "foo.py"

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -141,12 +141,13 @@ def test_generate_project_report_to_dict(fake_repository):
     """Extremely simple test for ProjectReport.to_dict."""
     project = Project(fake_repository)
     report = ProjectReport.generate(project)
-    # FIXME: Actually do something
+    # TODO: Actually do something
     report.to_dict()
 
 
 def test_bill_of_materials(fake_repository):
-    """FIXME: This test currently does nothing."""
+    """Generate a bill of materials."""
     project = Project(fake_repository)
     report = ProjectReport.generate(project)
+    # TODO: Actually do something
     report.bill_of_materials()


### PR DESCRIPTION
I discovered today that `reuse addheader` outputs `TODO`, which isn't very nice. I will release a patch for that very soon. To prevent this from happening in the future, I have made pylint check for FIXMEs. If there is a FIXME, the linter will complain. The linter will not complain about TODOs.

The task of this PR is to turn some FIXMEs into TODOs, some TODOs into FIXMEs, and then to actually fix the FIXMEs.