### PR TITLE
Deal with extensionless licenses in LICENSES/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,13 @@ The versions follow [semantic versioning](https://semver.org).
 - Implemented `--root` argument to specify the root of the project without
   heuristics.
 
+- The linter will complain about licenses without file extensions.
+
+### Changed
+
+- The linter output has been very slightly re-ordered to be more internally
+  consistent.
+
 ### Removed
 
 - `lint` no longer accepts path arguments. Where previously one could do `reuse

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ following sections:
 
 The versions follow [semantic versioning](https://semver.org).
 
+## Unreleased - YYYY-MM-DD
+
+### Fixed
+
+- A license that does not have a file extension, but whose full name is a valid
+  SPDX License Identifier is now correctly identified as such. The linter will
+  complain about them, however.
+
 ## 0.5.0 - 2019-08-29
 
 ### Added

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -171,33 +171,34 @@ This is some example output of ``reuse lint``:
 
 .. code-block:: text
 
-  # MISSING COPYRIGHT AND LICENSING INFORMATION
-
-  The following files have no copyright and licensing information:
-  * no-information.txt
-
-
   # BAD LICENSES
 
   'bad-license' found in:
   * LICENSES/bad-license.txt
 
 
-  # MISSING LICENSES
+  # UNUSED LICENSES
 
-  'MIT' found in:
-  * src/reuse/header.py
+  The following licenses are not used:
+  * bad-license
+
+
+  # MISSING COPYRIGHT AND LICENSING INFORMATION
+
+  The following files have no copyright and licensing information:
+  * no-information.txt
 
 
   # SUMMARY
 
   * Bad licenses: bad-license
-  * Missing licenses: MIT
+  * Licenses without file extension:
+  * Missing licenses:
   * Unused licenses: bad-license
   * Used licenses: Apache-2.0, CC-BY-SA-4.0, CC0-1.0, GPL-3.0-or-later
   * Read errors: 0
-  * Files with copyright information: 56 / 57
-  * Files with license information: 56 / 57
+  * Files with copyright information: 57 / 58
+  * Files with license information: 57 / 58
 
   Unfortunately, your project is not compliant with version 3.0 of the REUSE Specification :-(
 
@@ -220,6 +221,12 @@ Bad licenses
 
 Licenses that are found in ``LICENSES/`` that are not found in the SPDX License
 List or do not start with ``LicenseRef-`` are bad licenses.
+
+Licenses without file extension
++++++++++++++++++++++++++++++++
+
+These are licenses whose file names are a valid SPDX License Identifier, but
+which do not have a file extension.
 
 Missing licenses
 ++++++++++++++++

--- a/src/reuse/lint.py
+++ b/src/reuse/lint.py
@@ -47,16 +47,6 @@ def lint(report: ProjectReport, out=sys.stdout) -> bool:
         )
     )
 
-    if report.licenses_without_extension:
-        out.write("\n")
-        out.write(
-            _(
-                "One or more licenses in the project do not have a file "
-                "extension."
-            )
-        )
-        out.write("\n")
-
     out.write("\n")
     if success:
         out.write(
@@ -228,6 +218,16 @@ def lint_summary(report: ProjectReport, out=sys.stdout) -> None:
         out.write(" ")
         out.write(lic)
     out.write("\n")
+
+    if report.licenses_without_extension:
+        out.write("* ")
+        out.write(_("Licenses without file extension:"))
+        for i, lic in enumerate(sorted(report.licenses_without_extension)):
+            if i:
+                out.write(",")
+            out.write(" ")
+            out.write(lic)
+        out.write("\n")
 
     out.write("* ")
     out.write(_("Read errors: {count}".format(count=len(report.read_errors))))

--- a/src/reuse/lint.py
+++ b/src/reuse/lint.py
@@ -43,8 +43,19 @@ def lint(report: ProjectReport, out=sys.stdout) -> bool:
             # TODO: Should this be a separate entry if it's already in the
             # summary?
             report.unused_licenses,
+            report.licenses_without_extension,
         )
     )
+
+    if report.licenses_without_extension:
+        out.write("\n")
+        out.write(
+            _(
+                "One or more licenses in the project do not have a file "
+                "extension."
+            )
+        )
+        out.write("\n")
 
     out.write("\n")
     if success:

--- a/src/reuse/lint.py
+++ b/src/reuse/lint.py
@@ -23,26 +23,26 @@ def _write_element(element, out=sys.stdout):
 
 def lint(report: ProjectReport, out=sys.stdout) -> bool:
     """Lint the entire project."""
+    bad_licenses_result = lint_bad_licenses(report, out)
+    extensionless = lint_licenses_without_extension(report, out)
+    missing_licenses_result = lint_missing_licenses(report, out)
+    unused_licenses_result = lint_unused_licenses(report, out)
+    read_errors_result = lint_read_errors(report, out)
     files_without_cali = lint_files_without_copyright_and_licensing(
         report, out
     )
-    bad_licenses_result = lint_bad_licenses(report, out)
-    missing_licenses_result = lint_missing_licenses(report, out)
-    read_errors_result = lint_read_errors(report, out)
 
     lint_summary(report, out=out)
 
     success = not any(
         any(result)
         for result in (
-            files_without_cali,
             bad_licenses_result,
+            extensionless,
             missing_licenses_result,
+            unused_licenses_result,
             read_errors_result,
-            # TODO: Should this be a separate entry if it's already in the
-            # summary?
-            report.unused_licenses,
-            report.licenses_without_extension,
+            files_without_cali,
         )
     )
 
@@ -88,6 +88,26 @@ def lint_bad_licenses(report: ProjectReport, out=sys.stdout) -> Iterable[str]:
     return bad_files
 
 
+def lint_licenses_without_extension(
+    report: ProjectReport, out=sys.stdout
+) -> Iterable[str]:
+    """Lint for licenses without extensions."""
+    extensionless = []
+
+    if report.licenses_without_extension:
+        out.write("# ")
+        out.write(_("LICENSES WITHOUT FILE EXTENSION"))
+        out.write("\n\n")
+        out.write(_("The following licenses have no file extension:"))
+        out.write("\n")
+        for __, path in sorted(report.licenses_without_extension.items()):
+            extensionless.append(path)
+            _write_element(path, out=out)
+        out.write("\n\n")
+
+    return extensionless
+
+
 def lint_missing_licenses(
     report: ProjectReport, out=sys.stdout
 ) -> Iterable[str]:
@@ -111,6 +131,26 @@ def lint_missing_licenses(
         out.write("\n\n")
 
     return bad_files
+
+
+def lint_unused_licenses(
+    report: ProjectReport, out=sys.stdout
+) -> Iterable[str]:
+    """Lint for unused licenses."""
+    unused_licenses = []
+
+    if report.unused_licenses:
+        out.write("# ")
+        out.write(_("UNUSED LICENSES"))
+        out.write("\n\n")
+        out.write(_("The following licenses are not used:"))
+        out.write("\n")
+        for lic in sorted(report.unused_licenses):
+            unused_licenses.append(lic)
+            _write_element(lic, out=out)
+        out.write("\n\n")
+
+    return unused_licenses
 
 
 def lint_read_errors(report: ProjectReport, out=sys.stdout) -> Iterable[str]:
@@ -192,6 +232,15 @@ def lint_summary(report: ProjectReport, out=sys.stdout) -> None:
     out.write("\n")
 
     out.write("* ")
+    out.write(_("Licenses without file extension:"))
+    for i, lic in enumerate(sorted(report.licenses_without_extension)):
+        if i:
+            out.write(",")
+        out.write(" ")
+        out.write(lic)
+    out.write("\n")
+
+    out.write("* ")
     out.write(_("Missing licenses:"))
     for i, lic in enumerate(sorted(report.missing_licenses)):
         if i:
@@ -217,16 +266,6 @@ def lint_summary(report: ProjectReport, out=sys.stdout) -> None:
         out.write(" ")
         out.write(lic)
     out.write("\n")
-
-    if report.licenses_without_extension:
-        out.write("* ")
-        out.write(_("Licenses without file extension:"))
-        for i, lic in enumerate(sorted(report.licenses_without_extension)):
-            if i:
-                out.write(",")
-            out.write(" ")
-            out.write(lic)
-        out.write("\n")
 
     out.write("* ")
     out.write(_("Read errors: {count}".format(count=len(report.read_errors))))

--- a/src/reuse/project.py
+++ b/src/reuse/project.py
@@ -44,6 +44,8 @@ class Project:
     interactions.
     """
 
+    # pylint: disable=too-many-instance-attributes
+
     def __init__(self, root: PathLike, include_submodules: bool = False):
         self._root = Path(root)
         if not self._root.is_dir():

--- a/src/reuse/project.py
+++ b/src/reuse/project.py
@@ -196,6 +196,11 @@ class Project:
         The name of the path (minus its extension) should be a valid SPDX
         License Identifier.
         """
+        if path.name in self.license_map:
+            _LOGGER.warning(
+                _("{path} does not have a file extension").format(path=path)
+            )
+            return path.name
         if path.stem in self.license_map:
             return path.stem
         if path.stem.startswith("LicenseRef-"):

--- a/src/reuse/project.py
+++ b/src/reuse/project.py
@@ -242,8 +242,6 @@ class Project:
                 continue
             if Path(path).suffix == ".license":
                 continue
-            if Path(path).suffix == ".spdx":
-                continue
 
             path = self._relative_from_root(path)
             _LOGGER.debug(_("determining identifier of %s"), path)

--- a/src/reuse/project.py
+++ b/src/reuse/project.py
@@ -60,7 +60,7 @@ class Project:
         if self._is_git_repo:
             self._all_ignored_files = _all_files_ignored_by_git(self._root)
 
-        self.licenses_without_extension = set()
+        self.licenses_without_extension = dict()
 
         self.license_map = LICENSE_MAP.copy()
         # TODO: Is this correct?
@@ -209,6 +209,8 @@ class Project:
         The name of the path (minus its extension) should be a valid SPDX
         License Identifier.
         """
+        if not path.suffix:
+            raise IdentifierNotFound("{} has no file extension".format(path))
         if path.stem in self.license_map:
             return path.stem
         if path.stem.startswith("LicenseRef-"):
@@ -269,7 +271,7 @@ class Project:
                         )
                     )
                     identifier = path.name
-                    self.licenses_without_extension.add(identifier)
+                    self.licenses_without_extension[identifier] = path
                 else:
                     identifier = path.stem
                     _LOGGER.warning(

--- a/src/reuse/project.py
+++ b/src/reuse/project.py
@@ -261,7 +261,7 @@ class Project:
                 identifier = self._identifier_of_license(path)
             except IdentifierNotFound:
                 if path.name in self.license_map:
-                    _LOGGER.warning(
+                    _LOGGER.info(
                         _("{path} does not have a file extension").format(
                             path=path
                         )

--- a/src/reuse/report.py
+++ b/src/reuse/report.py
@@ -41,7 +41,7 @@ class ProjectReport:  # pylint: disable=too-many-instance-attributes
         self.bad_licenses = dict()
         self.read_errors = set()
         self.file_reports = set()
-        self.licenses_without_extension = set()
+        self.licenses_without_extension = dict()
 
         self.do_checksum = do_checksum
 
@@ -53,20 +53,21 @@ class ProjectReport:  # pylint: disable=too-many-instance-attributes
         """Turn the report into a json-like dictionary."""
         return {
             "path": str(Path(self.path).resolve()),
+            "bad_licenses": {
+                lic: [str(file_) for file_ in files]
+                for lic, files in self.bad_licenses.items()
+            },
             "licenses": {
                 identifier: str(path)
                 for identifier, path in self.licenses.items()
             },
-            "licenses_without_extension": sorted(
-                self.licenses_without_extension
-            ),
+            "licenses_without_extension": {
+                identifier: str(path)
+                for identifier, path in self.licenses_without_extension.items()
+            },
             "missing_licenses": {
                 lic: [str(file_) for file_ in files]
                 for lic, files in self.missing_licenses.items()
-            },
-            "bad_licenses": {
-                lic: [str(file_) for file_ in files]
-                for lic, files in self.bad_licenses.items()
             },
             "read_errors": list(map(str, self.read_errors)),
             "file_reports": [report.to_dict() for report in self.file_reports],

--- a/src/reuse/report.py
+++ b/src/reuse/report.py
@@ -40,6 +40,7 @@ class ProjectReport:  # pylint: disable=too-many-instance-attributes
         self.bad_licenses = dict()
         self.read_errors = set()
         self.file_reports = set()
+        self.licenses_without_extension = set()
 
         self._unused_licenses = None
         self._files_without_licenses = None
@@ -53,6 +54,9 @@ class ProjectReport:  # pylint: disable=too-many-instance-attributes
                 identifier: str(path)
                 for identifier, path in self.licenses.items()
             },
+            "licenses_without_extension": sorted(
+                self.licenses_without_extension
+            ),
             "missing_licenses": {
                 lic: [str(file_) for file_ in files]
                 for lic, files in self.missing_licenses.items()
@@ -155,6 +159,9 @@ class ProjectReport:  # pylint: disable=too-many-instance-attributes
         project_report = cls()
         project_report.path = project.root
         project_report.licenses = project.licenses
+        project_report.licenses_without_extension = (
+            project.licenses_without_extension
+        )
         for path in paths:
             for file_ in project.all_files(path):
                 try:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -67,6 +67,21 @@ def test_lint_fail(fake_repository, stringio):
     assert ":-(" in stringio.getvalue()
 
 
+def test_lint_no_file_extension(fake_repository, stringio):
+    """If a license has no file extension, the lint fails."""
+    (fake_repository / "LICENSES/CC0-1.0.txt").rename(
+        fake_repository / "LICENSES/CC0-1.0"
+    )
+    result = main(["lint", str(fake_repository)], out=stringio)
+
+    assert result > 0
+    assert (
+        "One or more licenses in the project do not have a file extension."
+        in stringio.getvalue()
+    )
+    assert ":-(" in stringio.getvalue()
+
+
 def test_spdx(fake_repository, stringio):
     """Compile to an SPDX document."""
     os.chdir(str(fake_repository))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -107,10 +107,7 @@ def test_lint_no_file_extension(fake_repository, stringio):
     result = main(["lint", str(fake_repository)], out=stringio)
 
     assert result > 0
-    assert (
-        "One or more licenses in the project do not have a file extension."
-        in stringio.getvalue()
-    )
+    assert "Licenses without file extension: CC0-1.0" in stringio.getvalue()
     assert ":-(" in stringio.getvalue()
 
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -233,13 +233,24 @@ def test_license_file_detected(empty_directory):
     assert LicenseSymbol("MIT") in spdx_info.spdx_expressions
 
 
-def test_licenses_empty(empty_directory):
-    """If the identifier of a license could not be identified, silently carry
-    on."""
+def test_licenses_filename(empty_directory):
+    """Detect the license identifier of a license from its stem."""
     (empty_directory / "LICENSES").mkdir()
     (empty_directory / "LICENSES/foo.txt").touch()
     project = Project(empty_directory)
     assert "foo" in project.licenses
+
+
+def test_licenses_no_extension(empty_directory):
+    """Detect the license identifier of a license from its full name if it is
+    in the license list.
+    """
+    (empty_directory / "LICENSES").mkdir()
+    (empty_directory / "LICENSES/GPL-3.0-or-later").touch()
+    (empty_directory / "LICENSES/MIT-3.0-or-later").touch()
+    project = Project(empty_directory)
+    assert "GPL-3.0-or-later" in project.licenses
+    assert "MIT-3" in project.licenses
 
 
 def test_licenses_subdirectory(empty_directory):


### PR DESCRIPTION
Fixes #87

Does the following things:

- If a file `LICENSES/GPL-3.0-or-later` is recognised where `GPL-3.0-or-later` is any valid SPDX License Identifier without file extension, then that license is still recognised.

- The user is given a warning in the above scenario.

- The linter does not pass if any such extensionless licenses are found.

This is an improvement from the simple crash documented in #87.