### PR TITLE
Add comment styles for Racket and Org files

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -42,6 +42,8 @@ Contributors
 
 - Maximilian Dolling <mdolling@gfz-potsdam.de>
 
+- yoctocell
+
 
 Translators
 -----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ The versions follow [semantic versioning](https://semver.org).
   + .svg
   + .json
   + .csv
+  + .rkt
+  + .org
 
 - More file names are recognised:
   + .bashrc

--- a/src/reuse/_comment.py
+++ b/src/reuse/_comment.py
@@ -544,6 +544,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".rb": PythonCommentStyle,
     ".rbw": PythonCommentStyle,
     ".rbx": PythonCommentStyle,
+    ".rkt": LispCommentStyle,
     ".rs": CCommentStyle,
     ".rss": HtmlCommentStyle,
     ".rst": ReStructedTextCommentStyle,

--- a/src/reuse/_comment.py
+++ b/src/reuse/_comment.py
@@ -519,6 +519,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".nim": PythonCommentStyle,
     ".nimrod": PythonCommentStyle,
     ".nix": PythonCommentStyle,
+    ".org": PythonCommentStyle,
     ".php": CCommentStyle,
     ".php3": CCommentStyle,
     ".php4": CCommentStyle,


### PR DESCRIPTION
Use  `LispCommentStyle` for Racket, and `PythonCommentStyle` for Org files.