### PR TITLE
Handle deprecated licenses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ The versions follow [semantic versioning](https://semver.org).
 - `--include-submodules` is added to also include submodules when linting et
   cetera.
 
+- Deprecated licenses are now recognised. `lint` will complain about deprecated
+  licenses.
+
 - `addheader` now also recognises the following extensions:
 
   + .kt

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -192,6 +192,7 @@ This is some example output of ``reuse lint``:
   # SUMMARY
 
   * Bad licenses: bad-license
+  * Deprecated licenses:
   * Licenses without file extension:
   * Missing licenses:
   * Unused licenses: bad-license

--- a/src/reuse/_licenses.py
+++ b/src/reuse/_licenses.py
@@ -31,11 +31,8 @@ def _load_license_list(file_name):
         licenses = json.load(lics)
         version = licenses["licenseListVersion"].split(".")
         for lic in licenses["licenses"]:
-            if lic.get("isDeprecatedLicenseId"):
-                continue
-            name = lic["name"]
             identifier = lic["licenseId"]
-            licenses_map[identifier] = name
+            licenses_map[identifier] = lic
     return version, licenses_map
 
 
@@ -49,11 +46,8 @@ def _load_exception_list(file_name):
         exceptions = json.load(excs)
         version = exceptions["licenseListVersion"].split(".")
         for exc in exceptions["exceptions"]:
-            if exc.get("isDeprecatedLicenseId"):
-                continue
-            name = exc["name"]
             identifier = exc["licenseExceptionId"]
-            exceptions_map[identifier] = name
+            exceptions_map[identifier] = exc
     return version, exceptions_map
 
 

--- a/src/reuse/lint.py
+++ b/src/reuse/lint.py
@@ -43,6 +43,7 @@ def lint(report: ProjectReport, out=sys.stdout) -> bool:
             # TODO: Should this be a separate entry if it's already in the
             # summary?
             report.unused_licenses,
+            report.deprecated_licenses,
         )
     )
 
@@ -185,6 +186,15 @@ def lint_summary(report: ProjectReport, out=sys.stdout) -> None:
     out.write("* ")
     out.write(_("Bad licenses:"))
     for i, lic in enumerate(sorted(report.bad_licenses)):
+        if i:
+            out.write(",")
+        out.write(" ")
+        out.write(lic)
+    out.write("\n")
+
+    out.write("* ")
+    out.write(_("Deprecated licenses:"))
+    for i, lic in enumerate(sorted(report.deprecated_licenses)):
         if i:
             out.write(",")
         out.write(" ")

--- a/src/reuse/report.py
+++ b/src/reuse/report.py
@@ -39,6 +39,7 @@ class ProjectReport:  # pylint: disable=too-many-instance-attributes
         self.licenses = dict()
         self.missing_licenses = dict()
         self.bad_licenses = dict()
+        self.deprecated_licenses = set()
         self.read_errors = set()
         self.file_reports = set()
 
@@ -64,6 +65,7 @@ class ProjectReport:  # pylint: disable=too-many-instance-attributes
                 lic: [str(file_) for file_ in files]
                 for lic, files in self.bad_licenses.items()
             },
+            "deprecated_licenses": sorted(self.deprecated_licenses),
             "read_errors": list(map(str, self.read_errors)),
             "file_reports": [report.to_dict() for report in self.file_reports],
         }
@@ -186,10 +188,12 @@ class ProjectReport:  # pylint: disable=too-many-instance-attributes
                         lint_file_info.file_report.path
                     )
 
-        # More bad licenses
+        # More bad licenses, and also deprecated licenses
         for name, path in project.licenses.items():
             if name not in project.license_map:
                 project_report.bad_licenses.setdefault(name, set()).add(path)
+            elif project.license_map[name]["isDeprecatedLicenseId"]:
+                project_report.deprecated_licenses.add(name)
 
         return project_report
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -126,6 +126,18 @@ def test_generate_project_report_bad_license_in_file(fake_repository):
     assert "bad" in result.bad_licenses
 
 
+def test_generate_project_report_deprecated_license(fake_repository):
+    """Deprecated licenses are detected."""
+    (fake_repository / "LICENSES/GPL-3.0-or-later.txt").rename(
+        fake_repository / "LICENSES/GPL-3.0.txt"
+    )
+
+    project = Project(fake_repository)
+    result = ProjectReport.generate(project)
+
+    assert "GPL-3.0" in result.deprecated_licenses
+
+
 def test_generate_project_report_read_error(fake_repository):
     """Files that cannot be read are added to the read error list."""
     (fake_repository / "bad").symlink_to("does_not_exist")


### PR DESCRIPTION
Fixes #18 

Kind of. It only deals with deprecated licenses, not with the "+" operator.

Together with #89 this is necessary to fix #87 

Not *entirely* happy with this patch, though. The clunkiness of `lint.py` is starting to show. I'm really happy with `report.py` though.

One remark while writing this patch: The order of the items in the `lint` summary is NOT consistent inside of the codebase. It would be nice if this were fixed?