### PR TITLE
Ignore CAL-1.0 and CAL-1.0-Combined-Work-Exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@ The versions follow [semantic versioning](https://semver.org).
 
 ### Fixed
 
+- The licenses CAL-1.0 and CAL-1.0-Combined-Work-Exception contain an SPDX tag
+  within themselves. Files that are named after these licenses are now ignored.
+
 ### Security
 
 ## 0.10.1 - 2020-05-14

--- a/src/reuse/__init__.py
+++ b/src/reuse/__init__.py
@@ -52,6 +52,8 @@ _IGNORE_FILE_PATTERNS = [
     re.compile(r"^\.gitkeep$"),
     re.compile(r".*\.license$"),
     re.compile(r".*\.spdx$"),
+    # Workaround for https://github.com/fsfe/reuse-tool/issues/229
+    re.compile(r"^CAL-1.0(-Combined-Work-Exception)?(\..+)?$"),
 ]
 
 #: Simple structure for holding SPDX information.

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -53,6 +53,19 @@ def test_all_files_ignore_dot_license(empty_directory):
     assert {file_.name for file_ in project.all_files()} == {"foo"}
 
 
+def test_all_files_ignore_cal_license(empty_directory):
+    """CAL licenses contain SPDX tags referencing themselves. They should be
+    skipped.
+    """
+    (empty_directory / "CAL-1.0").write_text("foo")
+    (empty_directory / "CAL-1.0.txt").write_text("foo")
+    (empty_directory / "CAL-1.0-Combined-Work-Exception").write_text("foo")
+    (empty_directory / "CAL-1.0-Combined-Work-Exception.txt").write_text("foo")
+
+    project = Project(empty_directory)
+    assert not list(project.all_files())
+
+
 def test_all_files_ignore_git(empty_directory):
     """When the git directory is present, ignore it."""
     (empty_directory / ".git").mkdir()


### PR DESCRIPTION
These licenses contain SPDX tags referring to themselves. This causes issues in #229. Ignoring them is a workaround.