### PR TITLE
Use UTF-8 explicitly when reading files, too.

### DIFF
--- a/src/reuse/header.py
+++ b/src/reuse/header.py
@@ -384,7 +384,7 @@ def _add_header_to_file(
             out.write("\n")
             return result
 
-    with path.open("rt") as fp:
+    with path.open("rt", encoding="utf-8") as fp:
         text = fp.read()
 
     try:


### PR DESCRIPTION
Since the file will be written out in UTF-8, it's a safe bet that they should also be read in UTF-8.

Alternatively, we could support a global setting to override the default encoding, but in 2020 that sounds like a recipe for more headaches than not.