### PR TITLE
Implement `--root` argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,19 @@ following sections:
 
 The versions follow [semantic versioning](https://semver.org).
 
+## Unreleased - YYYY-MM-DD
+
+### Added
+
+- Implemented `--root` argument to specify the root of the project without
+  heuristics.
+
+### Changed
+
+- `lint` no longer accepts path arguments. Where previously one could do `reuse
+  lint SUBDIRECTORY`, this is no longer possible. When linting, you must always
+  lint the entire project. To change the project's root, use `--root`.
+
 ## 0.6.0 - 2019-11-19
 
 ### Added
@@ -33,9 +46,6 @@ The versions follow [semantic versioning](https://semver.org).
   + .yaml
   + .yml
 
-- Implemented `--root` argument to specify the root of the project without
-  heuristics.
-
 ### Changed
 
 - Made the workaround for `MachineReadableFormatError` introduced in 0.5.2 more
@@ -49,10 +59,6 @@ The versions follow [semantic versioning](https://semver.org).
 - Git submodules are now ignored by default.
 
 - `addheader --explicit-license` now no longer breaks on unsupported filetypes.
-
-- `lint` will now raise an error when it is provided paths that are not inside
-  of the project root. e.g., `lint ../` fails, assuming that the current working
-  directory is the project root.
 
 ## 0.5.2 - 2019-10-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ The versions follow [semantic versioning](https://semver.org).
   + .kt
   + .xml
 
+- Implemented `--root` argument to specify the root of the project without
+  heuristics.
+
 ### Changed
 
 - Made the workaround for `MachineReadableFormatError` introduced in 0.5.2 more
@@ -44,6 +47,10 @@ The versions follow [semantic versioning](https://semver.org).
 - Git submodules are now ignored by default.
 
 - `addheader --explicit-license` now no longer breaks on unsupported filetypes.
+
+- `lint` will now raise an error when it is provided paths that are not inside
+  of the project root. e.g., `lint ../` fails, assuming that the current working
+  directory is the project root.
 
 ## 0.5.2 - 2019-10-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ The versions follow [semantic versioning](https://semver.org).
 - Implemented `--root` argument to specify the root of the project without
   heuristics.
 
-### Changed
+### Removed
 
 - `lint` no longer accepts path arguments. Where previously one could do `reuse
   lint SUBDIRECTORY`, this is no longer possible. When linting, you must always

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -192,9 +192,10 @@ line containing '©', 'Copyright', or 'SPDX-FileCopyrightText:', then the tag an
 everything following it is considered a valid copyright notice, even if the
 copyright notice is not compliant with the specification.
 
-When running ``reuse lint``, the root of the project is automatically found if
-the working directory is inside a git repository. Otherwise, it treats the
-working directory or the specified directory as the root of the project.
+When running ``reuse``, the root of the project is automatically found if the
+working directory is inside a git repository. Otherwise, it treats the working
+directory or the specified directory as the root of the project. You can
+override the root of the project with the ``--root`` optional argument.
 
 Git submodules are automatically ignored unless ``--include-submodules`` is
 passed as optional argument.

--- a/src/reuse/_main.py
+++ b/src/reuse/_main.py
@@ -240,8 +240,6 @@ def main(args: List[str] = None, out=sys.stdout) -> int:
     else:
         project = create_project()
     project.include_submodules = parsed_args.include_submodules
-    # FIXME: Do a test here to see whether all provided paths are children of
-    # root.
 
     return parsed_args.func(parsed_args, project, out)
 

--- a/src/reuse/_main.py
+++ b/src/reuse/_main.py
@@ -20,8 +20,8 @@ from . import (
     spdx,
 )
 from ._format import INDENT, fill_all, fill_paragraph
-from ._util import setup_logging
-from .project import create_project
+from ._util import PathType, setup_logging
+from .project import Project, create_project
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -69,6 +69,12 @@ def parser() -> argparse.ArgumentParser:
         "--include-submodules",
         action="store_true",
         help=_("do not skip over Git submodules"),
+    )
+    parser.add_argument(
+        "--root",
+        action="store",
+        type=PathType("r", force_directory=True),
+        help=_("define root of project"),
     )
     parser.add_argument(
         "--version",
@@ -229,8 +235,13 @@ def main(args: List[str] = None, out=sys.stdout) -> int:
         out.write("reuse {}\n".format(__version__))
         return 0
 
-    project = create_project()
+    if parsed_args.root:
+        project = Project(parsed_args.root)
+    else:
+        project = create_project()
     project.include_submodules = parsed_args.include_submodules
+    # FIXME: Do a test here to see whether all provided paths are children of
+    # root.
 
     return parsed_args.func(parsed_args, project, out)
 

--- a/src/reuse/_main.py
+++ b/src/reuse/_main.py
@@ -73,6 +73,7 @@ def parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--root",
         action="store",
+        metavar="PATH",
         type=PathType("r", force_directory=True),
         help=_("define root of project"),
     )
@@ -81,7 +82,7 @@ def parser() -> argparse.ArgumentParser:
         action="store_true",
         help=_("show program's version number and exit"),
     )
-    parser.set_defaults(func=lambda x, y: parser.print_help())
+    parser.set_defaults(func=lambda *args: parser.print_help())
 
     subparsers = parser.add_subparsers(title=_("subcommands"))
 

--- a/src/reuse/_main.py
+++ b/src/reuse/_main.py
@@ -21,6 +21,7 @@ from . import (
 )
 from ._format import INDENT, fill_all, fill_paragraph
 from ._util import setup_logging
+from .project import create_project
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -227,7 +228,11 @@ def main(args: List[str] = None, out=sys.stdout) -> int:
     if parsed_args.version:
         out.write("reuse {}\n".format(__version__))
         return 0
-    return parsed_args.func(parsed_args, out)
+
+    project = create_project()
+    project.include_submodules = parsed_args.include_submodules
+
+    return parsed_args.func(parsed_args, project, out)
 
 
 if __name__ == "__main__":

--- a/src/reuse/download.py
+++ b/src/reuse/download.py
@@ -16,7 +16,7 @@ import requests
 
 from ._licenses import EXCEPTION_MAP, LICENSE_MAP
 from ._util import PathType, find_licenses_directory
-from .project import create_project
+from .project import Project
 from .report import ProjectReport
 
 # All raw text files are available as files underneath this path.
@@ -89,7 +89,7 @@ def add_arguments(parser) -> None:
     )
 
 
-def run(args, out=sys.stdout) -> int:
+def run(args, project: Project, out=sys.stdout) -> int:
     """Download license and place it in the LICENSES/ directory."""
 
     def _already_exists(path: PathLike):
@@ -133,7 +133,6 @@ def run(args, out=sys.stdout) -> int:
         out.write("\n")
 
     if args.all:
-        project = create_project()
         # TODO: This is fairly inefficient, but gets the job done.
         report = ProjectReport.generate(project)
         licenses = report.missing_licenses

--- a/src/reuse/header.py
+++ b/src/reuse/header.py
@@ -38,7 +38,7 @@ from ._util import (
     make_copyright_line,
     spdx_identifier,
 )
-from .project import Project, create_project
+from .project import Project
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -411,7 +411,7 @@ def add_arguments(parser) -> None:
     parser.add_argument("path", action="store", nargs="+", type=PathType("w"))
 
 
-def run(args, out=sys.stdout) -> int:
+def run(args, project: Project, out=sys.stdout) -> int:
     """Add headers to files."""
     if not any((args.copyright, args.license)):
         args.parser.error(_("option --copyright or --license is required"))
@@ -427,8 +427,6 @@ def run(args, out=sys.stdout) -> int:
     if args.style is None and not args.explicit_license:
         _verify_paths_supported(paths, args.parser)
 
-    project = create_project()
-    project.include_submodules = args.include_submodules
     template = None
     commented = False
     if args.template:

--- a/src/reuse/init.py
+++ b/src/reuse/init.py
@@ -16,6 +16,7 @@ import requests
 from ._licenses import EXCEPTION_MAP, LICENSE_MAP
 from ._util import PathType, find_root
 from .download import _path_to_license_file, put_license_in_file
+from .project import Project
 
 
 def prompt_licenses(out=sys.stdout) -> List[str]:
@@ -70,9 +71,9 @@ def add_arguments(parser):
     )
 
 
