### PR TITLE
Fix unused_licenses regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@ The versions follow [semantic versioning](https://semver.org).
   + sonar-project.properties
 ### Fixed
 
+- Fixed a regression where unused licenses were not at all detected. (#285)
+
 - Declared dependency on `python-debian <= 0.1.38`. Later versions of the
   dependency do not import on Windows. (#310)
 

--- a/src/reuse/report.py
+++ b/src/reuse/report.py
@@ -263,10 +263,7 @@ class ProjectReport:  # pylint: disable=too-many-instance-attributes
             for lic in file_report.spdxfile.licenses_in_file
         }
         self._unused_licenses = {
-            lic
-            for file_report in self.file_reports
-            for lic in file_report.spdxfile.licenses_in_file
-            if lic not in all_used_licenses
+            lic for lic in self.licenses if lic not in all_used_licenses
         }
 
         return self._unused_licenses

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -141,6 +141,18 @@ def test_generate_project_report_bad_license(fake_repository, multiprocessing):
     assert not result.missing_licenses
 
 
+def test_generate_project_report_unused_license(
+    fake_repository, multiprocessing
+):
+    """Unused licenses are detected."""
+    (fake_repository / "LICENSES/MIT.txt").write_text("foo")
+
+    project = Project(fake_repository)
+    result = ProjectReport.generate(project, multiprocessing=multiprocessing)
+
+    assert result.unused_licenses == {"MIT"}
+
+
 def test_generate_project_report_bad_license_in_file(
     fake_repository, multiprocessing
 ):


### PR DESCRIPTION
For some reason, unused licenses were not at all detected. This commit
fixes that, and adds a test.

Fixes #285 