### PR TITLE
addheader: No longer remove newlines at the ends of files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ The versions follow [semantic versioning](https://semver.org).
 - Fixed a bug with `addheader --explicit-license` that would result in
   `file.license.license` if `file.license` already existed.
 
+- No longer remove newlines at the end of files when using `addheader`.
+
 ### Security
 
 ## 0.8.0 - 2020-01-20

--- a/src/reuse/header.py
+++ b/src/reuse/header.py
@@ -267,7 +267,7 @@ def find_and_replace_header(
     if before.strip():
         new_text = before.strip("\n") + "\n\n" + new_text
     if after.strip():
-        new_text = new_text + "\n\n" + after.strip("\n")
+        new_text = new_text + "\n\n" + after.strip("\n") + "\n"
     return new_text
 
 

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -183,15 +183,18 @@ def test_find_and_replace_no_header():
         {"GPL-3.0-or-later"}, {"SPDX" "-FileCopyrightText: Mary Sue"}
     )
     text = "pass"
-    expected = cleandoc(
-        """
-        # spdx-FileCopyrightText: Mary Sue
-        #
-        # spdx-License-Identifier: GPL-3.0-or-later
+    expected = (
+        cleandoc(
+            """
+            # spdx-FileCopyrightText: Mary Sue
+            #
+            # spdx-License-Identifier: GPL-3.0-or-later
 
-        pass
-        """
-    ).replace("spdx", "SPDX")
+            pass
+            """
+        ).replace("spdx", "SPDX")
+        + "\n"
+    )
 
     assert find_and_replace_header(text, spdx_info) == expected
 
@@ -199,15 +202,18 @@ def test_find_and_replace_no_header():
 def test_find_and_replace_verbatim():
     """Replace a header with itself."""
     spdx_info = SpdxInfo(set(), set())
-    text = cleandoc(
-        """
-        # spdx-FileCopyrightText: Mary Sue
-        #
-        # spdx-License-Identifier: GPL-3.0-or-later
+    text = (
+        cleandoc(
+            """
+            # spdx-FileCopyrightText: Mary Sue
+            #
+            # spdx-License-Identifier: GPL-3.0-or-later
 
-        pass
-        """
-    ).replace("spdx", "SPDX")
+            pass
+            """
+        ).replace("spdx", "SPDX")
+        + "\n"
+    )
 
     assert find_and_replace_header(text, spdx_info) == text
 
@@ -226,17 +232,21 @@ def test_find_and_replace_newline_before_header():
         pass
         """
     ).replace("spdx", "SPDX")
-    text = "\n" + text
-    expected = cleandoc(
-        """
-        # spdx-FileCopyrightText: Jane Doe
-        # spdx-FileCopyrightText: Mary Sue
-        #
-        # spdx-License-Identifier: GPL-3.0-or-later
 
-        pass
-        """
-    ).replace("spdx", "SPDX")
+    text = "\n" + text
+    expected = (
+        cleandoc(
+            """
+            # spdx-FileCopyrightText: Jane Doe
+            # spdx-FileCopyrightText: Mary Sue
+            #
+            # spdx-License-Identifier: GPL-3.0-or-later
+
+            pass
+            """
+        ).replace("spdx", "SPDX")
+        + "\n"
+    )
 
     assert find_and_replace_header(text, spdx_info) == expected
 
@@ -258,21 +268,24 @@ def test_find_and_replace_preserve_preceding():
         pass
         """
     ).replace("spdx", "SPDX")
-    expected = cleandoc(
-        """
-        # Hello, world!
+    expected = (
+        cleandoc(
+            """
+            # Hello, world!
 
-        def foo(bar):
-            return bar
+            def foo(bar):
+                return bar
 
-        # spdx-FileCopyrightText: Jane Doe
-        # spdx-FileCopyrightText: Mary Sue
-        #
-        # spdx-License-Identifier: GPL-3.0-or-later
+            # spdx-FileCopyrightText: Jane Doe
+            # spdx-FileCopyrightText: Mary Sue
+            #
+            # spdx-License-Identifier: GPL-3.0-or-later
 
-        pass
-        """
-    ).replace("spdx", "SPDX")
+            pass
+            """
+        ).replace("spdx", "SPDX")
+        + "\n"
+    )
 
     assert find_and_replace_header(text, spdx_info) == expected
 
