### PR TITLE
Tests for Dockerfile and Docker image

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -121,3 +121,15 @@ jobs:
     - name: Create docs with Sphinx
       run: |
         make docs
+
+  docker:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build Dockerfile
+      run: |
+        docker build -t reuse .
+    - name: Run Docker image
+      run: |
+        docker run -v "$(pwd):/data" reuse


### PR DESCRIPTION
This PR adds a step in the CI to test whether the Dockerfile can be built and whether the result successfully lints the source of this programme.

Thereby, we should be able to detect whether changes in some base image will result in errors.

Fixes #171 