### PR TITLE
Add R Markdown (.Rmd) file extension

### DIFF
--- a/src/reuse/_comment.py
+++ b/src/reuse/_comment.py
@@ -510,6 +510,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".qbs": CCommentStyle,
     ".qml": CCommentStyle,
     ".R": PythonCommentStyle,
+    ".Rmd": HtmlCommentStyle,
     ".rake": PythonCommentStyle,
     ".rb": PythonCommentStyle,
     ".rbw": PythonCommentStyle,


### PR DESCRIPTION
RMarkdown[1] is simply Markdown with embedded R code.
Therefore comments are HTML-style, like in Markdown.

[1]: https://rmarkdown.rstudio.com/