### PR TITLE
feat: support comment style for .bashrc files

### DIFF
--- a/src/reuse/_comment.py
+++ b/src/reuse/_comment.py
@@ -572,6 +572,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
 }
 
 FILENAME_COMMENT_STYLE_MAP = {
+    ".bashrc": PythonCommentStyle,
     ".coveragerc": PythonCommentStyle,
     ".dockerignore": PythonCommentStyle,
     ".editorconfig": PythonCommentStyle,


### PR DESCRIPTION
This commit ensures that the .bashrc filename is supported for the addheader
command.

The .bashrc files are used to configure the bash terminal. Typically they are
included from other bash configuration files. It is similar to a bash
script like the already supported .bash extension. In this case however the
hashbang will typically not be there.

Signed-off-by: Nico Rikken <nico.rikken@alliander.com>