### PR TITLE
Preserve shebangs and other pre-SPDX headers

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -32,6 +32,8 @@ Contributors
 
 - Stefan Bakker <s.bakker777@gmail.com>
 
+- Kirill Elagin <kirelagin@gmail.com>
+
 Translators
 -----------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ The versions follow [semantic versioning](https://semver.org).
 - Made the workaround for `MachineReadableFormatError` introduced in 0.5.2 more
   generic.
 
+- Improved shebang detection in `addheader`.
+
+- For `addheader`, the SPDX comment block now need not be the first thing in the
+  file. It will find the SPDX comment block and deal with it in-place.
+
 ## 0.5.2 - 2019-10-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,6 @@ The versions follow [semantic versioning](https://semver.org).
 - For `addheader`, the SPDX comment block now need not be the first thing in the
   file. It will find the SPDX comment block and deal with it in-place.
 
-
 - Git submodules are now ignored by default.
 
 ## 0.5.2 - 2019-10-27

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -36,10 +36,11 @@ current year is 2019):
 You can use as many ``--copyright`` and ``--copyright`` arguments, so long as
 there is at least one such argument.
 
-The REUSE header always starts at the first character in a file. If a different
-REUSE header already existed, its tags are copied, and the header is replaced.
-If the pre-existing comment header did not contain any copyright and licensing
-information, it is moved downwards in the file. A shebang is always preserved.
+The REUSE header is placed at the very top of the file. If a different REUSE
+header already existed---at the top or elsewhere---its tags are copied, and the
+header is replaced in-place.
+
+Shebangs are always preserved at the top of the file.
 
 Comment styles
 --------------

--- a/src/reuse/_util.py
+++ b/src/reuse/_util.py
@@ -201,6 +201,7 @@ def extract_spdx_info(text: str) -> None:
     """Extract SPDX information from comments in a string.
 
     :raises ExpressionError: if an SPDX expression could not be parsed
+    :raises ParseError: if an SPDX expression could not be parsed
     """
     expression_matches = set(map(str.strip, _IDENTIFIER_PATTERN.findall(text)))
     expressions = set()
@@ -219,6 +220,14 @@ def extract_spdx_info(text: str) -> None:
                 break
 
     return SpdxInfo(expressions, copyright_matches)
+
+
+def contains_spdx_info(text: str) -> bool:
+    """The text contains SPDX info."""
+    try:
+        return any(extract_spdx_info(text))
+    except (ExpressionError, ParseError):
+        return False
 
 
 def make_copyright_line(statement: str, year: str = None) -> str:

--- a/src/reuse/header.py
+++ b/src/reuse/header.py
@@ -144,9 +144,6 @@ def create_header(
             spdx_info.copyright_lines.union(existing_spdx.copyright_lines),
         )
 
