### PR TITLE
Add basic mercurial support

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -34,6 +34,8 @@ Contributors
 
 - Kirill Elagin <kirelagin@gmail.com>
 
+- John Mulligan <jmulligan@redhat.com>
+
 Translators
 -----------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,9 +39,14 @@ The versions follow [semantic versioning](https://semver.org).
 
 ### Added
 
-### Changed
+- Added support for Mercurial 4.3+.
 
 - A pre-commit hook has been added.
+
+### Changed
+
+- Under the hood, a lot of code that has to do with Git and Mercurial was moved
+  into its own module.
 
 ### Deprecated
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-# Create a base image that has git installed.
+# Create a base image that has dependencies installed.
 FROM alpine:3.11 AS base
 
-RUN apk --no-cache add git python3
+RUN apk --no-cache add git mercurial python3
 
 # Build reuse into a virtualenv
 FROM base AS build

--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ To update reuse, run this command:
 
     pip3 install --user --upgrade reuse
 
+For full functionality, the following pieces of software are recommended:
+
+- Git
+- Mercurial 4.3+
+
 ### Installation via package managers
 
 There are packages available for easy install on some operating systems. You are

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -29,7 +29,7 @@ everything following it is considered a valid copyright notice, even if the
 copyright notice is not compliant with the specification.
 
 When running the tool, the root of the project is automatically found if the
-working directory is inside a git repository. Otherwise, it treats the working
+working directory is inside a VCS repository. Otherwise, it treats the working
 directory as the root of the project. You can override the root of the project
 with the ``--root`` optional argument.
 

--- a/src/reuse/__init__.py
+++ b/src/reuse/__init__.py
@@ -59,6 +59,7 @@ else:
 
 _IGNORE_DIR_PATTERNS = [
     re.compile(r"^\.git$"),
+    re.compile(r"^\.hg$"),
     re.compile(r"^LICENSES$"),
     re.compile(r"^\.reuse$"),
 ]

--- a/src/reuse/_util.py
+++ b/src/reuse/_util.py
@@ -17,7 +17,7 @@ from gettext import gettext as _
 from hashlib import sha1
 from os import PathLike
 from pathlib import Path
-from typing import BinaryIO, List, Optional, Set
+from typing import BinaryIO, List, Optional
 
 from boolean.boolean import Expression, ParseError
 from debian.copyright import Copyright
@@ -94,30 +94,7 @@ def execute_command(
     )
 
 
-def find_root() -> Optional[Path]:
-    """Try to find the root of the project from CWD. If none is found, return
-    None.
-    """
-    cwd = Path.cwd()
-    if in_git_repo(cwd):
-        command = [GIT_EXE, "rev-parse", "--show-toplevel"]
-        result = execute_command(command, _LOGGER, cwd=cwd)
-
-        if not result.returncode:
-            path = result.stdout.decode("utf-8")[:-1]
-            return Path(os.path.relpath(path, cwd))
-    if in_hg_repo(cwd):
-        command = [HG_EXE, "root"]
-        result = execute_command(command, _LOGGER, cwd=cwd)
-
-        if not result.returncode:
-            path = result.stdout.decode("utf-8")[:-1]
-            return Path(os.path.relpath(path, cwd))
-
-    return None
-
-
-def find_licenses_directory(root: PathLike = None) -> Optional[Path]:
+def find_licenses_directory(root: PathLike) -> Optional[Path]:
     """Find the licenses directory from CWD or *root*. In the following order:
 
     - LICENSES/ in *root*.
@@ -129,8 +106,6 @@ def find_licenses_directory(root: PathLike = None) -> Optional[Path]:
     The returned LICENSES/ directory NEED NOT EXIST. It may still need to be
     created.
     """
-    if root is None:
-        root = find_root()
     cwd = Path.cwd()
     licenses_path = cwd / "LICENSES"
 
@@ -140,95 +115,6 @@ def find_licenses_directory(root: PathLike = None) -> Optional[Path]:
         licenses_path = cwd
 
     return licenses_path
-
-
-def in_git_repo(cwd: PathLike = None) -> bool:
-    """Is *cwd* inside of a git repository?
-
-    Always return False if git is not installed.
-    """
-    if cwd is None:
-        cwd = Path.cwd()
-
-    if GIT_EXE:
-        command = [GIT_EXE, "status"]
-        result = execute_command(command, _LOGGER, cwd=cwd)
-
-        return not result.returncode
-
-    return False
-
-
-def in_hg_repo(cwd: PathLike = None) -> bool:
-    """Is *cwd* inside of a mercurial repository?
-
-    Always return False if mercurial (hg) is not installed.
-    """
-    if cwd is None:
-        cwd = Path.cwd()
-
-    if GIT_EXE:
-        command = [HG_EXE, "root"]
-        result = execute_command(command, _LOGGER, cwd=cwd)
-
-        return not result.returncode
-
-    return False
-
-
-def all_files_ignored_by_git(root: PathLike) -> Set[Path]:
-    """Return a set of all files ignored by git. If a whole directory is
-    ignored, don't return all files inside of it.
-
-    Return an empty list if git is not installed.
-    """
-    root = Path(root)
-
-    if GIT_EXE:
-        command = [
-            GIT_EXE,
-            "ls-files",
-            "--exclude-standard",
-            "--ignored",
-            "--others",
-            "--directory",
-            # TODO: This flag is unexpected.  I reported it as a bug in Git.
-            # This flag---counter-intuitively---lists untracked directories
-            # that contain ignored files.
-            "--no-empty-directory",
-            # Separate output with \0 instead of \n.
-            "-z",
-        ]
-        result = execute_command(command, _LOGGER, cwd=root)
-        all_files = result.stdout.decode("utf-8").split("\0")
-        return {Path(file_) for file_ in all_files}
-    return set()
-
-
-def all_files_ignored_by_hg(root: PathLike) -> Set[Path]:
-    """Return a set of all files ignored by mercurial. If a whole directory is
-    ignored, don't return all files inside of it.
-
-    Return an empty list if mercurial is not installed.
-    """
-    root = Path(root)
-
-    if HG_EXE:
-        command = [
-            HG_EXE,
-            "status",
-            "--ignored",
-            # terse is marked 'experimental' in the hg help but is documented
-            # in the man page. It collapses the output of a dir containing
-            # only ignored files to the ignored name like the git command does.
-            "--terse=i",
-            "--no-status",
-            "--print0",
-        ]
-        result = execute_command(command, _LOGGER, cwd=root)
-        all_files = result.stdout.decode("utf-8").split("\0")
-        return {Path(file_) for file_ in all_files}
-    return set()
 
 
 def decoded_text_from_binary(binary_file: BinaryIO, size: int = None) -> str:

--- a/src/reuse/_util.py
+++ b/src/reuse/_util.py
@@ -150,7 +150,7 @@ def in_git_repo(cwd: PathLike = None) -> bool:
     return False
 
 
-def _all_files_ignored_by_git(root: PathLike) -> Set[Path]:
+def all_files_ignored_by_git(root: PathLike) -> Set[Path]:
     """Return a set of all files ignored by git. If a whole directory is
     ignored, don't return all files inside of it.
 

--- a/src/reuse/init.py
+++ b/src/reuse/init.py
@@ -14,9 +14,10 @@ from typing import List
 import requests
 
 from ._licenses import EXCEPTION_MAP, LICENSE_MAP
-from ._util import PathType, find_root
+from ._util import PathType
 from .download import _path_to_license_file, put_license_in_file
 from .project import Project
+from .vcs import find_root
 
 
 def prompt_licenses(out=sys.stdout) -> List[str]:

--- a/src/reuse/project.py
+++ b/src/reuse/project.py
@@ -27,7 +27,7 @@ from ._util import (
     _HEADER_BYTES,
     GIT_EXE,
     PathLike,
-    _all_files_ignored_by_git,
+    all_files_ignored_by_git,
     _copyright_from_dep5,
     _determine_license_path,
     decoded_text_from_binary,
@@ -58,7 +58,7 @@ class Project:
         else:
             _LOGGER.warning(_("could not find Git"))
         if self._is_git_repo:
-            self._all_ignored_files = _all_files_ignored_by_git(self._root)
+            self._all_ignored_files = all_files_ignored_by_git(self._root)
 
         self.licenses_without_extension = dict()
 

--- a/src/reuse/project.py
+++ b/src/reuse/project.py
@@ -28,16 +28,12 @@ from ._util import (
     GIT_EXE,
     HG_EXE,
     PathLike,
-    all_files_ignored_by_git,
-    all_files_ignored_by_hg,
     _copyright_from_dep5,
     _determine_license_path,
     decoded_text_from_binary,
     extract_spdx_info,
-    find_root,
-    in_git_repo,
-    in_hg_repo,
 )
+from .vcs import VCSStrategyGit, VCSStrategyHg, VCSStrategyNone, find_root
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -54,18 +50,13 @@ class Project:
         if not self._root.is_dir():
             raise NotADirectoryError(f"{self._root} is no valid path")
 
-        self._is_git_repo = self._is_hg_repo = False
-        self._all_ignored_files = set()
-        if GIT_EXE and in_git_repo(self._root):
-            self._is_git_repo = True
-        if HG_EXE and in_hg_repo(self._root):
-            self._is_hg_repo = True
+        if GIT_EXE and VCSStrategyGit.in_repo(self._root):
+            self.vcs_strategy = VCSStrategyGit(self)
+        elif HG_EXE and VCSStrategyHg.in_repo(self._root):
+            self.vcs_strategy = VCSStrategyHg(self)
         else:
             _LOGGER.warning(_("could not find supported VCS"))
-        if self._is_git_repo:
-            self._all_ignored_files = all_files_ignored_by_git(self._root)
-        elif self._is_hg_repo:
-            self._all_ignored_files = all_files_ignored_by_hg(self._root)
+            self.vcs_strategy = VCSStrategyNone(self)
 
         self.licenses_without_extension = dict()
 
@@ -133,7 +124,7 @@ class Project:
         # Search the .reuse/dep5 file for SPDX information.
         if self._copyright:
             dep5_result = _copyright_from_dep5(
-                self._relative_from_root(path), self._copyright
+                self.relative_from_root(path), self._copyright
             )
             if any(dep5_result):
                 _LOGGER.info(
@@ -159,7 +150,7 @@ class Project:
             dep5_result.copyright_lines.union(file_result.copyright_lines),
         )
 
-    def _relative_from_root(self, path: Path) -> Path:
+    def relative_from_root(self, path: Path) -> Path:
         """If the project root is /tmp/project, and *path* is
         /tmp/project/src/file, then return src/file.
         """
@@ -167,15 +158,6 @@ class Project:
             return path.relative_to(self.root)
         except ValueError:
             return Path(os.path.relpath(path, start=self.root))
-
-    def _ignored_by_vcs(self, path: Path) -> bool:
-        """Is *path* covered by the ignore mechanism of the VCS (e.g.,
-        .gitignore)?
-        """
-        if self._is_git_repo or self._is_hg_repo:
-            path = self._relative_from_root(path)
-            return path in self._all_ignored_files
-        return False
 
     def _is_path_ignored(self, path: Path) -> bool:
         """Is *path* ignored by some mechanism?"""
@@ -189,7 +171,7 @@ class Project:
                 if pattern.match(name):
                     return True
 
-        if self._ignored_by_vcs(path):
+        if self.vcs_strategy.is_ignored(path):
             return True
 
         return False
@@ -249,7 +231,7 @@ class Project:
             if Path(path).suffix == ".license":
                 continue
 
-            path = self._relative_from_root(path)
+            path = self.relative_from_root(path)
             _LOGGER.debug(
                 _("determining identifier of '{path}'").format(path=path)
             )

--- a/src/reuse/report.py
+++ b/src/reuse/report.py
@@ -347,7 +347,7 @@ class FileReport:
             raise OSError(f"{path} is not a file")
 
         # pylint: disable=protected-access
-        relative = project._relative_from_root(path)
+        relative = project.relative_from_root(path)
         report = cls("./" + str(relative), path, do_checksum=do_checksum)
 
         # Checksum and ID

--- a/src/reuse/vcs.py
+++ b/src/reuse/vcs.py
@@ -1,0 +1,211 @@
+# SPDX-FileCopyrightText: 2017-2019 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""This module deals with version control systems."""
+
+import logging
+import os
+from abc import ABC, abstractmethod
+from os import PathLike
+from pathlib import Path
+from typing import Optional, Set
+
+from ._util import GIT_EXE, HG_EXE, execute_command
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class VCSStrategy(ABC):
+    """Strategy pattern for version control systems."""
+
+    @abstractmethod
+    def __init__(self, project: "Project"):
+        self.project = project
+
+    @abstractmethod
+    def is_ignored(self, path: PathLike) -> bool:
+        """Is *path* ignored by the VCS?"""
+
+    @classmethod
+    @abstractmethod
+    def in_repo(cls, directory: PathLike) -> bool:
+        """Is *directory* inside of the VCS repository?
+
+        :raises NotADirectoryError: if directory is not a directory.
+        """
+
+    @classmethod
+    @abstractmethod
+    def find_root(cls, cwd: PathLike = None) -> Optional[Path]:
+        """Try to find the root of the project from *cwd*. If none is found,
+        return None.
+
+        :raises NotADirectoryError: if directory is not a directory.
+        """
+
+
+class VCSStrategyNone(VCSStrategy):
+    """Strategy that is used when there is no VCS."""
+
+    def __init__(self, project: "Project"):
+        # pylint: disable=useless-super-delegation
+        super().__init__(project)
+
+    def is_ignored(self, path: PathLike) -> bool:
+        return False
+
+    @classmethod
+    def in_repo(cls, directory: PathLike) -> bool:
+        return False
+
+    @classmethod
+    def find_root(cls, cwd: PathLike = None) -> Optional[Path]:
+        return None
+
+
+class VCSStrategyGit(VCSStrategy):
+    """Strategy that is used for Git."""
+
+    def __init__(self, project):
+        super().__init__(project)
+        if not GIT_EXE:
+            raise FileNotFoundError("Could not find binary for Git")
+        self._all_ignored_files = self._find_all_ignored_files()
+
+    def _find_all_ignored_files(self) -> Set[Path]:
+        """Return a set of all files ignored by git. If a whole directory is
+        ignored, don't return all files inside of it.
+        """
+        command = [
+            GIT_EXE,
+            "ls-files",
+            "--exclude-standard",
+            "--ignored",
+            "--others",
+            "--directory",
+            # TODO: This flag is unexpected.  I reported it as a bug in Git.
+            # This flag---counter-intuitively---lists untracked directories
+            # that contain ignored files.
+            "--no-empty-directory",
+            # Separate output with \0 instead of \n.
+            "-z",
+        ]
+        result = execute_command(command, _LOGGER, cwd=self.project.root)
+        all_files = result.stdout.decode("utf-8").split("\0")
+        return {Path(file_) for file_ in all_files}
+
+    def is_ignored(self, path: PathLike) -> bool:
+        path = self.project.relative_from_root(path)
+        return path in self._all_ignored_files
+
+    @classmethod
+    def in_repo(cls, directory: PathLike) -> bool:
+        if directory is None:
+            directory = Path.cwd()
+
+        if not Path(directory).is_dir():
+            raise NotADirectoryError()
+
+        command = [GIT_EXE, "status"]
+        result = execute_command(command, _LOGGER, cwd=directory)
+
+        return not result.returncode
+
+    @classmethod
+    def find_root(cls, cwd: PathLike = None) -> Optional[Path]:
+        if cwd is None:
+            cwd = Path.cwd()
+
+        if not Path(cwd).is_dir():
+            raise NotADirectoryError()
+
+        command = [GIT_EXE, "rev-parse", "--show-toplevel"]
+        result = execute_command(command, _LOGGER, cwd=cwd)
+
+        if not result.returncode:
+            path = result.stdout.decode("utf-8")[:-1]
+            return Path(os.path.relpath(path, cwd))
+
+        return None
+
+
+class VCSStrategyHg(VCSStrategy):
+    """Strategy that is used for Mercurial."""
+
+    def __init__(self, project: "Project"):
+        super().__init__(project)
+        if not HG_EXE:
+            raise FileNotFoundError("Could not find binary for Mercurial")
+        self._all_ignored_files = self._find_all_ignored_files()
+
+    def _find_all_ignored_files(self) -> Set[Path]:
+        """Return a set of all files ignored by mercurial. If a whole directory
+        is ignored, don't return all files inside of it.
+        """
+        command = [
+            HG_EXE,
+            "status",
+            "--ignored",
+            # terse is marked 'experimental' in the hg help but is documented
+            # in the man page. It collapses the output of a dir containing only
+            # ignored files to the ignored name like the git command does.
+            "--terse=i",
+            "--no-status",
+            "--print0",
+        ]
+        result = execute_command(command, _LOGGER, cwd=self.project.root)
+        all_files = result.stdout.decode("utf-8").split("\0")
+        return {Path(file_) for file_ in all_files}
+
+    def is_ignored(self, path: PathLike) -> bool:
+        path = self.project.relative_from_root(path)
+        return path in self._all_ignored_files
+
+    @classmethod
+    def in_repo(cls, directory: PathLike) -> bool:
+        if directory is None:
+            directory = Path.cwd()
+
+        if not Path(directory).is_dir():
+            raise NotADirectoryError()
+
+        command = [HG_EXE, "root"]
+        result = execute_command(command, _LOGGER, cwd=directory)
+
+        return not result.returncode
+
+    @classmethod
+    def find_root(cls, cwd: PathLike = None) -> Optional[Path]:
+        if cwd is None:
+            cwd = Path.cwd()
+
+        if not Path(cwd).is_dir():
+            raise NotADirectoryError()
+
+        command = [HG_EXE, "root"]
+        result = execute_command(command, _LOGGER, cwd=cwd)
+
+        if not result.returncode:
+            path = result.stdout.decode("utf-8")[:-1]
+            return Path(os.path.relpath(path, cwd))
+
+        return None
+
+
+def find_root(cwd: PathLike = None) -> Optional[Path]:
+    """Try to find the root of the project from *cwd*. If none is found,
+    return None.
+
+    :raises NotADirectoryError: if directory is not a directory.
+    """
+    if GIT_EXE:
+        root = VCSStrategyGit.find_root(cwd=cwd)
+        if root:
+            return root
+    if HG_EXE:
+        root = VCSStrategyHg.find_root(cwd=cwd)
+        if root:
+            return root
+    return None

--- a/src/reuse/vcs.py
+++ b/src/reuse/vcs.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2017-2019 Free Software Foundation Europe e.V.
 # SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+# SPDX-FileCopyrightText: 2020 John Mulligan <jmulligan@redhat.com>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/reuse/vcs.py
+++ b/src/reuse/vcs.py
@@ -152,7 +152,8 @@ class VCSStrategyHg(VCSStrategy):
             # terse is marked 'experimental' in the hg help but is documented
             # in the man page. It collapses the output of a dir containing only
             # ignored files to the ignored name like the git command does.
-            "--terse=i",
+            # TODO: Re-enable this flag in the future.
+            # "--terse=i",
             "--no-status",
             "--print0",
         ]

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -61,6 +61,15 @@ def test_all_files_ignore_git(empty_directory):
     assert not list(project.all_files())
 
 
