### PR TITLE
feat: support uncommentable style for .csv files

### DIFF
--- a/src/reuse/_comment.py
+++ b/src/reuse/_comment.py
@@ -461,6 +461,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".cpp": CCommentStyle,
     ".cs": CCommentStyle,
     ".css": CssCommentStyle,
+    ".csv": UncommentableCommentStyle,
     ".d": CCommentStyle,
     ".dart": CCommentStyle,
     ".di": CCommentStyle,


### PR DESCRIPTION
CSV files cannot be annotated as their structure ensure the correct
interpretation of the enclosed data. I'm not aware of csv extensions for
comments, and in any case they wouldn't be supported by all tools.

This commit renders them 'uncommentable' to ensure that a .license file is added.

Signed-off-by: Nico Rikken <nico.rikken@alliander.com>