### PR TITLE
Add go.mod support

### DIFF
--- a/src/reuse/_comment.py
+++ b/src/reuse/_comment.py
@@ -515,6 +515,7 @@ FILENAME_COMMENT_STYLE_MAP = {
     "Manifest.in": PythonCommentStyle,
     "ROOT": MlCommentStyle,
     "configure.ac": M4CommentStyle,
+    "go.mod": CCommentStyle,
     "manifest": PythonCommentStyle,  # used by cdist
     "requirements.txt": PythonCommentStyle,
     "setup.cfg": PythonCommentStyle,


### PR DESCRIPTION
As https://github.com/fsfe/reuse-tool/pull/234/ seems to have stalled for legal reasons, I am submitting a new PR containing just the change of adding support for `go.mod` files.

A `go.mod` file is a Go module definition, similar to a Makefile.