### PR TITLE
Preserve newlines at the ends of files with addheader - alternative implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,8 +57,6 @@ The versions follow [semantic versioning](https://semver.org).
 - Fixed a bug with `addheader --explicit-license` that would result in
   `file.license.license` if `file.license` already existed.
 
-- No longer remove newlines at the end of files when using `addheader`.
-
 ### Security
 
 ## 0.8.0 - 2020-01-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ The versions follow [semantic versioning](https://semver.org).
 - Fixed a bug with `addheader --explicit-license` that would result in
   `file.license.license` if `file.license` already existed.
 
+- No longer remove newlines at the end of files when using `addheader`.
+
 ### Security
 
 ## 0.8.0 - 2020-01-20

--- a/src/reuse/header.py
+++ b/src/reuse/header.py
@@ -267,7 +267,7 @@ def find_and_replace_header(
     if before.strip():
         new_text = before.strip("\n") + "\n\n" + new_text
     if after.strip():
-        new_text = new_text + "\n\n" + after.strip("\n")
+        new_text = new_text + "\n\n" + after.lstrip("\n")
     return new_text
 
 

--- a/src/reuse/header.py
+++ b/src/reuse/header.py
@@ -267,7 +267,7 @@ def find_and_replace_header(
     if before.strip():
         new_text = before.strip("\n") + "\n\n" + new_text
     if after.strip():
-        new_text = new_text + "\n\n" + after.strip("\n") + "\n"
+        new_text = new_text + "\n\n" + after.strip("\n")
     return new_text
 
 

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -394,3 +394,23 @@ def test_find_and_replace_keep_old_comment():
     ).replace("spdx", "SPDX")
 
     assert find_and_replace_header(text, spdx_info) == expected
+
+
+def test_find_and_replace_preserve_newline():
+    """If the file content ends with a newline, don't remove it."""
+
+    spdx_info = SpdxInfo(set(), set())
+    text = (
+        cleandoc(
+            """
+            # spdx-FileCopyrightText: Mary Sue
+            #
+            # spdx-License-Identifier: GPL-3.0-or-later
+
+            pass
+            """
+        ).replace("spdx", "SPDX")
+        + "\n"
+    )
+
+    assert find_and_replace_header(text, spdx_info) == text

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -183,18 +183,15 @@ def test_find_and_replace_no_header():
         {"GPL-3.0-or-later"}, {"SPDX" "-FileCopyrightText: Mary Sue"}
     )
     text = "pass"
-    expected = (
-        cleandoc(
-            """
-            # spdx-FileCopyrightText: Mary Sue
-            #
-            # spdx-License-Identifier: GPL-3.0-or-later
+    expected = cleandoc(
+        """
+        # spdx-FileCopyrightText: Mary Sue
+        #
+        # spdx-License-Identifier: GPL-3.0-or-later
 
-            pass
-            """
-        ).replace("spdx", "SPDX")
-        + "\n"
-    )
+        pass
+        """
+    ).replace("spdx", "SPDX")
 
     assert find_and_replace_header(text, spdx_info) == expected
 
@@ -202,18 +199,15 @@ def test_find_and_replace_no_header():
 def test_find_and_replace_verbatim():
     """Replace a header with itself."""
     spdx_info = SpdxInfo(set(), set())
-    text = (
-        cleandoc(
-            """
-            # spdx-FileCopyrightText: Mary Sue
-            #
-            # spdx-License-Identifier: GPL-3.0-or-later
+    text = cleandoc(
+        """
+        # spdx-FileCopyrightText: Mary Sue
+        #
+        # spdx-License-Identifier: GPL-3.0-or-later
 
-            pass
-            """
-        ).replace("spdx", "SPDX")
-        + "\n"
-    )
+        pass
+        """
+    ).replace("spdx", "SPDX")
 
     assert find_and_replace_header(text, spdx_info) == text
 
@@ -232,21 +226,17 @@ def test_find_and_replace_newline_before_header():
         pass
         """
     ).replace("spdx", "SPDX")
-
     text = "\n" + text
-    expected = (
-        cleandoc(
-            """
-            # spdx-FileCopyrightText: Jane Doe
-            # spdx-FileCopyrightText: Mary Sue
-            #
-            # spdx-License-Identifier: GPL-3.0-or-later
+    expected = cleandoc(
+        """
+        # spdx-FileCopyrightText: Jane Doe
+        # spdx-FileCopyrightText: Mary Sue
+        #
+        # spdx-License-Identifier: GPL-3.0-or-later
 
-            pass
-            """
-        ).replace("spdx", "SPDX")
-        + "\n"
-    )
+        pass
+        """
+    ).replace("spdx", "SPDX")
 
     assert find_and_replace_header(text, spdx_info) == expected
 
@@ -268,24 +258,21 @@ def test_find_and_replace_preserve_preceding():
         pass
         """
     ).replace("spdx", "SPDX")
-    expected = (
-        cleandoc(
-            """
-            # Hello, world!
+    expected = cleandoc(
+        """
+        # Hello, world!
 
-            def foo(bar):
-                return bar
+        def foo(bar):
+            return bar
 
-            # spdx-FileCopyrightText: Jane Doe
-            # spdx-FileCopyrightText: Mary Sue
-            #
-            # spdx-License-Identifier: GPL-3.0-or-later
+        # spdx-FileCopyrightText: Jane Doe
+        # spdx-FileCopyrightText: Mary Sue
+        #
+        # spdx-License-Identifier: GPL-3.0-or-later
 
-            pass
-            """
-        ).replace("spdx", "SPDX")
-        + "\n"
-    )
+        pass
+        """
+    ).replace("spdx", "SPDX")
 
     assert find_and_replace_header(text, spdx_info) == expected
 
@@ -306,21 +293,18 @@ def test_find_and_replace_keep_shebang():
         pass
         """
     ).replace("spdx", "SPDX")
-    expected = (
-        cleandoc(
-            """
-            #!/usr/bin/env python3
+    expected = cleandoc(
+        """
+        #!/usr/bin/env python3
 
-            # spdx-FileCopyrightText: Jane Doe
-            # spdx-FileCopyrightText: Mary Sue
-            #
-            # spdx-License-Identifier: GPL-3.0-or-later
+        # spdx-FileCopyrightText: Jane Doe
+        # spdx-FileCopyrightText: Mary Sue
+        #
+        # spdx-License-Identifier: GPL-3.0-or-later
 
-            pass
-            """
-        ).replace("spdx", "SPDX")
-        + "\n"
-    )
+        pass
+        """
+    ).replace("spdx", "SPDX")
 
     assert find_and_replace_header(text, spdx_info) == expected
 
@@ -339,21 +323,18 @@ def test_find_and_replace_separate_shebang():
         pass
         """
     ).replace("spdx", "SPDX")
