### PR TITLE
feat: support commentable style for sonar-project.properties files

### DIFF
--- a/src/reuse/_comment.py
+++ b/src/reuse/_comment.py
@@ -598,6 +598,7 @@ FILENAME_COMMENT_STYLE_MAP = {
     "meson.build": PythonCommentStyle,
     "requirements.txt": PythonCommentStyle,
     "setup.cfg": PythonCommentStyle,
+    "sonar-project.properties": PythonCommentStyle,
 }
 
 


### PR DESCRIPTION
The sonar-project.properties file is to configure SonarScanner on a repository
level. More documentation can be found at:
https://docs.sonarqube.org/latest/analysis/scan/sonarscanner/

This commit ensures this file format is supported for the addheader command.

Signed-off-by: Nico Rikken <nico.rikken@alliander.com>