-def run(args, out=sys.stdout):
+def run(args, project: Project, out=sys.stdout):
     """List all non-compliant files."""
-    # pylint: disable=too-many-statements
+    # pylint: disable=too-many-statements,unused-argument
     if args.path:
         root = args.path
     else:

--- a/src/reuse/lint.py
+++ b/src/reuse/lint.py
@@ -253,7 +253,7 @@ def add_arguments(parser):
 
 def run(args, project: Project, out=sys.stdout):
     """List all non-compliant files."""
-    report = ProjectReport.generate(project, [project.root], do_checksum=False)
+    report = ProjectReport.generate(project, do_checksum=False)
     result = lint(report, out=out)
 
     return 0 if result else 1

--- a/src/reuse/lint.py
+++ b/src/reuse/lint.py
@@ -12,7 +12,7 @@ from typing import Iterable
 
 from . import __REUSE_version__
 from ._util import PathType
-from .project import create_project
+from .project import Project
 from .report import ProjectReport
 
 
@@ -250,10 +250,8 @@ def add_arguments(parser):
     parser.add_argument("path", action="store", nargs="*", type=PathType("r"))
 
 
-def run(args, out=sys.stdout):
+def run(args, project: Project, out=sys.stdout):
     """List all non-compliant files."""
-    project = create_project()
-    project.include_submodules = args.include_submodules
     paths = args.path
     if not paths:
         paths = [project.root]

