### PR TITLE
Always explicitly encode output files in UTF-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ The versions follow [semantic versioning](https://semver.org).
 
 ### Changed
 
+- Always write the output files encoded in UTF-8, explicitly. This is already the
+  default on most Unix systems, but it was not on Windows.
+
 ### Deprecated
 
 ### Removed

--- a/src/reuse/header.py
+++ b/src/reuse/header.py
@@ -378,7 +378,7 @@ def _add_header_to_file(
             out.write("\n")
             return result
 
-    with path.open("r") as fp:
+    with path.open("rt") as fp:
         text = fp.read()
 
     try:
@@ -407,7 +407,7 @@ def _add_header_to_file(
         out.write("\n")
         result = 1
     else:
-        with path.open("w") as fp:
+        with path.open("wt", encoding='utf-8') as fp:
             fp.write(output)
         # TODO: This may need to be rephrased more elegantly.
         out.write(_("Successfully changed header of {path}").format(path=path))


### PR DESCRIPTION
This addresses #221 — Python already takes care of decoding arguments correctly, but the default mode of the files depends on `locale.getpreferredencoding(False)` (see https://docs.python.org/3/library/functions.html#open).

Since most languages are now enforcing utf-8 encoding for source code, this should be a positive change for all of them.