### PR TITLE
Add pylint to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,3 +7,7 @@ repos:
     rev: stable
     hooks:
     - id: black
+-   repo: https://github.com/PyCQA/pylint
+    rev: pylint-2.4.4
+    hooks:
+    - id: pylint


### PR DESCRIPTION
Inspired by #212, this commit adds pylint to the repo's pre-commit hooks.