--- a/src/reuse/lint.py
+++ b/src/reuse/lint.py
@@ -6,14 +6,11 @@
 the reports and printing some conclusions.
 """
 
-import os
 import sys
 from gettext import gettext as _
-from itertools import chain
 from typing import Iterable
 
 from . import __REUSE_version__
-from ._util import PathType
 from .project import Project
 from .report import ProjectReport
 
@@ -247,12 +244,13 @@ def lint_summary(report: ProjectReport, out=sys.stdout) -> None:
     out.write("\n")
 
 
-def add_arguments(parser):
+def add_arguments(parser):  # pylint: disable=unused-argument
     """Add arguments to parser."""
 
 
 def run(args, project: Project, out=sys.stdout):
     """List all non-compliant files."""
+    # pylint: disable=unused-argument
     report = ProjectReport.generate(project, do_checksum=False)
     result = lint(report, out=out)
 

--- a/src/reuse/lint.py
+++ b/src/reuse/lint.py
@@ -6,8 +6,10 @@
 the reports and printing some conclusions.
 """
 
+import os
 import sys
 from gettext import gettext as _
+from itertools import chain
 from typing import Iterable
 
 from . import __REUSE_version__
@@ -255,6 +257,15 @@ def run(args, project: Project, out=sys.stdout):
     paths = args.path
     if not paths:
         paths = [project.root]
+
+    if os.path.commonprefix(
+        [path.resolve() for path in chain([project.root], paths)]
+    ) != str(project.root.resolve()):
+        args.parser.error(
+            _(
+                "the provided path(s) are not subdirectories of the root: {}"
+            ).format(project.root)
+        )
 
     report = ProjectReport.generate(project, paths, do_checksum=False)
     result = lint(report, out=out)

--- a/src/reuse/lint.py
+++ b/src/reuse/lint.py
@@ -249,25 +249,11 @@ def lint_summary(report: ProjectReport, out=sys.stdout) -> None:
 
 def add_arguments(parser):
     """Add arguments to parser."""