+def test_all_files_ignore_hg(empty_directory):
+    """When the hg directory is present, ignore it."""
+    (empty_directory / ".hg").mkdir()
+    (empty_directory / ".hg/config").touch()
+
+    project = Project(empty_directory)
+    assert not list(project.all_files())
+
+
 @git
 def test_all_files_git_ignored(git_repository):
     """Given a Git repository where some files are ignored, do not yield those

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -317,7 +317,7 @@ def test_licenses_subdirectory(empty_directory):
 def test_relative_from_root(empty_directory):
     """A simple test. Given /path/to/root/src/hello.py, return src/hello.py."""
     project = Project(empty_directory)
-    assert project._relative_from_root(project.root / "src/hello.py") == Path(
+    assert project.relative_from_root(project.root / "src/hello.py") == Path(
         "src/hello.py"
     )
 
@@ -333,6 +333,6 @@ def test_relative_from_root_no_shared_base_path(empty_directory):
     project = Project(empty_directory)
     parent = empty_directory.parent
     os.chdir(parent)
-    assert project._relative_from_root(
+    assert project.relative_from_root(
         Path(f"{project.root.name}/src/hello.py")
     ) == Path("src/hello.py")

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -19,6 +19,7 @@ from reuse import _util
 from reuse.project import Project
 
 git = pytest.mark.skipif(not _util.GIT_EXE, reason="requires git")
+hg = pytest.mark.skipif(not _util.HG_EXE, reason="requires hg")
 posix = pytest.mark.skipif(
     sys.platform == "win32", reason="Windows not supported"
 )
@@ -118,6 +119,44 @@ def test_all_files_submodule_is_ignored(submodule_repository):
     gitignore.write_text(contents)
     project = Project(submodule_repository)
     assert Path("submodule/foo.py").absolute() not in project.all_files()
+
+
+@hg
+def test_all_files_hg_ignored(hg_repository):
+    """Given a mercurial repository where some files are ignored, do not yield
+    those files.
+    """
+    project = Project(hg_repository)
+    assert Path("build/hello.py").absolute() not in project.all_files()
+
+
+@hg
+def test_all_files_hg_ignored_different_cwd(hg_repository):
+    """Given a mercurial repository where some files are ignored, do not yield
+    those files.
+
+    Be in a different CWD during the above.
+    """
+    os.chdir(hg_repository / "LICENSES")
+    project = Project(hg_repository)
+    assert Path("build/hello.py").absolute() not in project.all_files()
+
+
+@hg
+def test_all_files_hg_ignored_contains_space(hg_repository):
+    """File names that contain spaces are also ignored."""
+    (hg_repository / "I contain spaces.pyc").touch()
+    project = Project(hg_repository)
+    assert Path("I contain spaces.pyc").absolute() not in project.all_files()
+
+
+@hg
+@posix
+def test_all_files_hg_ignored_contains_newline(hg_repository):
+    """File names that contain newlines are also ignored."""
+    (hg_repository / "hello\nworld.pyc").touch()
+    project = Project(hg_repository)
+    assert Path("hello\nworld.pyc").absolute() not in project.all_files()
 
 
 def test_spdx_info_of_file_does_not_exist(fake_repository):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -140,17 +140,6 @@ def test_copyright_from_dep5(copyright):
     assert "2017 Mary Sue" in result.copyright_lines
 
 
-@git
-def test_find_root_in_git_repo(git_repository):
-    """When using reuse from a child directory in a Git repo, always find the
-    root directory.
-    """
-    os.chdir("src")
-    result = _util.find_root()
-
-    assert Path(result).absolute().resolve() == git_repository
-
-
 def test_make_copyright_line_simple():
     """Given a simple statement, make it a copyright line."""
     assert (

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2017-2019 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Tests for reuse.vcs"""
+
+# pylint: disable=invalid-name
+
+import os
+from pathlib import Path
+
+import pytest
+
+from reuse import vcs
+from reuse._util import GIT_EXE, HG_EXE
+
+git = pytest.mark.skipif(not GIT_EXE, reason="requires git")
+hg = pytest.mark.skipif(not HG_EXE, reason="requires mercurial")
+
+
+@git
+def test_find_root_in_git_repo(git_repository):
+    """When using reuse from a child directory in a Git repo, always find the
+    root directory.
+    """
+    os.chdir("src")
+    result = vcs.find_root()
+
+    assert Path(result).absolute().resolve() == git_repository
+
+
+@hg
+def test_find_root_in_hg_repo(hg_repository):
+    """When using reuse from a child directory in a Mercurial repo, always find
+    the root directory.
+    """
+    os.chdir("src")
+    result = vcs.find_root()
+
+    assert Path(result).absolute().resolve() == hg_repository


### PR DESCRIPTION
Fixes #99 as far as running the tool on a couple of repos of my own went.

I won't claim that this is comprehensive support for Mercurial as compared to the current git support but it got the tool working for me and generating sensible reports (vs checking my build artifacts). I did try to add some tests as far as code paths that seemed relevant to running `hg` versus `git` goes.

I could probably add a few more tests if needed but I am not sure what you would think are tests that really need a specific check when run using mercurial versus git.
