### PR TITLE
allow different styles of copyright lines

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -69,6 +69,17 @@ The REUSE header is placed at the very top of the file. If a different REUSE
 header already existed---at the top or elsewhere---its tags are copied, and the
 header is replaced in-place.
 
+With the argument ``--copyright-style`` it is posible to change the default
+``SPDX-FileCopyrightText`` to one of the following style:
+
+.. code-block::
+
+  spdx:           SPDX-FileCopyrightText: <year> <statement>
+  string:         Copyright <year> <statement>
+  string-c:       Copyright (C) <year> <statement>
+  string-symbol:  Copyright © <year> <statement>
+  symbol:         © <year> <statement>
+
 Shebangs are always preserved at the top of the file.
 
 Comment styles

--- a/src/reuse/_util.py
+++ b/src/reuse/_util.py
@@ -54,6 +54,14 @@ _COPYRIGHT_PATTERNS = [
     re.compile(r"(© .*?)" + _END_PATTERN),
 ]
 
+_COPYRIGHT_STYLES = {
+    "spdx": "SPDX-FileCopyrightText:",
+    "string": "Copyright",
+    "string-c": "Copyright (C)",
+    "string-symbol": "Copyright ©",
+    "symbol": "©",
+}
+
 # Amount of bytes that we assume will be big enough to contain the entire
 # comment header (including SPDX tags), so that we don't need to read the
 # entire file.
@@ -201,19 +209,29 @@ def contains_spdx_info(text: str) -> bool:
         return False
 
 
-def make_copyright_line(statement: str, year: str = None) -> str:
+def make_copyright_line(
+    statement: str, year: str = None, copyright_style: str = "spdx"
+) -> str:
     """Given a statement, prefix it with ``SPDX-FileCopyrightText:`` if it is
     not already prefixed with some manner of copyright tag.
     """
     if "\n" in statement:
         raise RuntimeError(f"Unexpected newline in '{statement}'")
+
+    copyright_prefix = _COPYRIGHT_STYLES.get(copyright_style)
+    if copyright_prefix is None:
+        raise RuntimeError(
+            "Unexpected copyright syle: Need 'spdx', 'string', 'string-c',"
+            "'string-symbol' or 'symbol'"
+        )
+
     for pattern in _COPYRIGHT_PATTERNS:
         match = pattern.search(statement)
         if match is not None:
             return statement
     if year is not None:
-        return f"SPDX-FileCopyrightText: {year} {statement}"
-    return f"SPDX-FileCopyrightText: {statement}"
+        return f"{copyright_prefix} {year} {statement}"
+    return f"{copyright_prefix} {statement}"
 
 
 def _checksum(path: PathLike) -> str:

--- a/src/reuse/header.py
+++ b/src/reuse/header.py
@@ -38,6 +38,7 @@ from ._comment import (
     PythonCommentStyle,
 )
 from ._util import (
+    _COPYRIGHT_STYLES,
     PathType,
     _determine_license_path,
     _determine_license_suffix_path,
@@ -454,6 +455,12 @@ def add_arguments(parser) -> None:
         help=_("comment style to use, optional"),
     )
     parser.add_argument(
+        "--copyright-style",
+        action="store",
+        choices=list(_COPYRIGHT_STYLES.keys()),
+        help=_("copyright style to use, optional"),
+    )
+    parser.add_argument(
         "--template",
         "-t",
         action="store",
@@ -548,8 +555,14 @@ def run(args, project: Project, out=sys.stdout) -> int:
             year = datetime.date.today().year
 
     expressions = set(args.license) if args.license is not None else set()
+    copyright_style = (
+        args.copyright_style if args.copyright_style is not None else "spdx"
+    )
     copyright_lines = (
-        {make_copyright_line(x, year=year) for x in args.copyright}
+        {
+            make_copyright_line(x, year=year, copyright_style=copyright_style)
+            for x in args.copyright
+        }
         if args.copyright is not None
         else set()
     )

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -156,6 +156,52 @@ def test_make_copyright_line_year():
     )
 
 
+def test_make_copyright_line_style_spdx():
+    """Given a simple statement and style, make it a copyright line."""
+    statement = _util.make_copyright_line("hello", copyright_style="spdx")
+    assert statement == "SPDX-FileCopyrightText: hello"
+
+
+def test_make_copyright_line_style_spdx_year():
+    """Given a simple statement, style and a year, make it a copyright line."""
+    statement = _util.make_copyright_line(
+        "hello", year=2019, copyright_style="spdx"
+    )
+    assert statement == "SPDX-FileCopyrightText: 2019 hello"
+
+
+def test_make_copyright_line_style_string_year():
+    """Given a simple statement, style and a year, make it a copyright line."""
+    statement = _util.make_copyright_line(
+        "hello", year=2019, copyright_style="string"
+    )
+    assert statement == "Copyright 2019 hello"
+
+
+def test_make_copyright_line_style_string_c_year():
+    """Given a simple statement, style and a year, make it a copyright line."""
+    statement = _util.make_copyright_line(
+        "hello", year=2019, copyright_style="string-c"
+    )
+    assert statement == "Copyright (C) 2019 hello"
+
+
+def test_make_copyright_line_style_string_symbol_year():
+    """Given a simple statement, style and a year, make it a copyright line."""
+    statement = _util.make_copyright_line(
+        "hello", year=2019, copyright_style="string-symbol"
+    )
+    assert statement == "Copyright © 2019 hello"
+
+
+def test_make_copyright_line_style_symbol_year():
+    """Given a simple statement, style and a year, make it a copyright line."""
+    statement = _util.make_copyright_line(
+        "hello", year=2019, copyright_style="symbol"
+    )
+    assert statement == "© 2019 hello"
+
+
 def test_make_copyright_line_existing_spdx_copyright():
     """Given a copyright line, do nothing."""
     value = "SPDX" "-FileCopyrightText: hello"


### PR DESCRIPTION
adds the arg `--copyright-style` which accepts `spdx`, `string` and
`symbol`.

- [x] Add test cases
- [x] Add docs
- [x] ~~Ask option to `init`~~

I don't this this option is relevant to the `init` function.

Signed-off-by: Paul Spooren <mail@aparcar.org>