### PR TITLE
fix: comment support from Manifest.in to MANIFEST.in

### DIFF
--- a/src/reuse/_comment.py
+++ b/src/reuse/_comment.py
@@ -591,7 +591,7 @@ FILENAME_COMMENT_STYLE_MAP = {
     "Jenkinsfile": CCommentStyle,
     "Makefile": PythonCommentStyle,
     "Makefile.am": PythonCommentStyle,
-    "Manifest.in": PythonCommentStyle,
+    "MANIFEST.in": PythonCommentStyle,
     "Rakefile": PythonCommentStyle,
     "ROOT": MlCommentStyle,
     "configure.ac": M4CommentStyle,


### PR DESCRIPTION
Correct the supported filename for Python source package configurations from
Manifest.in to the expected MANIFEST.in. Manifest.in is the default location for
this location, as is described in the Python packaging documentation:
https://packaging.python.org/guides/using-manifest-in/

This commit was preceded by a small consideration as documented in issue
https://github.com/fsfe/reuse-tool/issues/306

Signed-off-by: Nico Rikken <nico.rikken@alliander.com>