### PR TITLE
Add NixOS package link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ welcome to help us package this tool for more distributions!
 * Fedora: [reuse](https://apps.fedoraproject.org/packages/reuse)
 * openSUSE: [reuse](https://software.opensuse.org/package/reuse)
 * GNU Guix: [reuse](https://guix.gnu.org/packages/reuse-0.5.0/)
+* NixOS: [reuse](https://nixos.org/nixos/packages.html?attr=reuse)
 
 ### Installation from source
 


### PR DESCRIPTION
I'm actually not sure if that is the most accurate representation since the package manager is actually [Nix](https://nixos.org/nix/) and can be used on every linux distro, macOS and in theory also *BSD and Windows.