### PR TITLE
_comment: recognize Makefile .mk suffix

### DIFF
--- a/src/reuse/_comment.py
+++ b/src/reuse/_comment.py
@@ -451,6 +451,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".m4": M4CommentStyle,
     ".markdown": HtmlCommentStyle,
     ".md": HtmlCommentStyle,
+    ".mk": PythonCommentStyle,
     ".ml": MlCommentStyle,
     ".ML": MlCommentStyle,
     ".mli": MlCommentStyle,


### PR DESCRIPTION
File suffixes `.mk` are used for Makefile, recognize those files.

Signed-off-by: Paul Spooren <mail@aparcar.org>