-        if header.startswith("#!"):
-            new_header = header.split("\n")[0] + "\n"
-
     new_header += _create_new_header(
         spdx_info,
         template=template,
@@ -237,6 +234,17 @@ def find_and_replace_header(
     _LOGGER.debug("before = {}".format(repr(before)))
     _LOGGER.debug("header = {}".format(repr(header)))
     _LOGGER.debug("after = {}".format(repr(after)))
+
+    # Extract shebang from header and put it in before. It's a bit messy, but
+    # it ends up working.
+    if header.startswith("#!") and not before.strip():
+        before = ""
+        for line in header.splitlines():
+            if line.startswith("#!"):
+                before = before + "\n" + line
+                header.replace(line, "", 1)
+            else:
+                break
 
     header = create_header(
         spdx_info,

--- a/src/reuse/header.py
+++ b/src/reuse/header.py
@@ -124,6 +124,8 @@ def create_header(
     :raises MissingSpdxInfo: if the generated comment is missing SPDX
         information.
     """
+    if template is None:
+        template = DEFAULT_TEMPLATE
     if style is None:
         style = PythonCommentStyle
 
@@ -218,8 +220,6 @@ def find_and_replace_header(
     :raises MissingSpdxInfo: if the generated comment is missing SPDX
         information.
     """
-    if template is None:
-        template = DEFAULT_TEMPLATE
     if style is None:
         style = PythonCommentStyle
 
@@ -240,7 +240,14 @@ def find_and_replace_header(
         for line in header.splitlines():
             if line.startswith("#!"):
                 before = before + "\n" + line
-                header.replace(line, "", 1)
+                header = header.replace(line, "", 1)
+            else:
+                break
+    elif after.startswith("#!") and not any((before, header)):
+        for line in after.splitlines():
+            if line.startswith("#!"):
+                before = before + "\n" + line
+                after = after.replace(line, "", 1)
             else:
                 break
 

--- a/src/reuse/header.py
+++ b/src/reuse/header.py
@@ -50,7 +50,7 @@ DEFAULT_TEMPLATE = _ENV.get_template("default_template.jinja2")
 _NEWLINE_PATTERN = re.compile(r"\n", re.MULTILINE)
 
 
-class TextSections(NamedTuple):
+class _TextSections(NamedTuple):
     """Used to split up text in three parts."""
 
     before: str
@@ -169,9 +169,9 @@ def _indices_of_newlines(text: str) -> Sequence[int]:
     return indices
 
 
-def find_first_spdx_comment(
+def _find_first_spdx_comment(
     text: str, style: CommentStyle = None
-) -> TextSections:
+) -> _TextSections:
     """Find the first SPDX comment in the file. Return a tuple with everything
     preceding the comment, the comment itself, and everything following it.
 
@@ -188,7 +188,7 @@ def find_first_spdx_comment(
         except CommentParseError:
             continue
         if contains_spdx_info(comment):
-            return TextSections(
+            return _TextSections(
                 text[:index], comment + "\n", text[index + len(comment) + 1 :]
             )
 
@@ -225,7 +225,7 @@ def find_and_replace_header(
         style = PythonCommentStyle
 
     try:
-        before, header, after = find_first_spdx_comment(text, style=style)
+        before, header, after = _find_first_spdx_comment(text, style=style)
     except MissingSpdxInfo:
         before, header, after = "", "", text
 

--- a/src/reuse/header.py
+++ b/src/reuse/header.py
@@ -124,8 +124,6 @@ def create_header(
     :raises MissingSpdxInfo: if the generated comment is missing SPDX
         information.
     """
-    if template is None:
-        template = DEFAULT_TEMPLATE
     if style is None:
         style = PythonCommentStyle
 

--- a/src/reuse/header.py
+++ b/src/reuse/header.py
@@ -7,11 +7,12 @@
 
 import datetime
 import logging
+import re
 import sys
 from gettext import gettext as _
 from os import PathLike
 from pathlib import Path
-from typing import Optional
+from typing import NamedTuple, Optional, Sequence
 
 from binaryornot.check import is_binary
 from boolean.boolean import ParseError
@@ -31,6 +32,7 @@ from ._comment import (
 from ._util import (
     PathType,
     _determine_license_path,
+    contains_spdx_info,
     extract_spdx_info,
     make_copyright_line,
     spdx_identifier,
@@ -43,6 +45,16 @@ _ENV = Environment(
     loader=PackageLoader("reuse", "templates"), trim_blocks=True
 )
 DEFAULT_TEMPLATE = _ENV.get_template("default_template.jinja2")
+
+_NEWLINE_PATTERN = re.compile(r"\n", re.MULTILINE)
+
+
+class TextSections(NamedTuple):
+    """Used to split up text in three parts."""
+
+    before: str
+    middle: str
+    after: str
 
 
 class MissingSpdxInfo(Exception):
@@ -141,7 +153,48 @@ def create_header(
         template_is_commented=template_is_commented,
         style=style,
     )
-    return new_header
+    return new_header + "\n"
+
+
+def _indices_of_newlines(text: str) -> Sequence[int]:
+    indices = [0]
+    start = 0
+
+    while True:
+        match = _NEWLINE_PATTERN.search(text, start)
+        if match:
+            start = match.span()[1]
+            indices.append(start)
+        else:
+            break
+
+    return indices
+
+
+def find_first_spdx_comment(
+    text: str, style: CommentStyle = None
+) -> TextSections:
+    """Find the first SPDX comment in the file. Return a tuple with everything
+    preceding the comment, the comment itself, and everything following it.
+
+    :raises MissingSpdxInfo: if no SPDX info can be found in any comment
+    """
+    if style is None:
+        style = PythonCommentStyle
+
+    indices = _indices_of_newlines(text)
+
+    for index in indices:
+        try:
+            comment = style.comment_at_first_character(text[index:])
+        except CommentParseError:
+            continue
+        if contains_spdx_info(comment):
+            return TextSections(
+                text[:index], comment + "\n", text[index + len(comment) + 1 :]
+            )
+
+    raise MissingSpdxInfo()
 
 
 def find_and_replace_header(
@@ -151,11 +204,10 @@ def find_and_replace_header(
     template_is_commented: bool = False,
     style: CommentStyle = None,
 ) -> str:
-    """Find the comment block starting at the first character in *text*. That
-    comment block is replaced by a new comment block containing *spdx_info*. It
-    is formatted as according to *template*. The template is normally
-    uncommented, but if it is already commented, *template_is_commented* should
-    be :const:`True`.
+    """Find the first SPDX comment block in *text*. That comment block is
+    replaced by a new comment block containing *spdx_info*. It is formatted as
+    according to *template*. The template is normally uncommented, but if it is
+    already commented, *template_is_commented* should be :const:`True`.
 
     If both *style* and *template_is_commented* are provided, *style* is only
     used to find the header comment.
@@ -177,21 +229,16 @@ def find_and_replace_header(
         style = PythonCommentStyle
 
     try:
-        header = style.comment_at_first_character(text)
-    except CommentParseError:
-        # TODO: Log this
-        header = ""
+        before, header, after = find_first_spdx_comment(text, style=style)
+    except MissingSpdxInfo:
+        before, header, after = "", "", text
 
-    # TODO: This is a duplicated check that also happens inside of
-    # create_header.
-    try:
-        existing_spdx = extract_spdx_info(header)
-    except (ExpressionError, ParseError):
-        # This error is handled in create_header. Just set the value to None
-        # here to satisfy the linter.
-        existing_spdx = None
+    # pylint: disable=logging-format-interpolation
+    _LOGGER.debug("before = {}".format(repr(before)))
+    _LOGGER.debug("header = {}".format(repr(header)))
+    _LOGGER.debug("after = {}".format(repr(after)))
 
-    new_header = create_header(
+    header = create_header(
         spdx_info,
         header,
         template=template,
@@ -199,15 +246,12 @@ def find_and_replace_header(
         style=style,
     )
 
-    if header and any(existing_spdx):
-        text = text.replace(header, "", 1)
-    else:
-        # Some extra spacing for the new header.
-        new_header = new_header + "\n"
-        if not text.startswith("\n"):
-            new_header = new_header + "\n"
-
-    return new_header + text
+    new_text = header.strip("\n")
+    if before.strip():
+        new_text = before.strip("\n") + "\n\n" + new_text
+    if after.strip():
+        new_text = new_text + "\n\n" + after.strip("\n")
+    return new_text
 
 
 def _verify_paths_supported(paths, parser):

--- a/src/reuse/header.py
+++ b/src/reuse/header.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V.
 # SPDX-FileCopyrightText: 2019 Stefan Bakker <s.bakker777@gmail.com>
+# SPDX-FileCopyrightText: 2019 Kirill Elagin <kirelagin@gmail.com>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,7 @@ TESTS_DIRECTORY = Path(__file__).parent.resolve()
 RESOURCES_DIRECTORY = TESTS_DIRECTORY / "resources"
 
 
-def pytest_configure(config):
+def pytest_configure():
     """Called after command line options have been parsed and all plugins and
     initial conftest files been loaded.
     """

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -241,6 +241,42 @@ def test_find_and_replace_newline_before_header():
     assert find_and_replace_header(text, spdx_info) == expected
 
 
+def test_find_and_replace_preserve_preceding():
+    """When the SPDX header is in the middle of the file, keep it there."""
+    spdx_info = SpdxInfo(
+        set(["GPL-3.0-or-later"]), set(["SPDX" "-FileCopyrightText: Mary Sue"])
+    )
+    text = cleandoc(
+        """
+        # Hello, world!
+
+        def foo(bar):
+            return bar
+
+        # spdx-FileCopyrightText: Jane Doe
+
+        pass
+        """
+    ).replace("spdx", "SPDX")
+    expected = cleandoc(
+        """
+        # Hello, world!
+
+        def foo(bar):
+            return bar
+
+        # spdx-FileCopyrightText: Jane Doe
+        # spdx-FileCopyrightText: Mary Sue
+        #
+        # spdx-License-Identifier: GPL-3.0-or-later
+
+        pass
+        """
+    ).replace("spdx", "SPDX")
+
+    assert find_and_replace_header(text, spdx_info) == expected
+
+
 def test_find_and_replace_keep_shebang():
     """When encountering a shebang, keep it and put the REUSE header beneath
     it.

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -273,6 +273,36 @@ def test_find_and_replace_keep_shebang():
     assert find_and_replace_header(text, spdx_info) == expected
 
 
+def test_find_and_replace_separate_shebang():
+    """When the shebang is part of the same comment as the SPDX comment,
+    separate the two.
+    """
+    spdx_info = SpdxInfo(set(["GPL-3.0-or-later"]), set())
+    text = cleandoc(
+        """
+        #!/usr/bin/env python3
+        #!nix-shell -p python3
+        # spdx-FileCopyrightText: Jane Doe
+
+        pass
+        """
+    ).replace("spdx", "SPDX")
+    expected = cleandoc(
+        """
+        #!/usr/bin/env python3
+        #!nix-shell -p python3
+
+        # spdx-FileCopyrightText: Jane Doe
+        #
+        # spdx-License-Identifier: GPL-3.0-or-later
+
+        pass
+        """
+    ).replace("spdx", "SPDX")
+
+    assert find_and_replace_header(text, spdx_info) == expected
+
+
 def test_find_and_replace_keep_old_comment():
     """When encountering a comment that does not contain copyright and
     licensing information, preserve it below the REUSE header.

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -303,6 +303,34 @@ def test_find_and_replace_separate_shebang():
     assert find_and_replace_header(text, spdx_info) == expected
 
 
+def test_find_and_replace_only_shebang():
+    """When the file only contains a shebang, keep it at the top of the file.
+    """
+    spdx_info = SpdxInfo(set(["GPL-3.0-or-later"]), set())
+    text = cleandoc(
+        """
+        #!/usr/bin/env python3
+
+        # Hello, world!
+
+        pass
+        """
+    )
+    expected = cleandoc(
+        """
+        #!/usr/bin/env python3
+
+        # spdx-License-Identifier: GPL-3.0-or-later
+
+        # Hello, world!
+
+        pass
+        """
+    ).replace("spdx", "SPDX")
+
+    assert find_and_replace_header(text, spdx_info) == expected
+
+
 def test_find_and_replace_keep_old_comment():
     """When encountering a comment that does not contain copyright and
     licensing information, preserve it below the REUSE header.


### PR DESCRIPTION
Fixes #95 

Wrote the code to supercede #95. I ended up reusing a lot of code and ideas by @kirelagin, but went about it a little differently.

This is what the code does:

- Find the first comment block that contains SPDX info.
- Keep the comment block in that place, and preserve everything before and after it.
- Replace the contents of that comment block with new stuff.
- Oversimplified: If a shebang is detected somewhere in there, *deal with it*, and make sure it's at the top of the file.

#95 did much of the same, but made a lot of assumptions along the way. This code makes basically no assumptions at all, other than the following assumption:

- A shebang is any line or multiple of lines that all start with `#!`.
- (Another assumption it implicitly makes is that "the SPDX comment block is not indented", but shhh.)

This means that some esoteric multi-line shebangs aren't supported. I could probably deal with that as well, but don't really want to right now.