### PR TITLE
Add CMakeLists.txt to filename comment style map

### DIFF
--- a/src/reuse/_comment.py
+++ b/src/reuse/_comment.py
@@ -491,6 +491,7 @@ FILENAME_COMMENT_STYLE_MAP = {
     ".editorconfig": PythonCommentStyle,
     ".pylintrc": PythonCommentStyle,
     "Dockerfile": PythonCommentStyle,
+    "CMakeLists.txt": PythonCommentStyle,
     "Makefile": PythonCommentStyle,
     "Manifest.in": PythonCommentStyle,
     "manifest": PythonCommentStyle,  # used by cdist


### PR DESCRIPTION
CMake uses # for comments (`PythonCommentStyle`), and it's already in the extension map as *.cmake -> `PythonCommentStyle`, but `CMakeLists.txt` was missing from the filename mapping.