### PR TITLE
default_template: follow Kernel style

### DIFF
--- a/src/reuse/templates/default_template.jinja2
+++ b/src/reuse/templates/default_template.jinja2
@@ -1,7 +1,8 @@
+{% for expression in spdx_expressions %}
+SPDX-License-Identifier: {{ expression }}
+{% endfor %}
+
 {% for copyright_line in copyright_lines %}
 {{ copyright_line }}
 {% endfor %}
 
-{% for expression in spdx_expressions %}
-SPDX-License-Identifier: {{ expression }}
-{% endfor %}


### PR DESCRIPTION
The Kernel suggests to put the SPDX license identifier as high up as
possible, reflect that in the default_template.

[...]
The SPDX license identifier in kernel files shall be added at the first
possible line in a file which can contain a comment. For the majority or
files this is the first line, except for scripts which require the
‘#!PATH_TO_INTERPRETER’ in the first line. For those scripts the SPDX
identifier goes into the second line.
[...]

Signed-off-by: Paul Spooren <mail@aparcar.org>