### PR TITLE
Use CCommentStyle for TS files

### DIFF
--- a/src/reuse/_comment.py
+++ b/src/reuse/_comment.py
@@ -549,6 +549,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".thy": MlCommentStyle,
     ".toc": TexCommentStyle,
     ".toml": PythonCommentStyle,
+    ".ts": CCommentStyle,
     ".tsx": JsxCommentStyle,
     ".vala": CCommentStyle,
     ".xml": HtmlCommentStyle,


### PR DESCRIPTION
TypeScript (.ts) files use the same comment style as Javascript files (.js)