### PR TITLE
Add list command to list project files and licenses

### DIFF
--- a/src/reuse/_main.py
+++ b/src/reuse/_main.py
@@ -18,6 +18,7 @@ from . import (
     header,
     init,
     lint,
+    list,
     spdx,
 )
 from ._format import INDENT, fill_all, fill_paragraph
@@ -203,6 +204,17 @@ def parser() -> argparse.ArgumentParser:
         spdx.add_arguments,
         spdx.run,
         help=_("print the project's bill of materials in SPDX format"),
+    )
+
+    add_command(
+        subparsers,
+        "list",
+        list.add_arguments,
+        list.run,
+        help=_(
+            "list the project files and their license information in a "
+            "human-readable format"
+        ),
     )
 
     return parser

--- a/src/reuse/list.py
+++ b/src/reuse/list.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: 2020 Free Software Foundation Europe e.V. <https://fsfe.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""List the project files and their license information."""
+
+import logging
+import sys
+from gettext import gettext as _
+from pathlib import Path
+
+from .project import Project
+from .report import ProjectReport
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def add_arguments(_parser) -> None:
+    """Add arguments to the parser."""
+
+
+def print_table_line(out, line, widths) -> None:
+    """Fill the values of the given line to the given widths and print them to
+    the given output."""
+    values = [str.ljust(str(val), width) for (val, width) in zip(line, widths)]
+    print(*values, sep="  ", file=out)
+
+
+def print_table_separator(out, widths) -> None:
+    """Print a separator line with the given column widths to the given
+    output."""
+    values = ["-" * width for width in widths]
+    print(*values, sep="  ", file=out)
+
+
+def run(args, project: Project, out=sys.stdout) -> int:
+    """List the project files files and their license information in a
+    human-readable format."""
+    report = ProjectReport.generate(
+        project, multiprocessing=not args.no_multiprocessing
+    )
+
+    # Collect data and keep track of the longest values per column
+    table_header = [_("File"), _("License")]
+    column_widths = [len(header) for header in table_header]
+    table_data = []
+    for file_report in report.file_reports:
+        file_name = project.relative_from_root(Path(file_report.path))
+        licenses = ", ".join(sorted(file_report.spdxfile.licenses_in_file))
+        table_data.append([file_name, licenses])
+        column_widths[0] = max(column_widths[0], len(str(file_name)))
+        column_widths[1] = max(column_widths[1], len(licenses))
+
+    # Sort and print data, filling all values of the same column to the same
+    # width for proper alignment
+    table_data = sorted(table_data)
+    print_table_line(out, table_header, column_widths)
+    print_table_separator(out, column_widths)
+    for row in table_data:
+        print_table_line(out, row, column_widths)
+
+    return 0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-"""Tests for reuse._main: lint, spdx, download"""
+"""Tests for reuse._main: lint, list, spdx, download"""
 
 # pylint: disable=redefined-outer-name,unused-argument
 
@@ -139,6 +139,53 @@ def test_lint_no_multiprocessing(fake_repository, stringio, multiprocessing):
 
     assert result == 0
     assert ":-)" in stringio.getvalue()
+
+
+def test_list(fake_repository, stringio):
+    """List all files and their copyright information."""
+    os.chdir(str(fake_repository))
+    result = main(["list"], out=stringio)
+
+    lines = [line.rstrip() for line in stringio.getvalue().split("\n")]
+    expected_lines = [
+        "File                    License",
+        "----------------------  ----------------------------------------",
+        "doc/index.rst           CC0-1.0",
+        "src/custom.py           LicenseRef-custom",
+        "src/exception.py        Autoconf-exception-3.0, GPL-3.0-or-later",
+        "src/source_code.c       GPL-3.0-or-later",
+        "src/source_code.html    GPL-3.0-or-later",
+        "src/source_code.jinja2  GPL-3.0-or-later",
+        "src/source_code.py      GPL-3.0-or-later",
+        "",
+    ]
+
+    assert result == 0
+    assert lines == expected_lines
+
+
+def test_list_no_multiprocessing(fake_repository, stringio):
+    """List all files and their copyright information, with the
+    --no-multiprocessing option set."""
+    os.chdir(str(fake_repository))
+    result = main(["--no-multiprocessing", "list"], out=stringio)
+
+    lines = [line.rstrip() for line in stringio.getvalue().split("\n")]
+    expected_lines = [
+        "File                    License",
+        "----------------------  ----------------------------------------",
+        "doc/index.rst           CC0-1.0",
+        "src/custom.py           LicenseRef-custom",
+        "src/exception.py        Autoconf-exception-3.0, GPL-3.0-or-later",
+        "src/source_code.c       GPL-3.0-or-later",
+        "src/source_code.html    GPL-3.0-or-later",
+        "src/source_code.jinja2  GPL-3.0-or-later",
+        "src/source_code.py      GPL-3.0-or-later",
+        "",
+    ]
+
+    assert result == 0
+    assert lines == expected_lines
 
 
 def test_spdx(fake_repository, stringio):


### PR DESCRIPTION
This patch adds the list command that lists all project files and their
licenses in a human-readable format.

---

This PR provides a basic implementation of the list command as discussed in issue #256.  (It does not use the name report as there already is a `reuse.report` module.)

There are some question I’d like to discuss with you:
- Should we include additional information, for example the copyright text?  This might be hard to read in a table, especially if the text contains new lines.  We could replace new lines with spaces.
- Should we perform any kind of magic with the paths?  For example, trying to shorten them if they are longer than e. g. 80 characters, or grouping similar paths with the same license information.

Note that I had to deactive the pre-commit hook because it caused this error:

```
black....................................................................Passed
pylint...................................................................Failed
- hook id: pylint
- exit code: 1

Traceback (most recent call last):
  File "/home/robin/reps/reuse-tool/venv/bin/pylint", line 10, in <module>
    sys.exit(run_pylint())
  File "/home/robin/reps/reuse-tool/venv/lib/python3.7/site-packages/pylint/__init__.py", line 19, in run_pylint
    from pylint.lint import Run as PylintRun
  File "/home/robin/reps/reuse-tool/venv/lib/python3.7/site-packages/pylint/lint/__init__.py", line 75, in <module>
    from pylint.lint.check_parallel import check_parallel
  File "/home/robin/reps/reuse-tool/venv/lib/python3.7/site-packages/pylint/lint/check_parallel.py", line 7, in <module>
    from pylint import reporters
  File "/home/robin/reps/reuse-tool/venv/lib/python3.7/site-packages/pylint/reporters/__init__.py", line 24, in <module>
    from pylint import utils
  File "/home/robin/reps/reuse-tool/venv/lib/python3.7/site-packages/pylint/utils/__init__.py", line 46, in <module>
    from pylint.utils.ast_walker import ASTWalker
  File "/home/robin/reps/reuse-tool/venv/lib/python3.7/site-packages/pylint/utils/ast_walker.py", line 6, in <module>
    from astroid import nodes
  File "/home/robin/reps/reuse-tool/venv/lib/python3.7/site-packages/astroid/__init__.py", line 47, in <module>
    from astroid import inference, raw_building
  File "/home/robin/reps/reuse-tool/venv/lib/python3.7/site-packages/astroid/inference.py", line 34, in <module>
    from astroid import (
  File "/home/robin/reps/reuse-tool/venv/lib/python3.7/site-packages/astroid/protocols.py", line 29, in <module>
    from astroid import Store, arguments, bases
ImportError: cannot import name 'Store' from 'astroid' (/home/robin/reps/reuse-tool/venv/lib/python3.7/site-packages/astroid/__init__.py)
```