### PR TITLE
Make addheader detect .dockerignore, Gemfile and Rakefile

### DIFF
--- a/src/reuse/_comment.py
+++ b/src/reuse/_comment.py
@@ -561,6 +561,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
 }
 
 FILENAME_COMMENT_STYLE_MAP = {
+    ".dockerignore": PythonCommentStyle,
     ".editorconfig": PythonCommentStyle,
     ".gitattributes": PythonCommentStyle,
     ".gitignore": PythonCommentStyle,
@@ -571,9 +572,11 @@ FILENAME_COMMENT_STYLE_MAP = {
     ".Rprofile": PythonCommentStyle,
     "CMakeLists.txt": PythonCommentStyle,
     "Dockerfile": PythonCommentStyle,
+    "Gemfile": PythonCommentStyle,
     "Makefile": PythonCommentStyle,
     "Makefile.am": PythonCommentStyle,
     "Manifest.in": PythonCommentStyle,
+    "Rakefile": PythonCommentStyle,
     "ROOT": MlCommentStyle,
     "configure.ac": M4CommentStyle,
     "go.mod": CCommentStyle,


### PR DESCRIPTION
I just made a Ruby on Rails project REUSE compliant and noticed the `Gemfile` and `Rakefile` were not covered yet.

I also like to keep my Docker container build contexts small so added `.dockerignore` as well.