### PR TITLE
allow tab after SPDX-License-Identifier

### DIFF
--- a/src/reuse/_util.py
+++ b/src/reuse/_util.py
@@ -31,7 +31,7 @@ _LICENSING = Licensing()
 
 _END_PATTERN = r"(?:\*/)*(?:-->)*(?:\})*$"
 _IDENTIFIER_PATTERN = re.compile(
-    r"SPDX" "-License-Identifier:[ \t](.*?)" + _END_PATTERN, re.MULTILINE
+    r"SPDX" "-License-Identifier:[ \t]+(.*?)" + _END_PATTERN, re.MULTILINE
 )
 _COPYRIGHT_PATTERNS = [
     re.compile(r"(SPDX" "-FileCopyrightText: .*?)" + _END_PATTERN),

--- a/src/reuse/_util.py
+++ b/src/reuse/_util.py
@@ -34,7 +34,7 @@ _IDENTIFIER_PATTERN = re.compile(
     r"SPDX" "-License-Identifier:[ \t]+(.*?)" + _END_PATTERN, re.MULTILINE
 )
 _COPYRIGHT_PATTERNS = [
-    re.compile(r"(SPDX" "-FileCopyrightText: .*?)" + _END_PATTERN),
+    re.compile(r"(SPDX" "-FileCopyrightText:[ \t]+.*?)" + _END_PATTERN),
     re.compile(r"(Copyright .*?)" + _END_PATTERN),
     re.compile(r"(© .*?)" + _END_PATTERN),
 ]

--- a/src/reuse/_util.py
+++ b/src/reuse/_util.py
@@ -31,7 +31,7 @@ _LICENSING = Licensing()
 
 _END_PATTERN = r"(?:\*/)*(?:-->)*(?:\})*$"
 _IDENTIFIER_PATTERN = re.compile(
-    r"SPDX" "-License-Identifier: (.*?)" + _END_PATTERN, re.MULTILINE
+    r"SPDX" "-License-Identifier:[ \t](.*?)" + _END_PATTERN, re.MULTILINE
 )
 _COPYRIGHT_PATTERNS = [
     re.compile(r"(SPDX" "-FileCopyrightText: .*?)" + _END_PATTERN),

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -84,15 +84,31 @@ def test_extract_copyright():
     """Given a file with copyright information, have it return that copyright
     information.
     """
-    copyright = "SPDX-FileCopyrightText: 2019 Jane Doe"
+    copyright = "SPDX" "-FileCopyrightText: 2019 Jane Doe"
     result = _util.extract_spdx_info(copyright)
     assert result.copyright_lines == {copyright}
 
 
 def test_extract_copyright_duplicate():
     """When a copyright line is duplicated, only yield one."""
-    copyright = "SPDX-FileCopyrightText: 2019 Jane Doe"
+    copyright = "SPDX" "-FileCopyrightText: 2019 Jane Doe"
     result = _util.extract_spdx_info("\n".join((copyright, copyright)))
+    assert result.copyright_lines == {copyright}
+
+
+def test_extract_copyright_tab():
+    """A tag followed by a tab is also valid."""
+    copyright = "SPDX" "-FileCopyrightText:\t2019 Jane Doe"
+    result = _util.extract_spdx_info(copyright)
+    assert result.copyright_lines == {copyright}
+
+
+def test_extract_many_whitespace():
+    """When a tag is followed by a lot of whitespace, that is also valid. The
+    whitespace is not filtered out.
+    """
+    copyright = "SPDX" "-FileCopyrightText:    2019 Jane Doe"
+    result = _util.extract_spdx_info(copyright)
     assert result.copyright_lines == {copyright}
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2017-2019 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2020 Liferay, Inc. All rights reserved.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -59,6 +59,20 @@ def test_extract_no_info():
     assert result == _util.SpdxInfo(set(), set())
 
 
+def test_extract_tab():
+    """A tag followed by a tab is also valid."""
+    result = _util.extract_spdx_info("SPDX" "-License-Identifier:\tMIT")
+    assert result.spdx_expressions == {_LICENSING.parse("MIT")}
+
+
+def test_extract_many_whitespace():
+    """When a tag is followed by a lot of whitespace, the whitespace should be
+    filtered out.
+    """
+    result = _util.extract_spdx_info("SPDX" "-License-Identifier:    MIT")
+    assert result.spdx_expressions == {_LICENSING.parse("MIT")}
+
+
 def test_extract_bibtex_comment():
     """A special case for BibTex comments."""
     expression = "@Comment{SPDX" "-License-Identifier: GPL-3.0-or-later}"


### PR DESCRIPTION
The SPDX Specification does not specify that the whitespace between the `SPDX-License-Identifier:` string and the license expression must be a single space. The regular expression already matched multiple spaces or space-and-tab combinations before, so allowing a tab directly after the `SPDX-License-Identifier:` string improves consistency.