### PR TITLE
Add Meson's meson.build to the supported files.

### DIFF
--- a/src/reuse/_comment.py
+++ b/src/reuse/_comment.py
@@ -516,6 +516,7 @@ FILENAME_COMMENT_STYLE_MAP = {
     "ROOT": MlCommentStyle,
     "configure.ac": M4CommentStyle,
     "manifest": PythonCommentStyle,  # used by cdist
+    "meson.build": PythonCommentStyle,
     "requirements.txt": PythonCommentStyle,
     "setup.cfg": PythonCommentStyle,
 }


### PR DESCRIPTION
The comment syntax is documented at https://mesonbuild.com/Syntax.html#comments and matches Python's.