### PR TITLE
feat: support comments in .coveragerc files

### DIFF
--- a/src/reuse/_comment.py
+++ b/src/reuse/_comment.py
@@ -562,6 +562,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
 }
 
 FILENAME_COMMENT_STYLE_MAP = {
+    ".coveragerc": PythonCommentStyle,
     ".dockerignore": PythonCommentStyle,
     ".editorconfig": PythonCommentStyle,
     ".gitattributes": PythonCommentStyle,


### PR DESCRIPTION
.coveragerc files are common for configuring the coverage.py behavior, also used
by pytest. More details on the syntax are available in the coverage.py
documentation: https://coverage.readthedocs.io/en/latest/config.html

Signed-off-by: Nico Rikken <nico.rikken@alliander.com>