### PR TITLE
Ignore symlinks and 0-sized files

### DIFF
--- a/.github/workflows/latesttag.py
+++ b/.github/workflows/latesttag.py
@@ -8,6 +8,7 @@ from distutils.version import LooseVersion
 from urllib.request import urlopen
 
 from packaging.version import parse
+
 from reuse import __version__ as current
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@ The versions follow [semantic versioning](https://semver.org).
 
 ### Fixed
 
+- Fixed a bug where `addheader` wouldn't properly apply the template on
+  `.license` files if the `.license` file was non-empty, but did not contain
+  valid SPDX tags.
+
 ### Security
 
 ## 0.10.1 - 2020-05-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ The versions follow [semantic versioning](https://semver.org).
 
 ### Changed
 
+- All symlinks in projects are now ignored.
+
 ### Deprecated
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ The versions follow [semantic versioning](https://semver.org).
 
 ### Changed
 
-- All symlinks in projects are now ignored.
+- All symlinks and 0-sized files in projects are now ignored.
 
 ### Deprecated
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -36,6 +36,8 @@ with the ``--root`` optional argument.
 Git submodules are automatically ignored unless ``--include-submodules`` is
 passed as optional argument.
 
+Symbolically links and files that are zero-sized are automatically ignored.
+
 addheader
 =========
 

--- a/src/reuse/header.py
+++ b/src/reuse/header.py
@@ -34,6 +34,7 @@ from ._comment import (
     CommentCreateError,
     CommentParseError,
     CommentStyle,
+    EmptyCommentStyle,
     PythonCommentStyle,
 )
 from ._util import (
@@ -234,6 +235,7 @@ def find_and_replace_header(
     :raises MissingSpdxInfo: if the generated comment is missing SPDX
         information.
     """
+    # pylint: disable=too-many-branches
     if style is None:
         style = PythonCommentStyle
 
@@ -241,6 +243,10 @@ def find_and_replace_header(
         before, header, after = _find_first_spdx_comment(text, style=style)
     except MissingSpdxInfo:
         before, header, after = "", "", text
+
+    # Workaround. EmptyCommentStyle should always be completely replaced.
+    if style is EmptyCommentStyle:
+        after = ""
 
     # pylint: disable=logging-format-interpolation
     _LOGGER.debug(f"before = {repr(before)}")

--- a/src/reuse/project.py
+++ b/src/reuse/project.py
@@ -4,6 +4,7 @@
 
 """Module that contains the central Project class."""
 
+import contextlib
 import glob
 import logging
 import os
@@ -111,6 +112,12 @@ class Project:
                 if the_file.is_symlink():
                     _LOGGER.debug("skipping symlink '%s'", the_file)
                     continue
+                # Suppressing this error because I simply don't want to deal
+                # with that here.
+                with contextlib.suppress(OSError):
+                    if the_file.stat().st_size == 0:
+                        _LOGGER.debug("skipping 0-sized file '%s'", the_file)
+                        continue
 
                 _LOGGER.debug("yielding '%s'", the_file)
                 yield the_file

--- a/src/reuse/project.py
+++ b/src/reuse/project.py
@@ -91,6 +91,9 @@ class Project:
                 if self._is_path_ignored(the_dir):
                     _LOGGER.debug("ignoring '%s'", the_dir)
                     dirs.remove(dir_)
+                elif the_dir.is_symlink():
+                    _LOGGER.debug("skipping symlink '%s'", the_dir)
+                    dirs.remove(dir_)
                 elif (
                     the_dir / ".git"
                 ).is_file() and not self.include_submodules:
@@ -104,6 +107,9 @@ class Project:
                 the_file = root / file_
                 if self._is_path_ignored(the_file):
                     _LOGGER.debug("ignoring '%s'", the_file)
+                    continue
+                if the_file.is_symlink():
+                    _LOGGER.debug("skipping symlink '%s'", the_file)
                     continue
 
                 _LOGGER.debug("yielding '%s'", the_file)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -142,11 +142,11 @@ def _repo_contents(
 
     for file_ in (fake_repository / "src").iterdir():
         if file_.suffix == ".py":
-            file_.with_suffix(".pyc").touch()
+            file_.with_suffix(".pyc").write_text("foo")
 
     build_dir = fake_repository / "build"
     build_dir.mkdir()
-    (build_dir / "hello.py").touch()
+    (build_dir / "hello.py").write_text("foo")
 
 
 @pytest.fixture()

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -52,7 +52,7 @@ def test_lint_git(git_repository):
 def test_lint_submodule(submodule_repository):
     """Extremely simple test for lint with an ignored submodule."""
     project = Project(submodule_repository)
-    (submodule_repository / "submodule/foo.c").touch()
+    (submodule_repository / "submodule/foo.c").write_text("foo")
     report = ProjectReport.generate(project)
     result = lint(report)
     assert result
@@ -61,7 +61,7 @@ def test_lint_submodule(submodule_repository):
 def test_lint_submodule_included(submodule_repository):
     """Extremely simple test for lint with an included submodule."""
     project = Project(submodule_repository, include_submodules=True)
-    (submodule_repository / "submodule/foo.c").touch()
+    (submodule_repository / "submodule/foo.c").write_text("foo")
     report = ProjectReport.generate(project)
     result = lint(report)
     assert not result
@@ -124,7 +124,7 @@ def test_lint_missing_licenses(fake_repository, stringio):
 
 def test_lint_unused_licenses(fake_repository, stringio):
     """An unused license is detected."""
-    (fake_repository / "LICENSES/MIT.txt").touch()
+    (fake_repository / "LICENSES/MIT.txt").write_text("foo")
     project = Project(fake_repository)
     report = ProjectReport.generate(project)
     lint_summary(report, out=stringio)
@@ -136,7 +136,7 @@ def test_lint_unused_licenses(fake_repository, stringio):
 @posix
 def test_lint_read_errors(fake_repository, stringio):
     """A read error is detected."""
-    (fake_repository / "foo.py").touch()
+    (fake_repository / "foo.py").write_text("foo")
     (fake_repository / "foo.py").chmod(0o000)
     project = Project(fake_repository)
     report = ProjectReport.generate(project)
@@ -148,7 +148,7 @@ def test_lint_read_errors(fake_repository, stringio):
 
 def test_lint_files_without_copyright_and_licensing(fake_repository, stringio):
     """A file without copyright and licensing is detected."""
-    (fake_repository / "foo.py").touch()
+    (fake_repository / "foo.py").write_text("foo")
     project = Project(fake_repository)
     report = ProjectReport.generate(project)
     result = lint_files_without_copyright_and_licensing(report, out=stringio)

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -7,6 +7,7 @@
 # pylint: disable=invalid-name
 
 import shutil
+import sys
 
 import pytest
 
@@ -26,6 +27,9 @@ try:
 except ImportError:
     is_posix = False
 
+cpython = pytest.mark.skipif(
+    sys.implementation.name != "cpython", reason="only CPython supported"
+)
 posix = pytest.mark.skipif(not is_posix, reason="Windows not supported")
 
 
@@ -128,6 +132,7 @@ def test_lint_unused_licenses(fake_repository, stringio):
     assert "MIT" in stringio.getvalue()
 
 
+@cpython
 @posix
 def test_lint_read_errors(fake_repository, stringio):
     """A read error is detected."""

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -4,7 +4,11 @@
 
 """All tests for reuse.lint"""
 
+# pylint: disable=invalid-name
+
 import shutil
+
+import pytest
 
 from reuse.lint import (
     lint,
@@ -16,6 +20,13 @@ from reuse.lint import (
 )
 from reuse.project import Project
 from reuse.report import ProjectReport
+
+try:
+    import posix as is_posix
+except ImportError:
+    is_posix = False
+
+posix = pytest.mark.skipif(not is_posix, reason="Windows not supported")
 
 
 def test_lint_simple(fake_repository):
@@ -117,9 +128,11 @@ def test_lint_unused_licenses(fake_repository, stringio):
     assert "MIT" in stringio.getvalue()
 
 
+@posix
 def test_lint_read_errors(fake_repository, stringio):
     """A read error is detected."""
-    (fake_repository / "foo.py").symlink_to("does_not_exist")
+    (fake_repository / "foo.py").touch()
+    (fake_repository / "foo.py").chmod(0o000)
     project = Project(fake_repository)
     report = ProjectReport.generate(project)
     result = lint_read_errors(report, out=stringio)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -48,7 +48,7 @@ def test_lint_git(git_repository, stringio):
 
 def test_lint_submodule(submodule_repository, stringio):
     """Run a successful lint."""
-    (submodule_repository / "submodule/foo.c").touch()
+    (submodule_repository / "submodule/foo.c").write_text("foo")
     result = main(["lint"], out=stringio)
 
     assert result == 0
@@ -65,7 +65,7 @@ def test_lint_submodule_included(submodule_repository, stringio):
 
 def test_lint_submodule_included_fail(submodule_repository, stringio):
     """Run a failed lint."""
-    (submodule_repository / "submodule/foo.c").touch()
+    (submodule_repository / "submodule/foo.c").write_text("foo")
     result = main(["--include-submodules", "lint"], out=stringio)
 
     assert result == 1
@@ -74,7 +74,7 @@ def test_lint_submodule_included_fail(submodule_repository, stringio):
 
 def test_lint_fail(fake_repository, stringio):
     """Run a failed lint."""
-    (fake_repository / "foo.py").touch()
+    (fake_repository / "foo.py").write_text("foo")
     result = main(["lint"], out=stringio)
 
     assert result > 0

--- a/tests/test_main_addheader.py
+++ b/tests/test_main_addheader.py
@@ -584,8 +584,8 @@ def test_addheader_explicit_license_double(
     simple_file_license = fake_repository / "foo.txt.license"
     simple_file_license_license = fake_repository / "foo.txt.license.license"
 
-    simple_file.touch()
-    simple_file_license.touch()
+    simple_file.write_text("foo")
+    simple_file_license.write_text("foo")
 
     result = main(
         [
@@ -655,7 +655,7 @@ def test_addheader_explicit_license_unsupported_filetype(
 def test_addheader_license_file(fake_repository, stringio, mock_date_today):
     """Add a header to a .license file if it exists."""
     simple_file = fake_repository / "foo.py"
-    simple_file.touch()
+    simple_file.write_text("foo")
     license_file = fake_repository / "foo.py.license"
     license_file.write_text(
         cleandoc(
@@ -691,7 +691,7 @@ def test_addheader_license_file(fake_repository, stringio, mock_date_today):
             """
         ).replace("spdx", "SPDX")
     )
-    assert not simple_file.read_text()
+    assert simple_file.read_text() == "foo"
 
 
 def test_addheader_year_mutually_exclusive(fake_repository):
@@ -770,7 +770,7 @@ def test_addheader_force_multi_line_for_c(
 ):
     """--multi-line forces a multi-line comment for C."""
     simple_file = fake_repository / "foo.c"
-    simple_file.touch()
+    simple_file.write_text("foo")
 
     result = main(
         [
@@ -795,6 +795,8 @@ def test_addheader_force_multi_line_for_c(
              *
              * spdx-License-Identifier: GPL-3.0-or-later
              */
+
+            foo
             """
         ).replace("spdx", "SPDX")
     )

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -20,6 +20,11 @@ from license_expression import LicenseSymbol
 from reuse import _util
 from reuse.project import Project
 
+try:
+    import posix as is_posix
+except ImportError:
+    is_posix = False
+
 git = pytest.mark.skipif(not _util.GIT_EXE, reason="requires git")
 hg = pytest.mark.skipif(not _util.HG_EXE, reason="requires hg")
 posix = pytest.mark.skipif(
@@ -73,6 +78,7 @@ def test_all_files_ignore_hg(empty_directory):
     assert not list(project.all_files())
 
 
+@posix
 def test_all_files_symlinks(empty_directory):
     """All symlinks must be ignored."""
     (empty_directory / "blob").touch()

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -9,7 +9,6 @@
 
 import os
 import shutil
-import sys
 from inspect import cleandoc
 from pathlib import Path
 from textwrap import dedent
@@ -27,9 +26,7 @@ except ImportError:
 
 git = pytest.mark.skipif(not _util.GIT_EXE, reason="requires git")
 hg = pytest.mark.skipif(not _util.HG_EXE, reason="requires hg")
-posix = pytest.mark.skipif(
-    sys.platform == "win32", reason="Windows not supported"
-)
+posix = pytest.mark.skipif(not is_posix, reason="Windows not supported")
 
 TESTS_DIRECTORY = Path(__file__).parent.resolve()
 RESOURCES_DIRECTORY = TESTS_DIRECTORY / "resources"
@@ -37,15 +34,15 @@ RESOURCES_DIRECTORY = TESTS_DIRECTORY / "resources"
 
 def test_project_not_a_directory(empty_directory):
     """Cannot create a Project without a valid directory."""
-    (empty_directory / "foo.py").touch()
+    (empty_directory / "foo.py").write_text("foo")
     with pytest.raises(NotADirectoryError):
         Project(empty_directory / "foo.py")
 
 
 def test_all_files(empty_directory):
     """Given a directory with some files, yield all files."""
-    (empty_directory / "foo").touch()
-    (empty_directory / "bar").touch()
+    (empty_directory / "foo").write_text("foo")
+    (empty_directory / "bar").write_text("foo")
 
     project = Project(empty_directory)
     assert {file_.name for file_ in project.all_files()} == {"foo", "bar"}
@@ -53,8 +50,8 @@ def test_all_files(empty_directory):
 
 def test_all_files_ignore_dot_license(empty_directory):
     """When file and file.license are present, only yield file."""
-    (empty_directory / "foo").touch()
-    (empty_directory / "foo.license").touch()
+    (empty_directory / "foo").write_text("foo")
+    (empty_directory / "foo.license").write_text("foo")
 
     project = Project(empty_directory)
     assert {file_.name for file_ in project.all_files()} == {"foo"}
@@ -63,7 +60,7 @@ def test_all_files_ignore_dot_license(empty_directory):
 def test_all_files_ignore_git(empty_directory):
     """When the git directory is present, ignore it."""
     (empty_directory / ".git").mkdir()
-    (empty_directory / ".git/config").touch()
+    (empty_directory / ".git/config").write_text("foo")
 
     project = Project(empty_directory)
     assert not list(project.all_files())
@@ -81,7 +78,7 @@ def test_all_files_ignore_hg(empty_directory):
 @posix
 def test_all_files_symlinks(empty_directory):
     """All symlinks must be ignored."""
-    (empty_directory / "blob").touch()
+    (empty_directory / "blob").write_text("foo")
     (empty_directory / "blob.license").write_text(
         cleandoc(
             """
@@ -94,6 +91,14 @@ def test_all_files_symlinks(empty_directory):
     (empty_directory / "symlink").symlink_to("blob")
     project = Project(empty_directory)
     assert Path("symlink").absolute() not in project.all_files()
+
+
+def test_all_files_ignore_zero_sized(empty_directory):
+    """Empty files should be skipped."""
+    (empty_directory / "foo").touch()
+
+    project = Project(empty_directory)
+    assert Path("foo").absolute() not in project.all_files()
 
 
 @git
@@ -120,7 +125,7 @@ def test_all_files_git_ignored_different_cwd(git_repository):
 @git
 def test_all_files_git_ignored_contains_space(git_repository):
     """Files that contain spaces are also ignored."""
-    (git_repository / "I contain spaces.pyc").touch()
+    (git_repository / "I contain spaces.pyc").write_text("foo")
     project = Project(git_repository)
     assert Path("I contain spaces.pyc").absolute() not in project.all_files()
 
@@ -129,7 +134,7 @@ def test_all_files_git_ignored_contains_space(git_repository):
 @posix
 def test_all_files_git_ignored_contains_newline(git_repository):
     """Files that contain newlines are also ignored."""
-    (git_repository / "hello\nworld.pyc").touch()
+    (git_repository / "hello\nworld.pyc").write_text("foo")
     project = Project(git_repository)
     assert Path("hello\nworld.pyc").absolute() not in project.all_files()
 
@@ -137,7 +142,7 @@ def test_all_files_git_ignored_contains_newline(git_repository):
 @git
 def test_all_files_submodule_is_ignored(submodule_repository):
     """If a submodule is ignored, all_files should not raise an Exception."""
-    (submodule_repository / "submodule/foo.py").touch()
+    (submodule_repository / "submodule/foo.py").write_text("foo")
     gitignore = submodule_repository / ".gitignore"
     contents = gitignore.read_text()
     contents += "\nsubmodule/\n"
@@ -206,7 +211,7 @@ def test_spdx_info_of_unlicensed_file(fake_repository):
     """Return an empty SpdxInfo object when asking for the SPDX information
     of a file that has no SPDX information.
     """
-    (fake_repository / "foo.py").touch()
+    (fake_repository / "foo.py").write_text("foo")
     project = Project(fake_repository)
     assert not any(project.spdx_info_of("foo.py"))
 
@@ -299,7 +304,7 @@ def test_license_file_detected(empty_directory):
     """Test whether---when given a file and a license file---the license file
     is detected and read.
     """
-    (empty_directory / "foo.py").touch()
+    (empty_directory / "foo.py").write_text("foo")
     (empty_directory / "foo.py.license").write_text(
         "SPDX-FileCopyrightText: 2017 Mary Sue\nSPDX-License-Identifier: MIT\n"
     )
@@ -314,7 +319,7 @@ def test_license_file_detected(empty_directory):
 def test_licenses_filename(empty_directory):
     """Detect the license identifier of a license from its stem."""
     (empty_directory / "LICENSES").mkdir()
-    (empty_directory / "LICENSES/foo.txt").touch()
+    (empty_directory / "LICENSES/foo.txt").write_text("foo")
     project = Project(empty_directory)
     assert "foo" in project.licenses
 
@@ -324,8 +329,8 @@ def test_licenses_no_extension(empty_directory):
     in the license list.
     """
     (empty_directory / "LICENSES").mkdir()
-    (empty_directory / "LICENSES/GPL-3.0-or-later").touch()
-    (empty_directory / "LICENSES/MIT-3.0-or-later").touch()
+    (empty_directory / "LICENSES/GPL-3.0-or-later").write_text("foo")
+    (empty_directory / "LICENSES/MIT-3.0-or-later").write_text("foo")
     project = Project(empty_directory)
     assert "GPL-3.0-or-later" in project.licenses
     assert "MIT-3" in project.licenses
@@ -334,7 +339,7 @@ def test_licenses_no_extension(empty_directory):
 def test_licenses_subdirectory(empty_directory):
     """Find a license in a subdirectory of LICENSES/."""
     (empty_directory / "LICENSES/sub").mkdir(parents=True)
-    (empty_directory / "LICENSES/sub/MIT.txt").touch()
+    (empty_directory / "LICENSES/sub/MIT.txt").write_text("foo")
     project = Project(empty_directory)
     assert "MIT" in project.licenses
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
+# SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -9,6 +10,7 @@
 import os
 import shutil
 import sys
+from inspect import cleandoc
 from pathlib import Path
 from textwrap import dedent
 
@@ -69,6 +71,23 @@ def test_all_files_ignore_hg(empty_directory):
 
     project = Project(empty_directory)
     assert not list(project.all_files())
+
+
+def test_all_files_symlinks(empty_directory):
+    """All symlinks must be ignored."""
+    (empty_directory / "blob").touch()
+    (empty_directory / "blob.license").write_text(
+        cleandoc(
+            """
+            spdx-FileCopyrightText: Mary Sue
+
+            spdx-License-Identifier: GPL-3.0-or-later
+            """
+        ).replace("spdx", "SPDX")
+    )
+    (empty_directory / "symlink").symlink_to("blob")
+    project = Project(empty_directory)
+    assert Path("symlink").absolute() not in project.all_files()
 
 
 @git

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -7,6 +7,7 @@
 # pylint: disable=invalid-name
 
 import os
+import sys
 
 import pytest
 
@@ -18,6 +19,9 @@ try:
 except ImportError:
     is_posix = False
 
+cpython = pytest.mark.skipif(
+    sys.implementation.name != "cpython", reason="only CPython supported"
+)
 posix = pytest.mark.skipif(not is_posix, reason="Windows not supported")
 
 
@@ -176,6 +180,7 @@ def test_generate_project_report_deprecated_license(
     assert "GPL-3.0" in result.deprecated_licenses
 
 
+@cpython
 @posix
 def test_generate_project_report_read_error(fake_repository, multiprocessing):
     """Files that cannot be read are added to the read error list."""

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -4,10 +4,21 @@
 
 """Tests for reuse.report"""
 
+# pylint: disable=invalid-name
+
 import os
+
+import pytest
 
 from reuse.project import Project
 from reuse.report import FileReport, ProjectReport
+
+try:
+    import posix as is_posix
+except ImportError:
+    is_posix = False
+
+posix = pytest.mark.skipif(not is_posix, reason="Windows not supported")
 
 
 def test_generate_file_report_file_simple(fake_repository):
@@ -165,9 +176,11 @@ def test_generate_project_report_deprecated_license(
     assert "GPL-3.0" in result.deprecated_licenses
 
 
+@posix
 def test_generate_project_report_read_error(fake_repository, multiprocessing):
     """Files that cannot be read are added to the read error list."""
-    (fake_repository / "bad").symlink_to("does_not_exist")
+    (fake_repository / "bad").touch()
+    (fake_repository / "bad").chmod(0o000)
 
     project = Project(fake_repository)
     result = ProjectReport.generate(project, multiprocessing=multiprocessing)

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -132,7 +132,7 @@ def test_generate_project_report_missing_license(
 
 def test_generate_project_report_bad_license(fake_repository, multiprocessing):
     """Bad licenses are detected."""
-    (fake_repository / "LICENSES/bad.txt").touch()
+    (fake_repository / "LICENSES/bad.txt").write_text("foo")
 
     project = Project(fake_repository)
     result = ProjectReport.generate(project, multiprocessing=multiprocessing)
@@ -184,7 +184,7 @@ def test_generate_project_report_deprecated_license(
 @posix
 def test_generate_project_report_read_error(fake_repository, multiprocessing):
     """Files that cannot be read are added to the read error list."""
-    (fake_repository / "bad").touch()
+    (fake_repository / "bad").write_text("foo")
     (fake_repository / "bad").chmod(0o000)
 
     project = Project(fake_repository)


### PR DESCRIPTION
Fixes #202 
Fixes #208 

This patch ignores *all* symlinks, not just relative ones.