### PR TITLE
Comment style for uncommentable files

### DIFF
--- a/src/reuse/_comment.py
+++ b/src/reuse/_comment.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2019 Kirill Elagin
 # SPDX-FileCopyrightText: 2020 Dmitry Bogatov
 # SPDX-FileCopyrightText: 2021 Alliander N.V.
+# SPDX-FileCopyrightText: 2021 Alvar Penning
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -427,6 +428,12 @@ class TexCommentStyle(CommentStyle):
     INDENT_AFTER_SINGLE = " "
 
 
+class UncommentableCommentStyle(EmptyCommentStyle):
+    """A pseudo comment style to indicate that this file is uncommentable. This
+    results in an external .license file as for binaries or --explicit-license.
+    """
+
+
 #: A map of (common) file extensions against comment types.
 EXTENSION_COMMENT_STYLE_MAP = {
     ".adb": HaskellCommentStyle,
@@ -488,6 +495,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".jinja": JinjaCommentStyle,
     ".jinja2": JinjaCommentStyle,
     ".js": CCommentStyle,
+    ".json": UncommentableCommentStyle,
     ".jsx": JsxCommentStyle,
     ".jy": PythonCommentStyle,
     ".ksh": PythonCommentStyle,
@@ -582,6 +590,7 @@ FILENAME_COMMENT_STYLE_MAP = {
     "ROOT": MlCommentStyle,
     "configure.ac": M4CommentStyle,
     "go.mod": CCommentStyle,
+    "go.sum": UncommentableCommentStyle,
     "manifest": PythonCommentStyle,  # used by cdist
     "meson.build": PythonCommentStyle,
     "requirements.txt": PythonCommentStyle,
@@ -602,6 +611,7 @@ def _all_style_classes() -> List[CommentStyle]:
 
 _result = _all_style_classes()
 _result.remove(EmptyCommentStyle)
+_result.remove(UncommentableCommentStyle)
 
 #: A map of human-friendly names against style classes.
 NAME_STYLE_MAP = {style._shorthand: style for style in _result}

--- a/tests/test_main_addheader.py
+++ b/tests/test_main_addheader.py
@@ -540,6 +540,38 @@ def test_addheader_binary(
     )
 
 
+def test_addheader_uncommentable_json(
+    fake_repository, stringio, mock_date_today
+):
+    """Add a header to a .license file if the file is uncommentable, e.g., JSON."""
+    json_file = fake_repository / "foo.json"
+    json_file.write_text('{"foo": 23, "bar": 42}')
+
+    result = main(
+        [
+            "addheader",
+            "--license",
+            "GPL-3.0-or-later",
+            "--copyright",
+            "Mary Sue",
+            "foo.json",
+        ],
+        out=stringio,
+    )
+
+    assert result == 0
+    assert (
+        json_file.with_name(f"{json_file.name}.license").read_text().strip()
+        == cleandoc(
+            """
+            spdx-FileCopyrightText: 2018 Mary Sue
+
+            spdx-License-Identifier: GPL-3.0-or-later
+            """
+        ).replace("spdx", "SPDX")
+    )
+
+
 def test_addheader_explicit_license(
     fake_repository, stringio, mock_date_today
 ):


### PR DESCRIPTION
Previously, only binary files were handled as uncommentable [0]. For
other files the "--explicit-license" flag has to be set explicitly.
However, there are also text files which are uncommentable.

This commit / pull request introduces support for a new pseudo comment
style for uncommentable text files.

One use case is, for example, Golang's go.sum file. Hashes of the
referenced modules are listed there, but without any special header [1].
Thus it is not possible to add an SPDX header. However, this file cannot
be omitted. Whether the file is to be ignored license-wise was addressed
in a previous pull request [2], but not clarified.

With the changes introduced here, this file is recognized as
uncommentable and a .license file is created.

[0] https://reuse.software/tutorial/#binary-and-uncommentable-files
[1] https://blog.golang.org/using-go-modules
[2] https://github.com/fsfe/reuse-tool/pull/234