### PR TITLE
feat: support uncommentable style for .svg files

### DIFF
--- a/src/reuse/_comment.py
+++ b/src/reuse/_comment.py
@@ -555,6 +555,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".sh": PythonCommentStyle,
     ".sml": MlCommentStyle,
     ".sql": HaskellCommentStyle,
+    ".svg": UncommentableCommentStyle,
     ".swift": CCommentStyle,
     ".tex": TexCommentStyle,
     ".thy": MlCommentStyle,


### PR DESCRIPTION
Although SVG files can be considered plain-text, they are not suitable for
including copyright and license information.

This commit renders them 'uncommentable' so a .license file is added.

Signed-off-by: Nico Rikken <nico.rikken@alliander.com>