-    parser.add_argument("path", action="store", nargs="*", type=PathType("r"))
 
 
 def run(args, project: Project, out=sys.stdout):
     """List all non-compliant files."""
-    paths = args.path
-    if not paths:
-        paths = [project.root]
-
-    if os.path.commonprefix(
-        [path.resolve() for path in chain([project.root], paths)]
-    ) != str(project.root.resolve()):
-        args.parser.error(
-            _(
-                "the provided path(s) are not subdirectories of the root: {}"
-            ).format(project.root)
-        )
-
-    report = ProjectReport.generate(project, paths, do_checksum=False)
+    report = ProjectReport.generate(project, [project.root], do_checksum=False)
     result = lint(report, out=out)
 
     return 0 if result else 1

--- a/src/reuse/report.py
+++ b/src/reuse/report.py
@@ -149,42 +149,35 @@ class ProjectReport:  # pylint: disable=too-many-instance-attributes
 
     @classmethod
     def generate(
-        cls,
-        project: Project,
-        paths: Iterable[PathLike] = None,
-        do_checksum: bool = True,
+        cls, project: Project, do_checksum: bool = True
     ) -> "ProjectReport":
         """Generate a ProjectReport from a Project."""
-        if paths is None:
-            paths = [project.root]
-
         project_report = cls(do_checksum=do_checksum)
         project_report.path = project.root
         project_report.licenses = project.licenses
-        for path in paths:
-            for file_ in project.all_files(path):
-                try:
-                    lint_file_info = FileReport.generate(
-                        project, file_, do_checksum=project_report.do_checksum
-                    )
-                except (OSError, UnicodeError):
-                    # Translators: %s is a path.
-                    _LOGGER.info(_("Could not read %s"), file_)
-                    project_report.read_errors.add(file_)
-                    continue
+        for file_ in project.all_files():
+            try:
+                lint_file_info = FileReport.generate(
+                    project, file_, do_checksum=project_report.do_checksum
+                )
+            except (OSError, UnicodeError):
+                # Translators: %s is a path.
+                _LOGGER.info(_("Could not read %s"), file_)
+                project_report.read_errors.add(file_)
+                continue
 
-                # File report.
-                project_report.file_reports.add(lint_file_info.file_report)
+            # File report.
+            project_report.file_reports.add(lint_file_info.file_report)
 
-                # Bad and missing licenses.
-                for license in lint_file_info.missing_licenses:
-                    project_report.missing_licenses.setdefault(
-                        license, set()
-                    ).add(lint_file_info.file_report.path)
-                for license in lint_file_info.bad_licenses:
-                    project_report.bad_licenses.setdefault(license, set()).add(
-                        lint_file_info.file_report.path
-                    )
+            # Bad and missing licenses.
+            for license in lint_file_info.missing_licenses:
+                project_report.missing_licenses.setdefault(license, set()).add(
+                    lint_file_info.file_report.path
+                )
+            for license in lint_file_info.bad_licenses:
+                project_report.bad_licenses.setdefault(license, set()).add(
+                    lint_file_info.file_report.path
+                )
 
         # More bad licenses
         for name, path in project.licenses.items():

--- a/src/reuse/spdx.py
+++ b/src/reuse/spdx.py
@@ -10,7 +10,7 @@ import sys
 from gettext import gettext as _
 
 from ._util import PathType
-from .project import create_project
+from .project import Project
 from .report import ProjectReport
 
 _LOGGER = logging.getLogger(__name__)
@@ -23,7 +23,7 @@ def add_arguments(parser) -> None:
     )
 
 
-def run(args, out=sys.stdout) -> int:
+def run(args, project: Project, out=sys.stdout) -> int:
     """Print the project's bill of materials."""
     if args.file:
         out = args.file.open("w", encoding="UTF-8")
@@ -31,8 +31,6 @@ def run(args, out=sys.stdout) -> int:
             # Translators: %s is a file name.
             _LOGGER.warning(_("'%s' does not end with .spdx"), out.name)
 
