### PR TITLE
Recognize comment style by well-known filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ The versions follow [semantic versioning](https://semver.org).
 
 - `addheader` now recognises many more extensions. Too many to list here.
 
+- `addheader` now also recognises full filenames such as `Makefile` and
+  `.gitignore`.
+
 - Added BibTex comment style.
 
 ### Changed

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ import os
 import sys
 from shutil import copyfile
 
-from pkg_resources import get_distribution, DistributionNotFound
+from pkg_resources import DistributionNotFound, get_distribution
 
 sys.path.insert(0, os.path.abspath("../src/"))
 

--- a/src/reuse/_comment.py
+++ b/src/reuse/_comment.py
@@ -1,5 +1,6 @@
-# SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2019-2020 Free Software Foundation Europe e.V.
 # SPDX-FileCopyrightText: 2019 Kirill Elagin
+# SPDX-FileCopyrightText: 2020 Dmitry Bogatov
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -341,7 +342,7 @@ class TexCommentStyle(CommentStyle):
 
 
 #: A map of (common) file extensions against comment types.
-COMMENT_STYLE_MAP = {
+EXTENSION_COMMENT_STYLE_MAP = {
     ".adb": HaskellCommentStyle,
     ".ads": HaskellCommentStyle,
     ".ahk": LispCommentStyle,
@@ -440,6 +441,20 @@ COMMENT_STYLE_MAP = {
     ".yaml": PythonCommentStyle,
     ".yml": PythonCommentStyle,
     ".zsh": PythonCommentStyle,
+}
+
+FILENAME_COMMENT_STYLE_MAP = {
+    ".gitattributes": PythonCommentStyle,
+    ".gitignore": PythonCommentStyle,
+    ".gitmodules": PythonCommentStyle,
+    ".editorconfig": PythonCommentStyle,
+    ".pylintrc": PythonCommentStyle,
+    "Dockerfile": PythonCommentStyle,
+    "Makefile": PythonCommentStyle,
+    "Manifest.in": PythonCommentStyle,
+    "manifest": PythonCommentStyle,  # used by cdist
+    "requirements.txt": PythonCommentStyle,
+    "setup.cfg": PythonCommentStyle,
 }
 
 # IMPORTANT: !!! When adding a new style, also edit usage.rst !!!

--- a/src/reuse/header.py
+++ b/src/reuse/header.py
@@ -1,6 +1,7 @@
-# SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2019-2020 Free Software Foundation Europe e.V.
 # SPDX-FileCopyrightText: 2019 Stefan Bakker <s.bakker777@gmail.com>
 # SPDX-FileCopyrightText: 2019 Kirill Elagin <kirelagin@gmail.com>
+# SPDX-FileCopyrightText: 2020 Dmitry Bogatov
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -23,7 +24,8 @@ from license_expression import ExpressionError
 
 from . import SpdxInfo
 from ._comment import (
-    COMMENT_STYLE_MAP,
+    EXTENSION_COMMENT_STYLE_MAP,
+    FILENAME_COMMENT_STYLE_MAP,
     NAME_STYLE_MAP,
     CommentCreateError,
     CommentParseError,
@@ -268,10 +270,21 @@ def find_and_replace_header(
     return new_text
 
 
+def _get_comment_style(path: Path) -> CommentStyle:
+    """Return value of CommentStyle detected for *path*.
+
+    :raises KeyError: if no comment style is detected.
+    """
+    style = FILENAME_COMMENT_STYLE_MAP.get(path.name)
+    if style is None:
+        style = EXTENSION_COMMENT_STYLE_MAP[path.suffix]
+    return style
+
+
 def _verify_paths_supported(paths, parser):
     for path in paths:
         try:
-            COMMENT_STYLE_MAP[path.suffix]
+            _get_comment_style(path)
         except KeyError:
             # TODO: This check is duplicated.
             if not is_binary(str(path)):
@@ -321,7 +334,7 @@ def _add_header_to_file(
     if style is not None:
         style = NAME_STYLE_MAP[style]
     else:
-        style = COMMENT_STYLE_MAP[path.suffix]
+        style = _get_comment_style(path)
 
     with path.open("r") as fp:
         text = fp.read()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -408,6 +408,40 @@ def test_addheader_implicit_style(fake_repository, stringio, mock_date_today):
     )
 
 
+def test_addheader_implicit_style_filename(
+    fake_repository, stringio, mock_date_today
+):
+    """Add a header to a filename that is recognised."""
+    simple_file = fake_repository / "Makefile"
+    simple_file.write_text("pass")
+
+    result = main(
+        [
+            "addheader",
+            "--license",
+            "GPL-3.0-or-later",
+            "--copyright",
+            "Mary Sue",
+            "Makefile",
+        ],
+        out=stringio,
+    )
+
+    assert result == 0
+    assert (
+        simple_file.read_text()
+        == cleandoc(
+            """
+            # spdx-FileCopyrightText: 2018 Mary Sue
+            #
+            # spdx-License-Identifier: GPL-3.0-or-later
+
+            pass
+            """
+        ).replace("spdx", "SPDX")
+    )
+
+
 def test_addheader_unrecognised_style(fake_repository):
     """Add a header to a file that has an unrecognised extension."""
     simple_file = fake_repository / "foo.foo"


### PR DESCRIPTION
* src/reuse/_comment.py(FILENAME_COMMENT_STYLE_MAP):
   map from well-known full filenames to comment style

 * src/reuse/header.py(_get_comment_style): introduce new helper
   function that tries to detect file comment style by consulting
   both COMMENT_STYLE_MAP and FILENAME_COMMENT_STYLE_MAP.

 * src/reuse/header.py: replace call sites of COMMENT_STYLE_MAP with
   calls to `_get_comment_style`.

This change enables automatic detection of comment style for files that
have well-known names with extension, like "manifest" -- shell script,
used by "cdist" configuration management system. Previously, such files
required comment style to be specified explicitly by `--style` command
line option.


Fixes #135