### PR TITLE
Detect comment style for Scheme (.scm) and ClojureScript (.cljs, .cljc) files

### DIFF
--- a/src/reuse/_comment.py
+++ b/src/reuse/_comment.py
@@ -481,6 +481,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".rss": HtmlCommentStyle,
     ".sass": CssCommentStyle,
     ".scala": PythonCommentStyle,
+    ".scm": LispCommentStyle,
     ".scpt": AppleScriptCommentStyle,
     ".scptd": AppleScriptCommentStyle,
     ".scss": CssCommentStyle,

--- a/src/reuse/_comment.py
+++ b/src/reuse/_comment.py
@@ -407,6 +407,8 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".c": CCommentStyle,
     ".cl": LispCommentStyle,
     ".clj": LispCommentStyle,
+    ".cljc": LispCommentStyle,
+    ".cljs": LispCommentStyle,
     ".cmake": PythonCommentStyle,  # TODO: Bracket comments not supported.
     ".coffee": PythonCommentStyle,
     ".cpp": CCommentStyle,


### PR DESCRIPTION
This adds entries to `EXTENSION_COMMENT_STYLE_MAP` for Scheme (.scm) and ClojureScript (.cljs, .cljc) files using `LispCommentStyle`.