### PR TITLE
Add example of header to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,14 @@ nutshell:
    `SPDX-FileCopyrightText:`.
 3. Verify your work using this tool.
 
+Example of header:
+
+```
+# SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
+#
+# SPDX-License-Identifier: CC-BY-SA-4.0
+```
+
 To check against the recommendations, use `reuse lint`:
 
 ```


### PR DESCRIPTION
This was sorely lacking previously.