### PR TITLE
Add support for .mjs files

### DIFF
--- a/src/reuse/_comment.py
+++ b/src/reuse/_comment.py
@@ -501,6 +501,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".m4": M4CommentStyle,
     ".markdown": HtmlCommentStyle,
     ".md": HtmlCommentStyle,
+    ".mjs": CCommentStyle,
     ".mk": PythonCommentStyle,
     ".ml": MlCommentStyle,
     ".ML": MlCommentStyle,


### PR DESCRIPTION
To distinguish JavaScript modules from non-module files, some sources recommend using the `.mjs` extension [1]. They are otherwise identical to JavaScript `.js` files.

[1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules#aside_—_.mjs_versus_.js
