### PR TITLE
Automagically add year to header with addheader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ The versions follow [semantic versioning](https://semver.org).
 
 - TeX and ML comment styles added.
 
+- Added `--year` and `--exclude-year` to `reuse addheader`.
+
+### Changed
+
+- `reuse addheader` now automatically adds the current year to the copyright
+  notice.
+
 ## 0.4.1 - 2019-08-07
 
 ### Added

--- a/src/reuse/_util.py
+++ b/src/reuse/_util.py
@@ -218,7 +218,7 @@ def extract_spdx_info(text: str) -> None:
     return SpdxInfo(expressions, copyright_matches)
 
 
-def make_copyright_line(statement: str) -> str:
+def make_copyright_line(statement: str, year: str = None) -> str:
     """Given a statement, prefix it with ``SPDX-FileCopyrightText:`` if it is
     not already prefixed with some manner of copyright tag.
     """
@@ -228,6 +228,8 @@ def make_copyright_line(statement: str) -> str:
         match = pattern.search(statement)
         if match is not None:
             return statement
+    if year is not None:
+        return f"SPDX-FileCopyrightText: {year} {statement}"
     return f"SPDX-FileCopyrightText: {statement}"
 
 

--- a/src/reuse/header.py
+++ b/src/reuse/header.py
@@ -118,6 +118,19 @@ def find_and_replace_header(
     return new_header + text
 
 
+def _verify_paths_supported(paths, parser):
+    for path in paths:
+        try:
+            COMMENT_STYLE_MAP[path.suffix]
+        except KeyError:
+            parser.error(
+                _(
+                    "'{}' does not have a recognised file extension, "
+                    "please use --style".format(path)
+                )
+            )
+
+
 def add_arguments(parser) -> None:
     """Add arguments to parser."""
     parser.add_argument(
@@ -167,6 +180,10 @@ def run(args, out=sys.stdout) -> int:
             _("option --exclude-year and --year are mutually exclusive")
         )
 
+    # First loop to verify before proceeding
+    if args.style is None:
+        _verify_paths_supported(args.path, args.parser)
+
     year = None
     if not args.exclude_year:
         if args.year:
@@ -182,19 +199,6 @@ def run(args, out=sys.stdout) -> int:
     )
 
     spdx_info = SpdxInfo(expressions, copyright_lines)
-
-    # First loop to verify before proceeding
-    if args.style is None:
-        for path in args.path:
-            try:
-                style = COMMENT_STYLE_MAP[path.suffix]
-            except KeyError:
-                args.parser.error(
-                    _(
-                        "'{}' does not have a recognised file extension, "
-                        "please use --style".format(path)
-                    )
-                )
 
     for path in args.path:
         if args.style is not None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -223,7 +223,7 @@ def test_addheader_year(fake_repository, stringio):
     )
 
 
-def test_addheader_year(fake_repository, stringio):
+def test_addheader_no_year(fake_repository, stringio):
     """Add a header to a file without a year."""
     # pylint: disable=unused-argument
     simple_file = fake_repository / "foo.py"

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -114,6 +114,14 @@ def test_make_copyright_line_simple():
     )
 
 
+def test_make_copyright_line_year():
+    """Given a simple statement and a year, make it a copyright line."""
+    assert (
+        _util.make_copyright_line("hello", year="2019") == "SPDX"
+        "-FileCopyrightText: 2019 hello"
+    )
+
+
 def test_make_copyright_line_existing_spdx_copyright():
     """Given a copyright line, do nothing."""
     value = "SPDX" "-FileCopyrightText: hello"


### PR DESCRIPTION
This PR kind of works. I spent far too long trying to move this logic down into `_create_new_header`, but that would necessitate writing logic that can find-and-replace year ranges in copyright notices. That's doable, but fairly heuristic-y and makes some heavy assumptions about how people do their year ranges. This will suffice for now, I think.