### PR TITLE
Fix typo in docs

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -40,6 +40,8 @@ Contributors
 
 - David Alfonso
 
+- Maximilian Dolling <mdolling@gfz-potsdam.de>
+
 
 Translators
 -----------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -60,7 +60,7 @@ current year is 2019):
   #
   # SPDX-License-Identifier: MIT
 
-You can use as many ``--copyright`` and ``--copyright`` arguments, so long as
+You can use as many ``--copyright`` and ``--license`` arguments, so long as
 there is at least one such argument.
 
 The REUSE header is placed at the very top of the file. If a different REUSE


### PR DESCRIPTION
In the [`usage/addheaer` docs](https://reuse.readthedocs.io/en/stable/usage.html#addheader) the same arguments was listed twice as 'can be used multiple times'.
Tested with --license, worged so i assume it was meant to be the --license flag.