### PR TITLE
Add requirements-dev.txt to all Tox jobs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ envlist = py{36,37,38}-test, pypy3-test, lint, black, reuse, docs
 passenv = HOME CI
 deps =
     -r{toxinidir}/requirements.txt
+    -r{toxinidir}/requirements-dev.txt
 commands =
     py.test --cov-report term-missing --cov={envsitepackagesdir}/reuse
 
@@ -16,6 +17,7 @@ commands =
 basepython = python3
 deps =
     -r{toxinidir}/requirements.txt
+    -r{toxinidir}/requirements-dev.txt
 commands =
     /usr/bin/make lint
 
@@ -23,6 +25,7 @@ commands =
 basepython = python3
 deps =
     -r{toxinidir}/requirements.txt
+    -r{toxinidir}/requirements-dev.txt
 commands =
     /usr/bin/make blackcheck
 
@@ -30,6 +33,7 @@ commands =
 basepython = python3
 deps =
     -r{toxinidir}/requirements.txt
+    -r{toxinidir}/requirements-dev.txt
 commands =
     /usr/bin/make reuse
 
@@ -37,5 +41,6 @@ commands =
 basepython = python3
 deps =
     -r{toxinidir}/requirements.txt
+    -r{toxinidir}/requirements-dev.txt
 commands =
     /usr/bin/make docs


### PR DESCRIPTION
This was previously missing and caused Tox to fail. Because Tox isn't used by CI, I never noticed this.