### PR TITLE
When encountering an unsupported filetype, also suggest `--explicit-license` to the user

### DIFF
--- a/src/reuse/header.py
+++ b/src/reuse/header.py
@@ -278,8 +278,8 @@ def _verify_paths_supported(paths, parser):
                 parser.error(
                     _(
                         "'{}' does not have a recognised file extension, "
-                        "please use --style".format(path)
-                    )
+                        "please use --style or --explicit-license"
+                    ).format(path)
                 )
 
 


### PR DESCRIPTION
Fixes #116

Closes #120

Kind of. This is a workaround that requires a lot less code, but puts the burden on the user to do `--explicit-license`.