### PR TITLE
Make sure that Project.license_map only contains dictionaries

### DIFF
--- a/src/reuse/project.py
+++ b/src/reuse/project.py
@@ -295,7 +295,16 @@ class Project:
                 identifier.startswith("LicenseRef-")
                 and "Unknown" not in identifier
             ):
-                self.license_map[identifier] = path
+                self.license_map[identifier] = {
+                    "reference": str(path),
+                    "isDeprecatedLicenseId": False,
+                    "detailsUrl": None,
+                    "referenceNumber": None,
+                    "name": identifier,
+                    "licenseId": identifier,
+                    "seeAlso": [],
+                    "isOsiApproved": None,
+                }
 
         return license_files
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,6 +88,11 @@ def fake_repository(tmpdir_factory) -> Path:
         "SPDX"
         "-License-Identifier: GPL-3.0-or-later WITH Autoconf-exception-3.0"
     )
+    (directory / "src/custom.py").write_text(
+        "SPDX-FileCopyrightText: 2017 Mary Sue\n"
+        "SPDX"
+        "-License-Identifier: LicenseRef-custom"
+    )
 
     os.chdir(directory)
     return directory

--- a/tests/resources/fake_repository/src/custom.py
+++ b/tests/resources/fake_repository/src/custom.py
@@ -1,5 +1,1 @@
-# SPDX-FileCopyrightText: 2017 Mary Sue
-#
-# SPDX-License-Identifier: LicenseRef-custom
-
-pass
+# This file is overriden by the fake_repository fixture.

--- a/tests/resources/fake_repository/src/custom.py
+++ b/tests/resources/fake_repository/src/custom.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2017 Mary Sue
+#
+# SPDX-License-Identifier: LicenseRef-custom
+
+pass


### PR DESCRIPTION
Fixes #128 

Really simple fix. Tests have been updated to make sure this does not happen again.