### PR TITLE
Fix `addheader --explicit-license` to not break on unsupported files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ The versions follow [semantic versioning](https://semver.org).
 
 - Git submodules are now ignored by default.
 
+- `addheader --explicit-license` now no longer breaks on unsupported filetypes.
+
 ## 0.5.2 - 2019-10-27
 
 ### Added

--- a/src/reuse/header.py
+++ b/src/reuse/header.py
@@ -424,7 +424,7 @@ def run(args, out=sys.stdout) -> int:
     paths = [_determine_license_path(path) for path in args.path]
 
     # First loop to verify before proceeding
-    if args.style is None:
+    if args.style is None and not args.explicit_license:
         _verify_paths_supported(paths, args.parser)
 
     project = create_project()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -679,6 +679,45 @@ def test_addheader_explicit_license(
     assert simple_file.read_text() == "pass"
 
 
+def test_addheader_explicit_license_unsupported_filetype(
+    fake_repository, stringio, mock_date_today
+):
+    """Add a header to a .license file if --explicit-license is given, with the
+    base file being an otherwise unsupported filetype.
+    """
+    # pylint: disable=unused-argument
+    simple_file = fake_repository / "foo.txt"
+    simple_file.write_text("Preserve this")
+
+    result = main(
+        [
+            "addheader",
+            "--license",
+            "GPL-3.0-or-later",
+            "--copyright",
+            "Mary Sue",
+            "--explicit-license",
+            "foo.txt",
+        ],
+        out=stringio,
+    )
+
+    assert result == 0
+    assert (
+        simple_file.with_name(f"{simple_file.name}.license")
+        .read_text()
+        .strip()
+        == cleandoc(
+            """
+            spdx-FileCopyrightText: 2018 Mary Sue
+
+            spdx-License-Identifier: GPL-3.0-or-later
+            """
+        ).replace("spdx", "SPDX")
+    )
+    assert simple_file.read_text() == "Preserve this"
+
+
 def test_addheader_license_file(fake_repository, stringio, mock_date_today):
     """Add a header to a .license file if it exists."""
     # pylint: disable=unused-argument


### PR DESCRIPTION
Fixes #113 