@@ -293,18 +306,21 @@ def test_find_and_replace_keep_shebang():
         pass
         """
     ).replace("spdx", "SPDX")
-    expected = cleandoc(
-        """
-        #!/usr/bin/env python3
+    expected = (
+        cleandoc(
+            """
+            #!/usr/bin/env python3
 
-        # spdx-FileCopyrightText: Jane Doe
-        # spdx-FileCopyrightText: Mary Sue
-        #
-        # spdx-License-Identifier: GPL-3.0-or-later
+            # spdx-FileCopyrightText: Jane Doe
+            # spdx-FileCopyrightText: Mary Sue
+            #
+            # spdx-License-Identifier: GPL-3.0-or-later
 
-        pass
-        """
-    ).replace("spdx", "SPDX")
+            pass
+            """
+        ).replace("spdx", "SPDX")
+        + "\n"
+    )
 
     assert find_and_replace_header(text, spdx_info) == expected
 
@@ -323,18 +339,21 @@ def test_find_and_replace_separate_shebang():
         pass
         """
     ).replace("spdx", "SPDX")
-    expected = cleandoc(
-        """
-        #!/usr/bin/env python3
-        #!nix-shell -p python3
+    expected = (
+        cleandoc(
+            """
+            #!/usr/bin/env python3
+            #!nix-shell -p python3
 
-        # spdx-FileCopyrightText: Jane Doe
-        #
-        # spdx-License-Identifier: GPL-3.0-or-later
+            # spdx-FileCopyrightText: Jane Doe
+            #
+            # spdx-License-Identifier: GPL-3.0-or-later
 
-        pass
-        """
-    ).replace("spdx", "SPDX")
+            pass
+            """
+        ).replace("spdx", "SPDX")
+        + "\n"
+    )
 
     assert find_and_replace_header(text, spdx_info) == expected
 
@@ -352,17 +371,20 @@ def test_find_and_replace_only_shebang():
         pass
         """
     )
-    expected = cleandoc(
-        """
-        #!/usr/bin/env python3
+    expected = (
+        cleandoc(
+            """
+            #!/usr/bin/env python3
 
-        # spdx-License-Identifier: GPL-3.0-or-later
+            # spdx-License-Identifier: GPL-3.0-or-later
 
-        # Hello, world!
+            # Hello, world!
 
-        pass
-        """
-    ).replace("spdx", "SPDX")
+            pass
+            """
+        ).replace("spdx", "SPDX")
+        + "\n"
+    )
 
     assert find_and_replace_header(text, spdx_info) == expected
 
@@ -381,16 +403,19 @@ def test_find_and_replace_keep_old_comment():
         pass
         """
     ).replace("spdx", "SPDX")
-    expected = cleandoc(
-        """
-        # spdx-FileCopyrightText: Mary Sue
-        #
-        # spdx-License-Identifier: GPL-3.0-or-later
+    expected = (
+        cleandoc(
+            """
+            # spdx-FileCopyrightText: Mary Sue
+            #
+            # spdx-License-Identifier: GPL-3.0-or-later
 
-        # Hello, world!
+            # Hello, world!
 
-        pass
-        """
-    ).replace("spdx", "SPDX")
+            pass
+            """
+        ).replace("spdx", "SPDX")
+        + "\n"
+    )
 
     assert find_and_replace_header(text, spdx_info) == expected

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -273,6 +273,7 @@ def test_addheader_simple(fake_repository, stringio, mock_date_today):
             pass
             """
         ).replace("spdx", "SPDX")
+        + "\n"
     )
 
 
@@ -307,6 +308,7 @@ def test_addheader_year(fake_repository, stringio):
             pass
             """
         ).replace("spdx", "SPDX")
+        + "\n"
     )
 
 
@@ -340,6 +342,7 @@ def test_addheader_no_year(fake_repository, stringio):
             pass
             """
         ).replace("spdx", "SPDX")
+        + "\n"
     )
 
 
@@ -374,6 +377,7 @@ def test_addheader_specify_style(fake_repository, stringio, mock_date_today):
             pass
             """
         ).replace("spdx", "SPDX")
+        + "\n"
     )
 
 
@@ -406,6 +410,7 @@ def test_addheader_implicit_style(fake_repository, stringio, mock_date_today):
             pass
             """
         ).replace("spdx", "SPDX")
+        + "\n"
     )
 
 
@@ -440,6 +445,7 @@ def test_addheader_implicit_style_filename(
             pass
             """
         ).replace("spdx", "SPDX")
+        + "\n"
     )
 
 
@@ -508,6 +514,7 @@ def test_addheader_template_simple(
             pass
             """
         ).replace("spdx", "SPDX")
+        + "\n"
     )
 
 
@@ -551,6 +558,7 @@ def test_addheader_template_simple_multiple(
                 pass
                 """
             ).replace("spdx", "SPDX")
+            + "\n"
         )
 
 
@@ -621,6 +629,7 @@ def test_addheader_template_commented(
             pass
             """
         ).replace("spdx", "SPDX")
+        + "\n"
     )
 
 
@@ -684,6 +693,7 @@ def test_addheader_template_without_extension(
             pass
             """
         ).replace("spdx", "SPDX")
+        + "\n"
     )
 
 


### PR DESCRIPTION
Fixes #153 

Closes #155 