### PR TITLE
feat: .ipynb UncommentableCommentStyle support

### DIFF
--- a/src/reuse/_comment.py
+++ b/src/reuse/_comment.py
@@ -490,6 +490,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".hxsl": CCommentStyle,
     ".ini": LispCommentStyle,
     ".ino": CCommentStyle,
+    ".ipynb": UncommentableCommentStyle,
     ".iuml": PlantUmlCommentStyle,
     ".java": CCommentStyle,
     ".jinja": JinjaCommentStyle,


### PR DESCRIPTION
Although there have been discussions on notebooks to support metadata, license
information is not included in those discussions:

https://github.com/ipython/ipython/issues/6073
https://github.com/jupyter/nbformat/blob/master/nbformat/v4/nbformat.v4.schema.json

Also it would be complicated to add license information in the JSON structure if
it were supported.

So for now it is best to consider it uncommentable and add a .ipynb.license file.

Signed-off-by: Nico Rikken <nico.rikken@alliander.com>