### PR TITLE
Validate file is readable in addheader subcommand

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -44,6 +44,8 @@ Contributors
 
 - yoctocell
 
+- Tuomas Siipola
+
 
 Translators
 -----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ The versions follow [semantic versioning](https://semver.org).
   + .coveragerc
   + Jenkinsfile
   + sonar-project.properties
+
 ### Fixed
 
 - Fixed a regression where unused licenses were not at all detected. (#285)
@@ -68,6 +69,9 @@ The versions follow [semantic versioning](https://semver.org).
 
 - `MANIFEST.in` is now recognised instead of the incorrect `Manifest.in` by
   `addheader`. (#306)
+
+- `addheader` now checks whether a file is both readable and writeable instead
+  of only writeable. (#241)
 
 ## 0.12.1 - 2020-12-17
 

--- a/src/reuse/header.py
+++ b/src/reuse/header.py
@@ -505,7 +505,7 @@ def add_arguments(parser) -> None:
         action="store_true",
         help=_("skip files with unrecognised comment styles"),
     )
-    parser.add_argument("path", action="store", nargs="+", type=PathType("w"))
+    parser.add_argument("path", action="store", nargs="+", type=PathType("r+"))
 
 
 def run(args, project: Project, out=sys.stdout) -> int:


### PR DESCRIPTION
Previously it was only checked that the given file is writable.  For example, non-existing files are writable so an exception was raised after validation when trying to open the file. To fix this, introduce "r+" mode to `PathType` which validates that the file is both readable and writable.