### PR TITLE
Add contact address to all FSFE copyright statements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017-2018 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/.github/workflows/latesttag.yml
+++ b/.github/workflows/latesttag.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V. <https://fsfe.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V. <https://fsfe.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2018 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2018 Free Software Foundation Europe e.V. <https://fsfe.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2018 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2018 Free Software Foundation Europe e.V. <https://fsfe.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -17,7 +17,7 @@ jobs=0
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=redefined-builtin,C0330,duplicate-code,logging-format-interpolation
+disable=redefined-builtin,C0330,duplicate-code,logging-format-interpolation,line-too-long
 
 [REPORTS]
 

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -4,21 +4,21 @@ Upstream-Contact: Carmen Bianca Bakker <carmenbianca@fsfe.org>
 Source: https://github.com/fsfe/reuse-tool
 
 Files: .bumpversion.cfg setup.cfg
-Copyright: 2017-2019 Free Software Foundation Europe e.v.
+Copyright: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
 License: GPL-3.0-or-later
 
 Files: docs/reuse*.rst
-Copyright: 2017-2019 Free Software Foundation Europe e.V.
+Copyright: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
 License: CC-BY-SA-4.0
 
 Files: docs/modules.rst
-Copyright: 2017-2019 Free Software Foundation Europe e.V.
+Copyright: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
 License: CC-BY-SA-4.0
 
 Files: tests/resources/*
-Copyright: 2017-2019 Free Software Foundation Europe e.V.
+Copyright: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
 License: GPL-3.0-or-later
 
 Files: src/reuse.egg-info/*
-Copyright: 2017-2019 Free Software Foundation Europe e.V.
+Copyright: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
 License: GPL-3.0-or-later

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,5 +1,5 @@
 ..
-  SPDX-FileCopyrightText: 2017-2018 Free Software Foundation Europe e.V.
+  SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
   SPDX-FileCopyrightText: 2017 Sebastian Schuberth <schuberth@fsfe.org>
 
   SPDX-License-Identifier: CC-BY-SA-4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2017-2020 Free Software Foundation Europe e.V.
+SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
 
 SPDX-License-Identifier: CC-BY-SA-4.0
 -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V.
+SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V. <https://fsfe.org>
 
 SPDX-License-Identifier: CC-BY-SA-4.0
  -->

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V. <https://fsfe.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017-2019 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017-2018 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2017-2019 Free Software Foundation Europe e.V.
+SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
 
 SPDX-License-Identifier: CC-BY-SA-4.0
 -->

--- a/README.md
+++ b/README.md
@@ -189,8 +189,6 @@ Next, run `make help` to see the available interactions.
 
 ## License
 
-Copyright (C) 2017-2019 Free Software Foundation Europe e.V.
-
 This work is licensed under multiple licences. Because keeping this section
 up-to-date is challenging, here is a brief summary as of July 2019:
 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Next, run `make help` to see the available interactions.
 ## License
 
 This work is licensed under multiple licences. Because keeping this section
-up-to-date is challenging, here is a brief summary as of July 2019:
+up-to-date is challenging, here is a brief summary as of April 2020:
 
 - All original source code is licensed under GPL-3.0-or-later.
 - All documentation is licensed under CC-BY-SA-4.0.

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017-2018 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -1,5 +1,5 @@
 ..
-    SPDX-FileCopyrightText: 2017-2018  Free Software Foundation Europe e.V.
+    SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
 
     SPDX-License-Identifier: CC-BY-SA-4.0
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
 ..
-    SPDX-FileCopyrightText: 2017-2018  Free Software Foundation Europe e.V.
+    SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
 
     SPDX-License-Identifier: CC-BY-SA-4.0
 

--- a/docs/usage.rst.license
+++ b/docs/usage.rst.license
@@ -1,4 +1,4 @@
-SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V.
+SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V. <https://fsfe.org>
 
 SPDX-License-Identifier: CC-BY-SA-4.0
 

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V. <https://fsfe.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2018 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2018 Free Software Foundation Europe e.V. <https://fsfe.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017-2020 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017-2020 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# SPDX-FileCopyrightText: 2017-2018 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/reuse/__init__.py
+++ b/src/reuse/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017-2019 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/reuse/__main__.py
+++ b/src/reuse/__main__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V. <https://fsfe.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/reuse/_comment.py
+++ b/src/reuse/_comment.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2019-2020 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V. <https://fsfe.org>
 # SPDX-FileCopyrightText: 2019 Kirill Elagin
 # SPDX-FileCopyrightText: 2020 Dmitry Bogatov
 #

--- a/src/reuse/_format.py
+++ b/src/reuse/_format.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2018 Carmen Bianca Bakker
+# SPDX-FileCopyrightText: 2018 Free Software Foundation Europe e.V. <https://fsfe.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/reuse/_licenses.py
+++ b/src/reuse/_licenses.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2014 Ahmed H. Ismail
-# SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V. <https://fsfe.org>
 #
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-License-Identifier: GPL-3.0-or-later

--- a/src/reuse/_main.py
+++ b/src/reuse/_main.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017-2019 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/reuse/_util.py
+++ b/src/reuse/_util.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017-2019 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
 # SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 # SPDX-FileCopyrightText: 2020 Tuomas Siipola <tuomas@zpl.fi>
 #

--- a/src/reuse/download.py
+++ b/src/reuse/download.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V. <https://fsfe.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/reuse/header.py
+++ b/src/reuse/header.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2019-2020 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V. <https://fsfe.org>
 # SPDX-FileCopyrightText: 2019 Stefan Bakker <s.bakker777@gmail.com>
 # SPDX-FileCopyrightText: 2019 Kirill Elagin <kirelagin@gmail.com>
 # SPDX-FileCopyrightText: 2020 Dmitry Bogatov

--- a/src/reuse/init.py
+++ b/src/reuse/init.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V. <https://fsfe.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/reuse/lint.py
+++ b/src/reuse/lint.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017-2019 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/reuse/project.py
+++ b/src/reuse/project.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017-2019 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/reuse/report.py
+++ b/src/reuse/report.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017-2019 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/reuse/spdx.py
+++ b/src/reuse/spdx.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017-2019 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/reuse/templates/default_template.jinja2.license
+++ b/src/reuse/templates/default_template.jinja2.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V.
+SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V. <https://fsfe.org>
 
 SPDX-License-Identifier: CC0-1.0

--- a/src/reuse/vcs.py
+++ b/src/reuse/vcs.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017-2019 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
 # SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 # SPDX-FileCopyrightText: 2020 John Mulligan <jmulligan@redhat.com>
 #

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017-2019 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/tests/test_comment.py
+++ b/tests/test_comment.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V. <https://fsfe.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V. <https://fsfe.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V. <https://fsfe.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V. <https://fsfe.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V. <https://fsfe.org>
 # SPDX-FileCopyrightText: 2019 Stefan Bakker <s.bakker777@gmail.com>
 # SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 #

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017-2019 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017-2019 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017-2019 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
 # SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017-2019 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
 # SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017-2018 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 


### PR DESCRIPTION
This PR is kind of annoying, but it has bothered me for a while that this repo doesn't fully follow the REUSE suggestion to include a contact address in copyright statements.