### PR TITLE
add file extensions for Isabelle prover

### DIFF
--- a/src/reuse/_comment.py
+++ b/src/reuse/_comment.py
@@ -442,6 +442,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".markdown": HtmlCommentStyle,
     ".md": HtmlCommentStyle,
     ".ml": MlCommentStyle,
+    ".ML": MlCommentStyle,
     ".mli": MlCommentStyle,
     ".nim": PythonCommentStyle,
     ".nimrod": PythonCommentStyle,
@@ -474,6 +475,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".sql": HaskellCommentStyle,
     ".swift": CCommentStyle,
     ".tex": TexCommentStyle,
+    ".thy": MlCommentStyle,
     ".toc": TexCommentStyle,
     ".toml": PythonCommentStyle,
     ".vala": CCommentStyle,
@@ -495,6 +497,7 @@ FILENAME_COMMENT_STYLE_MAP = {
     "Manifest.in": PythonCommentStyle,
     "manifest": PythonCommentStyle,  # used by cdist
     "requirements.txt": PythonCommentStyle,
+    "ROOT": MlCommentStyle,
     "setup.cfg": PythonCommentStyle,
 }
 


### PR DESCRIPTION
This pull request adds file-extension recognition for 2 types of files used by the [Isabelle theorem prover](http://isabelle.in.tum.de), and one filename match for the same, mapping all three to the existing ml-comment style.

All three are recognised by syntax highlighting/linguist on github and satisfy their uniqueness requirements, so should be safe to add.

(We're in the process of converting a few larger repositories such as https://github.com/sel4/l4v to SPDX tags, and `reuse addheader` recognising these file types would be really handy).