### PR TITLE
Add __main__ module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ following sections:
 
 The versions follow [semantic versioning](https://semver.org).
 
+## Unreleased
+
+### Added
+
+- `python3 -m reuse` now works.
+
 ## 0.5.0 - 2019-08-29
 
 ### Added

--- a/src/reuse/__main__.py
+++ b/src/reuse/__main__.py
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Entry module for reuse."""
+
+if __name__ == "__main__":
+    from ._main import main
+
+    main()


### PR DESCRIPTION
Allows `python3 -m reuse`, as mentioned in #97 