### PR TITLE
Cast subprocess arguments to strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ The versions follow [semantic versioning](https://semver.org).
 - Fixed a bug with `addheader --explicit-license` that would result in
   `file.license.license` if `file.license` already existed.
 
+- Fixed a Windows-only bug to do with calling subprocesses.
+
 ### Security
 
 ## 0.8.1 - 2020-02-22

--- a/src/reuse/_util.py
+++ b/src/reuse/_util.py
@@ -73,7 +73,7 @@ def setup_logging(level: int = logging.WARNING) -> None:
 
 
 def execute_command(
-    command: List[str], logger: logging.Logger, **kwargs
+    command: List[str], logger: logging.Logger, cwd: PathLike = None, **kwargs
 ) -> subprocess.CompletedProcess:
     """Run the given command with subprocess.run. Forward kwargs. Silence
     output into a pipe unless kwargs override it.
@@ -84,7 +84,12 @@ def execute_command(
     stderr = kwargs.get("stderr", subprocess.PIPE)
 
     return subprocess.run(
-        command, stdout=stdout, stderr=stderr, check=False, **kwargs
+        map(str, command),
+        stdout=stdout,
+        stderr=stderr,
+        check=False,
+        cwd=str(cwd),
+        **kwargs,
     )
 
 


### PR DESCRIPTION
Fixes #195. Windows appears to dislike pathlib arguments to subprocess.

This didn't need to be in #197 after all.