### PR TITLE
Improved Docker entrypoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,14 @@ The versions follow [semantic versioning](https://semver.org).
 
 ### Changed
 
+- The Docker image has an entrypoint now. In effect, this means running:
+
+ `docker run -v $(pwd):/data fsfe/reuse lint`
+
+ instead of
+
+ `docker run -v $(pwd):/data fsfe/reuse reuse lint`.
+
 ### Deprecated
 
 ### Removed

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,5 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 WORKDIR /data
 
-CMD "$VIRTUAL_ENV/bin/reuse" lint
+ENTRYPOINT ["reuse"]
+CMD ["lint"]

--- a/README.md
+++ b/README.md
@@ -140,15 +140,27 @@ short summary:
 
 ### Run in Docker
 
-REUSE is simple to include in CI/CD processes. This way, you can check
-for REUSE compliance for each build. In our [resources for
-developers](https://reuse.software/dev/) you can learn how to integrate
-the REUSE tool in Drone, Travis, or GitLab CI.
+The `fsfe/reuse` Docker image is available on [Docker
+Hub](https://hub.docker.com/r/fsfe/reuse). With it, you can easily include REUSE
+in CI/CD processes. This way, you can check for REUSE compliance for each build.
+In our [resources for developers](https://reuse.software/dev/) you can learn how
+to integrate the REUSE tool in Drone, Travis, or GitLab CI.
 
-Within the `fsfe/reuse` Docker image available on [Docker
-Hub](https://hub.docker.com/r/fsfe/reuse), you can run the helper tool
-simply by executing `reuse lint`. To use the tool on your computer, you can
-mount your project directory and run `reuse lint <path/to/directory>`.
+You can run the helper tool simply by providing the command you want to run
+(e.g., `lint`, `spdx`). The image's working directory is `/data` by default. So
+if you want to lint a project that is in your current working directory, you can
+mount it on the container's `/data` directory, and tell the tool to lint. That
+looks a little like this:
+
+```bash
+docker run --volume $(pwd):/data fsfe/reuse lint
+```
+
+You can also provide additional arguments, like so:
+
+```bash
+docker run --volume $(pwd):/data fsfe/reuse --include-submodules spdx -o out.spdx
+```
 
 ### Run as pre-commit hook
 


### PR DESCRIPTION
This PR is tangent to https://github.com/fsfe/reuse-action/pull/4 and https://github.com/fsfe/reuse-action/pull/3.

In summary, instead of doing this:

```
docker run --volume $(pwd):/data fsfe/reuse reuse lint
```

You do this:

```
docker run --volume $(pwd):/data fsfe/reuse lint
```

This requires an update to https://reuse.software/dev/