-    project = create_project()
-    project.include_submodules = args.include_submodules
     report = ProjectReport.generate(project)
 
     out.write(report.bill_of_materials())

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,7 +5,7 @@
 
 """All tests for reuse._main"""
 
-# pylint: disable=redefined-outer-name
+# pylint: disable=redefined-outer-name,unused-argument
 
 import datetime
 import errno
@@ -37,9 +37,7 @@ def mock_date_today(monkeypatch):
     monkeypatch.setattr(datetime, "date", date)
 
 
-def test_lint(
-    fake_repository, stringio, git_exe
-):  # pylint: disable=unused-argument
+def test_lint(fake_repository, stringio, git_exe):
     """Run a successful lint. git_exe is there to make sure that the test
     also works if git is not installed.
     """
@@ -144,7 +142,6 @@ def test_spdx(fake_repository, stringio):
 
 def test_download(fake_repository, stringio, mock_put_license_in_file):
     """Straightforward test."""
-    # pylint: disable=unused-argument
     result = main(["download", "0BSD"], out=stringio)
 
     assert result == 0
@@ -157,7 +154,6 @@ def test_download_file_exists(
     fake_repository, stringio, mock_put_license_in_file
 ):
     """The to-be-downloaded file already exists."""
-    # pylint: disable=unused-argument
     mock_put_license_in_file.side_effect = FileExistsError(
         errno.EEXIST, "", "GPL-3.0-or-later.txt"
     )
@@ -172,7 +168,6 @@ def test_download_request_exception(
     fake_repository, stringio, mock_put_license_in_file
 ):
     """There was an error while downloading the license file."""
-    # pylint: disable=unused-argument
     mock_put_license_in_file.side_effect = requests.RequestException()
 
     result = main(["download", "0BSD"], out=stringio)
@@ -185,7 +180,6 @@ def test_download_invalid_spdx(
     fake_repository, stringio, mock_put_license_in_file
 ):
     """An invalid SPDX identifier was provided."""
-    # pylint: disable=unused-argument
     mock_put_license_in_file.side_effect = requests.RequestException()
 
     result = main(["download", "does-not-exist"], out=stringio)
@@ -198,7 +192,6 @@ def test_download_custom_output(
     empty_directory, stringio, mock_put_license_in_file
 ):
     """Download the license into a custom file."""
-    # pylint: disable=unused-argument
     result = main(["download", "-o", "foo", "0BSD"], out=stringio)
 
     assert result == 0
