### PR TITLE
Suggest valid SPDX License Identifiers when invalid one is given

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -18,8 +18,6 @@ Contributors
 
 - Sebastian Schuberth <schuberth@fsfe.org>
 
-- Kirill Elagin
-
 - Max Mehl <max.mehl@fsfe.org>
 
 - Matija Šuklje <hook@fsfe.org>
@@ -35,6 +33,9 @@ Contributors
 - Kirill Elagin <kirelagin@gmail.com>
 
 - John Mulligan <jmulligan@redhat.com>
+
+- Tuomas Siipola <tuomas@zpl.fi>
+
 
 Translators
 -----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ The versions follow [semantic versioning](https://semver.org).
 
 - A pre-commit hook has been added.
 
+- When an incorrect SPDX identifier is forwarded to `download` or `init`, the
+  tool now suggests what you might have meant.
+
 ### Changed
 
 - Under the hood, a lot of code that has to do with Git and Mercurial was moved

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ license-expression==1.2
 boolean.py==3.7
 Jinja2==2.10.3
 binaryornot==0.4.4
-jaro-winkler==2.0.0
 
 setuptools==41.6.0
 setuptools-scm==3.3.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ license-expression==1.2
 boolean.py==3.7
 Jinja2==2.10.3
 binaryornot==0.4.4
+jaro-winkler==2.0.0
 
 setuptools==41.6.0
 setuptools-scm==3.3.3

--- a/src/reuse/_licenses.py
+++ b/src/reuse/_licenses.py
@@ -53,3 +53,9 @@ def _load_exception_list(file_name):
 
 _, LICENSE_MAP = _load_license_list(_LICENSES)
 _, EXCEPTION_MAP = _load_exception_list(_EXCEPTIONS)
+ALL_MAP = {**LICENSE_MAP, **EXCEPTION_MAP}
+ALL_NON_DEPRECATED_MAP = {
+    identifier: contents.copy()
+    for identifier, contents in ALL_MAP.items()
+    if not contents["isDeprecatedLicenseId"]
+}

--- a/src/reuse/_util.py
+++ b/src/reuse/_util.py
@@ -303,6 +303,9 @@ def similar_spdx_identifiers(identifier: str) -> List[str]:
 
 
 def print_incorrect_spdx_identifier(identifier: str, out=sys.stdout) -> None:
+    """Print out that *identifier* is not valid, and follow up with some
+    suggestions.
+    """
     out.write(
         _("'{}' is not a valid SPDX License Identifier.").format(identifier)
     )

--- a/src/reuse/_util.py
+++ b/src/reuse/_util.py
@@ -13,6 +13,7 @@ import re
 import shutil
 import subprocess
 from argparse import ArgumentTypeError
+from difflib import SequenceMatcher
 from gettext import gettext as _
 from hashlib import sha1
 from itertools import chain
@@ -22,7 +23,6 @@ from typing import BinaryIO, List, Optional
 
 from boolean.boolean import Expression, ParseError
 from debian.copyright import Copyright
-from jaro import jaro_winkler_metric
 from license_expression import ExpressionError, Licensing
 
 from . import SpdxInfo
@@ -294,9 +294,9 @@ def validate_spdx_identifier(identifier: str) -> Optional[str]:
     error += "\n"
     suggestions = []
     for valid_identifier in valid_identifiers:
-        distance = jaro_winkler_metric(
-            identifier.lower(), valid_identifier.lower()
-        )
+        distance = SequenceMatcher(
+            a=identifier.lower(), b=valid_identifier.lower()
+        ).ratio()
         if distance > 0.75:
             suggestions.append((distance, valid_identifier))
     suggestions = sorted(suggestions, reverse=True)

--- a/src/reuse/_util.py
+++ b/src/reuse/_util.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2017-2019 Free Software Foundation Europe e.V.
 # SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+# SPDX-FileCopyrightText: 2020 Tuomas Siipola <tuomas@zpl.fi>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/reuse/_util.py
+++ b/src/reuse/_util.py
@@ -18,7 +18,6 @@ from argparse import ArgumentTypeError
 from difflib import SequenceMatcher
 from gettext import gettext as _
 from hashlib import sha1
-from itertools import chain
 from os import PathLike
 from pathlib import Path
 from typing import BinaryIO, List, Optional
@@ -29,7 +28,7 @@ from license_expression import ExpressionError, Licensing
 
 from . import SpdxInfo
 from ._comment import _all_style_classes
-from ._licenses import EXCEPTION_MAP, LICENSE_MAP
+from ._licenses import ALL_NON_DEPRECATED_MAP
 
 GIT_EXE = shutil.which("git")
 HG_EXE = shutil.which("hg")
@@ -286,12 +285,11 @@ def spdx_identifier(text: str) -> Expression:
 
 def similar_spdx_identifiers(identifier: str) -> List[str]:
     """Given an incorrect SPDX identifier, return a list of similar ones."""
-    valid_identifiers = list(chain(LICENSE_MAP, EXCEPTION_MAP))
     suggestions = []
-    if identifier in valid_identifiers:
+    if identifier in ALL_NON_DEPRECATED_MAP:
         return suggestions
 
-    for valid_identifier in valid_identifiers:
+    for valid_identifier in ALL_NON_DEPRECATED_MAP:
         distance = SequenceMatcher(
             a=identifier.lower(), b=valid_identifier.lower()
         ).ratio()

--- a/src/reuse/download.py
+++ b/src/reuse/download.py
@@ -7,15 +7,13 @@
 import errno
 import sys
 from gettext import gettext as _
-from itertools import chain
 from os import PathLike
 from pathlib import Path
 from urllib.parse import urljoin
 
 import requests
 
-from ._licenses import EXCEPTION_MAP, LICENSE_MAP
-from ._util import PathType, find_licenses_directory
+from ._util import PathType, find_licenses_directory, validate_spdx_identifier
 from .project import Project
 from .report import ProjectReport
 
@@ -103,19 +101,9 @@ def run(args, project: Project, out=sys.stdout) -> int:
     def _could_not_download(identifier: str):
         out.write(_("Error: Failed to download license."))
         out.write(" ")
-        if identifier not in chain(LICENSE_MAP, EXCEPTION_MAP):
-            out.write(
-                _("'{}' is not a valid SPDX License Identifier.").format(
-                    identifier
-                )
-            )
-            out.write("\n")
-            out.write(
-                _(
-                    "See <https://spdx.org/licenses/> for a list of valid "
-                    "SPDX License Identifiers."
-                )
-            )
+        error = validate_spdx_identifier(identifier)
+        if error:
+            out.write(error)
         else:
             out.write(_("Is your internet connection working?"))
         out.write("\n")

--- a/src/reuse/download.py
+++ b/src/reuse/download.py
@@ -7,14 +7,13 @@
 import errno
 import sys
 from gettext import gettext as _
-from itertools import chain
 from os import PathLike
 from pathlib import Path
 from urllib.parse import urljoin
 
 import requests
 
-from ._licenses import EXCEPTION_MAP, LICENSE_MAP
+from ._licenses import ALL_NON_DEPRECATED_MAP
 from ._util import (
     PathType,
     find_licenses_directory,
@@ -107,7 +106,7 @@ def run(args, project: Project, out=sys.stdout) -> int:
     def _could_not_download(identifier: str):
         out.write(_("Error: Failed to download license."))
         out.write(" ")
-        if identifier not in chain(LICENSE_MAP, EXCEPTION_MAP):
+        if identifier not in ALL_NON_DEPRECATED_MAP:
             print_incorrect_spdx_identifier(identifier, out=out)
         else:
             out.write(_("Is your internet connection working?"))

--- a/src/reuse/download.py
+++ b/src/reuse/download.py
@@ -7,13 +7,19 @@
 import errno
 import sys
 from gettext import gettext as _
+from itertools import chain
 from os import PathLike
 from pathlib import Path
 from urllib.parse import urljoin
 
 import requests
 
-from ._util import PathType, find_licenses_directory, validate_spdx_identifier
+from ._licenses import EXCEPTION_MAP, LICENSE_MAP
+from ._util import (
+    PathType,
+    find_licenses_directory,
+    print_incorrect_spdx_identifier,
+)
 from .project import Project
 from .report import ProjectReport
 
@@ -101,9 +107,8 @@ def run(args, project: Project, out=sys.stdout) -> int:
     def _could_not_download(identifier: str):
         out.write(_("Error: Failed to download license."))
         out.write(" ")
-        error = validate_spdx_identifier(identifier)
-        if error:
-            out.write(error)
+        if identifier not in chain(LICENSE_MAP, EXCEPTION_MAP):
+            print_incorrect_spdx_identifier(identifier, out=out)
         else:
             out.write(_("Is your internet connection working?"))
         out.write("\n")

--- a/src/reuse/init.py
+++ b/src/reuse/init.py
@@ -14,11 +14,7 @@ from typing import List
 import requests
 
 from ._licenses import EXCEPTION_MAP, LICENSE_MAP
-from ._util import (
-    PathType,
-    print_incorrect_spdx_identifier,
-    validate_spdx_identifier,
-)
+from ._util import PathType, print_incorrect_spdx_identifier
 from .download import _path_to_license_file, put_license_in_file
 from .project import Project
 from .vcs import find_root
@@ -50,6 +46,7 @@ def prompt_licenses(out=sys.stdout) -> List[str]:
             return licenses
         if result not in chain(LICENSE_MAP, EXCEPTION_MAP):
             print_incorrect_spdx_identifier(result, out=out)
+            out.write("\n\n")
         else:
             licenses.append(result)
 

--- a/src/reuse/init.py
+++ b/src/reuse/init.py
@@ -7,14 +7,13 @@
 import sys
 from gettext import gettext as _
 from inspect import cleandoc
-from itertools import chain
 from pathlib import Path
 from typing import List
 
 import requests
 
 from ._licenses import EXCEPTION_MAP, LICENSE_MAP
-from ._util import PathType
+from ._util import PathType, validate_spdx_identifier
 from .download import _path_to_license_file, put_license_in_file
 from .project import Project
 from .vcs import find_root
@@ -44,19 +43,9 @@ def prompt_licenses(out=sys.stdout) -> List[str]:
         out.write("\n")
         if not result:
             return licenses
-        if result not in chain(LICENSE_MAP, EXCEPTION_MAP):
-            out.write(
-                _("'{}' is not a valid SPDX License Identifier.").format(
-                    result
-                )
-            )
-            out.write("\n")
-            out.write(
-                _(
-                    "See <https://spdx.org/licenses/> for a list of valid "
-                    "SPDX License Identifiers."
-                )
-            )
+        error = validate_spdx_identifier(result)
+        if error:
+            out.write(error)
             out.write("\n\n")
         else:
             licenses.append(result)

--- a/src/reuse/init.py
+++ b/src/reuse/init.py
@@ -7,13 +7,12 @@
 import sys
 from gettext import gettext as _
 from inspect import cleandoc
-from itertools import chain
 from pathlib import Path
 from typing import List
 
 import requests
 
-from ._licenses import EXCEPTION_MAP, LICENSE_MAP
+from ._licenses import ALL_NON_DEPRECATED_MAP
 from ._util import PathType, print_incorrect_spdx_identifier
 from .download import _path_to_license_file, put_license_in_file
 from .project import Project
@@ -44,7 +43,7 @@ def prompt_licenses(out=sys.stdout) -> List[str]:
         out.write("\n")
         if not result:
             return licenses
-        if result not in chain(LICENSE_MAP, EXCEPTION_MAP):
+        if result not in ALL_NON_DEPRECATED_MAP:
             print_incorrect_spdx_identifier(result, out=out)
             out.write("\n\n")
         else:

--- a/src/reuse/init.py
+++ b/src/reuse/init.py
@@ -13,7 +13,11 @@ from typing import List
 import requests
 
 from ._licenses import EXCEPTION_MAP, LICENSE_MAP
-from ._util import PathType, validate_spdx_identifier
+from ._util import (
+    PathType,
+    print_incorrect_spdx_identifier,
+    validate_spdx_identifier,
+)
 from .download import _path_to_license_file, put_license_in_file
 from .project import Project
 from .vcs import find_root
@@ -44,9 +48,8 @@ def prompt_licenses(out=sys.stdout) -> List[str]:
         if not result:
             return licenses
         error = validate_spdx_identifier(result)
-        if error:
-            out.write(error)
-            out.write("\n\n")
+        if result not in chain(LICENSE_MAP, EXCEPTION_MAP):
+            print_incorrect_spdx_identifier(result, out=out)
         else:
             licenses.append(result)
 

--- a/src/reuse/init.py
+++ b/src/reuse/init.py
@@ -7,6 +7,7 @@
 import sys
 from gettext import gettext as _
 from inspect import cleandoc
+from itertools import chain
 from pathlib import Path
 from typing import List
 
@@ -47,7 +48,6 @@ def prompt_licenses(out=sys.stdout) -> List[str]:
         out.write("\n")
         if not result:
             return licenses
-        error = validate_spdx_identifier(result)
         if result not in chain(LICENSE_MAP, EXCEPTION_MAP):
             print_incorrect_spdx_identifier(result, out=out)
         else:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -286,3 +286,12 @@ def test_decoded_text_from_binary_crlf():
     text = "Hello\r\nworld"
     encoded = text.encode("utf-8")
     assert _util.decoded_text_from_binary(BytesIO(encoded)) == "Hello\nworld"
+
+
+def test_similar_spdx_identifiers():
+    """Given a misspelt SPDX License Identifier, suggest a better one."""
+    result = _util.similar_spdx_identifiers("GPL-3.0-or-lter")
+
+    assert "GPL-3.0-or-later" in result
+    assert "AGPL-3.0-or-later" in result
+    assert "LGPL-3.0-or-later" in result


### PR DESCRIPTION
Suggest corrections for typos like "GLP3-or-lter" and unclear licenses like "BSD" in init and download commands.