### PR TITLE
Do not checksum files when linting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ The versions follow [semantic versioning](https://semver.org).
 
 - Updated license list to 3.6-2-g2a14810.
 
+### Fixed
+
+- Performance of `reuse lint` improved by at least a factor of 2. It no longer
+  does any checksums on files behind the scenes.
+
 ## 0.5.0 - 2019-08-29
 
 ### Added

--- a/src/reuse/lint.py
+++ b/src/reuse/lint.py
@@ -257,7 +257,7 @@ def run(args, out=sys.stdout):
     if not paths:
         paths = [project.root]
 
-    report = ProjectReport.generate(project, paths)
+    report = ProjectReport.generate(project, paths, do_checksum=False)
     result = lint(report, out=out)
 
     return 0 if result else 1


### PR DESCRIPTION
This greatly improves the performance of the tool. Instead of reading every single file in full and checksumming them, it simply doesn't do that, and assigns a unique checksum to each file.

Original performance:

```
922.56user 471.02system 25:48.01elapsed 90%CPU (0avgtext+0avgdata 675684maxresident)k
245959016inputs+85696outputs (8major+254525minor)pagefaults 0swaps
```

New performance:

```
480.17user 119.80system 11:18.19elapsed 88%CPU (0avgtext+0avgdata 679352maxresident)k
5052184inputs+85648outputs (0major+243132minor)pagefaults 0swaps
```

Real-time performance is halved.