@@ -213,7 +206,6 @@ def test_download_custom_output_too_many(
     """Providing more than one license with a custom output results in an
     error.
     """
-    # pylint: disable=unused-argument
     with pytest.raises(SystemExit):
         main(
             ["download", "-o", "foo", "0BSD", "GPL-3.0-or-later"], out=stringio
@@ -223,7 +215,6 @@ def test_download_custom_output_too_many(
 # TODO: Replace this test with a monkeypatched test
 def test_addheader_simple(fake_repository, stringio, mock_date_today):
     """Add a header to a file that does not have one."""
-    # pylint: disable=unused-argument
     simple_file = fake_repository / "foo.py"
     simple_file.write_text("pass")
 
@@ -256,7 +247,6 @@ def test_addheader_simple(fake_repository, stringio, mock_date_today):
 
 def test_addheader_year(fake_repository, stringio):
     """Add a header to a file with a custom year."""
-    # pylint: disable=unused-argument
     simple_file = fake_repository / "foo.py"
     simple_file.write_text("pass")
 
@@ -291,7 +281,6 @@ def test_addheader_year(fake_repository, stringio):
 
 def test_addheader_no_year(fake_repository, stringio):
     """Add a header to a file without a year."""
-    # pylint: disable=unused-argument
     simple_file = fake_repository / "foo.py"
     simple_file.write_text("pass")
 
@@ -325,7 +314,6 @@ def test_addheader_no_year(fake_repository, stringio):
 
 def test_addheader_specify_style(fake_repository, stringio, mock_date_today):
     """Add a header to a file that does not have one, using a custom style."""
-    # pylint: disable=unused-argument
     simple_file = fake_repository / "foo.py"
     simple_file.write_text("pass")
 
@@ -360,7 +348,6 @@ def test_addheader_specify_style(fake_repository, stringio, mock_date_today):
 
 def test_addheader_implicit_style(fake_repository, stringio, mock_date_today):
     """Add a header to a file that has a recognised extension."""
-    # pylint: disable=unused-argument
     simple_file = fake_repository / "foo.js"
     simple_file.write_text("pass")
 
@@ -422,7 +409,6 @@ def test_addheader_template_simple(
     fake_repository, stringio, mock_date_today, template_simple_source
 ):
     """Add a header with a custom template."""
-    # pylint: disable=unused-argument
     simple_file = fake_repository / "foo.py"
     simple_file.write_text("pass")
     template_file = fake_repository / ".reuse/templates/mytemplate.jinja2"
@@ -464,7 +450,6 @@ def test_addheader_template_simple_multiple(
     fake_repository, stringio, mock_date_today, template_simple_source
 ):
     """Add a header with a custom template to multiple files."""
-    # pylint: disable=unused-argument
     simple_files = [fake_repository / f"foo{i}.py" for i in range(10)]
     for simple_file in simple_files:
         simple_file.write_text("pass")
@@ -508,7 +493,6 @@ def test_addheader_template_no_spdx(
     fake_repository, stringio, template_no_spdx_source
 ):
     """Add a header with a template that lacks SPDX info."""
-    # pylint: disable=unused-argument
     simple_file = fake_repository / "foo.py"
     simple_file.write_text("pass")
     template_file = fake_repository / ".reuse/templates/mytemplate.jinja2"
@@ -536,7 +520,6 @@ def test_addheader_template_commented(
     fake_repository, stringio, mock_date_today, template_commented_source
 ):
     """Add a header with a custom template that is already commented."""
-    # pylint: disable=unused-argument
     simple_file = fake_repository / "foo.c"
     simple_file.write_text("pass")
     template_file = (
@@ -602,7 +585,6 @@ def test_addheader_template_without_extension(
 ):
 
     """Find the correct header even when not using an extension."""
-    # pylint: disable=unused-argument
     simple_file = fake_repository / "foo.py"
     simple_file.write_text("pass")
     template_file = fake_repository / ".reuse/templates/mytemplate.jinja2"
@@ -644,7 +626,6 @@ def test_addheader_binary(
     fake_repository, stringio, mock_date_today, binary_string
 ):
     """Add a header to a .license file if the file is a binary."""
-    # pylint: disable=unused-argument
     binary_file = fake_repository / "foo.png"
     binary_file.write_bytes(binary_string)
 
@@ -679,7 +660,6 @@ def test_addheader_explicit_license(
     fake_repository, stringio, mock_date_today
 ):
     """Add a header to a .license file if --explicit-license is given."""
-    # pylint: disable=unused-argument
     simple_file = fake_repository / "foo.py"
     simple_file.write_text("pass")
 
@@ -718,7 +698,6 @@ def test_addheader_explicit_license_unsupported_filetype(
     """Add a header to a .license file if --explicit-license is given, with the
     base file being an otherwise unsupported filetype.
     """
-    # pylint: disable=unused-argument
     simple_file = fake_repository / "foo.txt"
     simple_file.write_text("Preserve this")
 
@@ -753,7 +732,6 @@ def test_addheader_explicit_license_unsupported_filetype(
 
 def test_addheader_license_file(fake_repository, stringio, mock_date_today):
     """Add a header to a .license file if it exists."""
-    # pylint: disable=unused-argument
     simple_file = fake_repository / "foo.py"
     simple_file.touch()
     license_file = fake_repository / "foo.py.license"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -99,6 +99,67 @@ def test_lint_fail(fake_repository, stringio):
     assert ":-(" in stringio.getvalue()
 
 
+def test_lint_custom_root(fake_repository, stringio):
+    """Use a custom root location."""
+    result = main(
+        ["--root", "doc", "lint", str(fake_repository / "doc")], out=stringio
+    )
+
+    assert result > 0
+    assert "index.rst" in stringio.getvalue()
+    assert ":-(" in stringio.getvalue()
+
+
+def test_lint_custom_root_git(git_repository, stringio):
+    """Use a custom root location in a git repo."""
+    result = main(
+        ["--root", "doc", "lint", str(git_repository / "doc")], out=stringio
+    )
+
+    assert result > 0
+    assert "index.rst" in stringio.getvalue()
+    assert ":-(" in stringio.getvalue()
+
+
+def test_lint_custom_root_different_cwd(fake_repository, stringio):
+    """Use a custom root while CWD is different."""
+    os.chdir("/")
+    result = main(
+        ["--root", str(fake_repository), "lint", str(fake_repository)],
+        out=stringio,
+    )
+
+    assert result == 0
+    assert ":-)" in stringio.getvalue()
+
+
+def test_lint_custom_root_is_file(fake_repository, stringio):
+    """Custom root cannot be a file."""
+    with pytest.raises(SystemExit):
+        main(
+            ["--root", ".reuse/dep5", "lint", str(fake_repository)],
+            out=stringio,
+        )
+
+
+def test_lint_custom_root_not_exists(fake_repository, stringio):
+    """Custom root must exist."""
+    with pytest.raises(SystemExit):
+        main(
+            ["--root", "does-not-exist", "lint", str(fake_repository)],
+            out=stringio,
+        )
+
+
+@pytest.mark.xfail(reason="not implemented")
+def test_lint_outside_of_root(fake_repository, stringio):
+    """Lint fails when the provided directories are outside of the root
+    directory.
+    """
+    with pytest.raises(SystemExit):
+        main(["--root", "doc", "lint", str(fake_repository)], out=stringio)
+
+
 def test_spdx(fake_repository, stringio):
     """Compile to an SPDX document."""
     os.chdir(str(fake_repository))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -151,7 +151,6 @@ def test_lint_custom_root_not_exists(fake_repository, stringio):
         )
 
 
-@pytest.mark.xfail(reason="not implemented")
 def test_lint_outside_of_root(fake_repository, stringio):
     """Lint fails when the provided directories are outside of the root
     directory.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -43,7 +43,7 @@ def test_lint(
     """Run a successful lint. git_exe is there to make sure that the test
     also works if git is not installed.
     """
-    result = main(["lint", str(fake_repository)], out=stringio)
+    result = main(["lint"], out=stringio)
 
     assert result == 0
     assert ":-)" in stringio.getvalue()
@@ -51,7 +51,7 @@ def test_lint(
 
 def test_lint_git(git_repository, stringio):
     """Run a successful lint."""
-    result = main(["lint", str(git_repository)], out=stringio)
+    result = main(["lint"], out=stringio)
 
     assert result == 0
     assert ":-)" in stringio.getvalue()
@@ -60,7 +60,7 @@ def test_lint_git(git_repository, stringio):
 def test_lint_submodule(submodule_repository, stringio):
     """Run a successful lint."""
     (submodule_repository / "submodule/foo.c").touch()
-    result = main(["lint", str(submodule_repository)], out=stringio)
+    result = main(["lint"], out=stringio)
 
     assert result == 0
     assert ":-)" in stringio.getvalue()
@@ -68,10 +68,7 @@ def test_lint_submodule(submodule_repository, stringio):
 
 def test_lint_submodule_included(submodule_repository, stringio):
     """Run a successful lint."""
-    result = main(
-        ["--include-submodules", "lint", str(submodule_repository)],
-        out=stringio,
-    )
+    result = main(["--include-submodules", "lint"], out=stringio)
 
     assert result == 0
     assert ":-)" in stringio.getvalue()
@@ -80,10 +77,7 @@ def test_lint_submodule_included(submodule_repository, stringio):
 def test_lint_submodule_included_fail(submodule_repository, stringio):
     """Run a failed lint."""
     (submodule_repository / "submodule/foo.c").touch()
-    result = main(
-        ["--include-submodules", "lint", str(submodule_repository)],
-        out=stringio,
-    )
+    result = main(["--include-submodules", "lint"], out=stringio)
 
     assert result == 1
     assert ":-(" in stringio.getvalue()
@@ -92,7 +86,7 @@ def test_lint_submodule_included_fail(submodule_repository, stringio):
 def test_lint_fail(fake_repository, stringio):
     """Run a failed lint."""
     (fake_repository / "foo.py").touch()
-    result = main(["lint", str(fake_repository)], out=stringio)
+    result = main(["lint"], out=stringio)
 
     assert result > 0
     assert "foo.py" in stringio.getvalue()
@@ -101,9 +95,7 @@ def test_lint_fail(fake_repository, stringio):
 
 def test_lint_custom_root(fake_repository, stringio):
     """Use a custom root location."""
-    result = main(
-        ["--root", "doc", "lint", str(fake_repository / "doc")], out=stringio
-    )
+    result = main(["--root", "doc", "lint"], out=stringio)
 
     assert result > 0
     assert "index.rst" in stringio.getvalue()
@@ -112,9 +104,7 @@ def test_lint_custom_root(fake_repository, stringio):
 
 def test_lint_custom_root_git(git_repository, stringio):
     """Use a custom root location in a git repo."""
-    result = main(
-        ["--root", "doc", "lint", str(git_repository / "doc")], out=stringio
-    )
+    result = main(["--root", "doc", "lint"], out=stringio)
 
     assert result > 0
     assert "index.rst" in stringio.getvalue()
@@ -124,10 +114,7 @@ def test_lint_custom_root_git(git_repository, stringio):
 def test_lint_custom_root_different_cwd(fake_repository, stringio):
     """Use a custom root while CWD is different."""
     os.chdir("/")
-    result = main(
-        ["--root", str(fake_repository), "lint", str(fake_repository)],
-        out=stringio,
-    )
+    result = main(["--root", str(fake_repository), "lint"], out=stringio)
 
     assert result == 0
     assert ":-)" in stringio.getvalue()
@@ -136,27 +123,13 @@ def test_lint_custom_root_different_cwd(fake_repository, stringio):
 def test_lint_custom_root_is_file(fake_repository, stringio):
     """Custom root cannot be a file."""
     with pytest.raises(SystemExit):
-        main(
-            ["--root", ".reuse/dep5", "lint", str(fake_repository)],
-            out=stringio,
-        )
+        main(["--root", ".reuse/dep5", "lint"], out=stringio)
 
 
 def test_lint_custom_root_not_exists(fake_repository, stringio):
     """Custom root must exist."""
     with pytest.raises(SystemExit):
-        main(
-            ["--root", "does-not-exist", "lint", str(fake_repository)],
-            out=stringio,
-        )
-
-
-def test_lint_outside_of_root(fake_repository, stringio):
-    """Lint fails when the provided directories are outside of the root
-    directory.
-    """
-    with pytest.raises(SystemExit):
-        main(["--root", "doc", "lint", str(fake_repository)], out=stringio)
+        main(["--root", "does-not-exist", "lint"], out=stringio)
 
 
 def test_spdx(fake_repository, stringio):


### PR DESCRIPTION
Fixes #94 

Closes #100 

This is an alternative approach to #100 that makes the declaration of the root directory explicit.

It also adds a sanity check: The root of a project must be the parent of all paths that are given to the linter. e.g., if the current working directory is the project root, you can't `reuse lint ../`.

This seems like a sufficient "fix"?