### PR TITLE
Add go.mod support

### DIFF
--- a/src/reuse/__init__.py
+++ b/src/reuse/__init__.py
@@ -52,6 +52,9 @@ _IGNORE_FILE_PATTERNS = [
     re.compile(r"^\.gitkeep$"),
     re.compile(r".*\.license$"),
     re.compile(r".*\.spdx$"),
+
+    # go.sum is a machine-maintained list of checksums used by Go modules.
+    re.compile(r".*go.sum$"),
 ]
 
 #: Simple structure for holding SPDX information.

--- a/src/reuse/__init__.py
+++ b/src/reuse/__init__.py
@@ -52,7 +52,6 @@ _IGNORE_FILE_PATTERNS = [
     re.compile(r"^\.gitkeep$"),
     re.compile(r".*\.license$"),
     re.compile(r".*\.spdx$"),
-
     # go.sum is a machine-maintained list of checksums used by Go modules.
     re.compile(r".*go.sum$"),
 ]

--- a/src/reuse/_comment.py
+++ b/src/reuse/_comment.py
@@ -515,6 +515,7 @@ FILENAME_COMMENT_STYLE_MAP = {
     "Manifest.in": PythonCommentStyle,
     "ROOT": MlCommentStyle,
     "configure.ac": M4CommentStyle,
+    "go.mod": CCommentStyle,
     "manifest": PythonCommentStyle,  # used by cdist
     "requirements.txt": PythonCommentStyle,
     "setup.cfg": PythonCommentStyle,


### PR DESCRIPTION
A `go.mod` file is a Go module definition, similar to a makefile.

The other half of `go.mod` is a checksum file `go.sum`, which is just a list of checksums, and is arguably a build artifact, but one that should be checked in to source control, and thus can't be put in `.gitignore`.