-    expected = (
-        cleandoc(
-            """
-            #!/usr/bin/env python3
-            #!nix-shell -p python3
+    expected = cleandoc(
+        """
+        #!/usr/bin/env python3
+        #!nix-shell -p python3
 
-            # spdx-FileCopyrightText: Jane Doe
-            #
-            # spdx-License-Identifier: GPL-3.0-or-later
+        # spdx-FileCopyrightText: Jane Doe
+        #
+        # spdx-License-Identifier: GPL-3.0-or-later
 
-            pass
-            """
-        ).replace("spdx", "SPDX")
-        + "\n"
-    )
+        pass
+        """
+    ).replace("spdx", "SPDX")
 
     assert find_and_replace_header(text, spdx_info) == expected
 
@@ -371,20 +352,17 @@ def test_find_and_replace_only_shebang():
         pass
         """
     )
-    expected = (
-        cleandoc(
-            """
-            #!/usr/bin/env python3
+    expected = cleandoc(
+        """
+        #!/usr/bin/env python3
 
-            # spdx-License-Identifier: GPL-3.0-or-later
+        # spdx-License-Identifier: GPL-3.0-or-later
 
-            # Hello, world!
+        # Hello, world!
 
-            pass
-            """
-        ).replace("spdx", "SPDX")
-        + "\n"
-    )
+        pass
+        """
+    ).replace("spdx", "SPDX")
 
     assert find_and_replace_header(text, spdx_info) == expected
 
@@ -403,19 +381,16 @@ def test_find_and_replace_keep_old_comment():
         pass
         """
     ).replace("spdx", "SPDX")
-    expected = (
-        cleandoc(
-            """
-            # spdx-FileCopyrightText: Mary Sue
-            #
-            # spdx-License-Identifier: GPL-3.0-or-later
+    expected = cleandoc(
+        """
+        # spdx-FileCopyrightText: Mary Sue
+        #
+        # spdx-License-Identifier: GPL-3.0-or-later
 
-            # Hello, world!
+        # Hello, world!
 
-            pass
-            """
-        ).replace("spdx", "SPDX")
-        + "\n"
-    )
+        pass
+        """
+    ).replace("spdx", "SPDX")
 
     assert find_and_replace_header(text, spdx_info) == expected

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -273,7 +273,6 @@ def test_addheader_simple(fake_repository, stringio, mock_date_today):
             pass
             """
         ).replace("spdx", "SPDX")
-        + "\n"
     )
 
 
@@ -308,7 +307,6 @@ def test_addheader_year(fake_repository, stringio):
             pass
             """
         ).replace("spdx", "SPDX")
-        + "\n"
     )
 
 
@@ -342,7 +340,6 @@ def test_addheader_no_year(fake_repository, stringio):
             pass
             """
         ).replace("spdx", "SPDX")
-        + "\n"
     )
 
 
@@ -377,7 +374,6 @@ def test_addheader_specify_style(fake_repository, stringio, mock_date_today):
             pass
             """
         ).replace("spdx", "SPDX")
-        + "\n"
     )
 
 
@@ -410,7 +406,6 @@ def test_addheader_implicit_style(fake_repository, stringio, mock_date_today):
             pass
             """
         ).replace("spdx", "SPDX")
-        + "\n"
     )
 
 
@@ -445,7 +440,6 @@ def test_addheader_implicit_style_filename(
             pass
             """
         ).replace("spdx", "SPDX")
-        + "\n"
     )
 
 
@@ -514,7 +508,6 @@ def test_addheader_template_simple(
             pass
             """
         ).replace("spdx", "SPDX")
-        + "\n"
     )
 
 
@@ -558,7 +551,6 @@ def test_addheader_template_simple_multiple(
                 pass
                 """
             ).replace("spdx", "SPDX")
-            + "\n"
         )
 
 
@@ -629,7 +621,6 @@ def test_addheader_template_commented(
             pass
             """
         ).replace("spdx", "SPDX")
-        + "\n"
     )
 
 
@@ -693,7 +684,6 @@ def test_addheader_template_without_extension(
             pass
             """
         ).replace("spdx", "SPDX")
-        + "\n"
     )
 
 


### PR DESCRIPTION
Fixes #153 

I was really unhappy with the solution I wrote in #164. I reverted that PR and wrote this instead, which is heaps and heaps and heaps more elegant.