### PR TITLE
Better support for unary "+" operator in license identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,11 @@ The versions follow [semantic versioning](https://semver.org).
 
 ### Fixed
 
+- Better support for unary "+" operator in license identifiers. For example, if
+  `Apache-1.0+` appears as a declared license, it should not be identified as
+  missing, bad, or unused if `LICENSES/Apache-1.0.txt` exists. It is, however,
+  identified separately as a used license. (#123)
+
 ### Security
 
 ## 0.14.0 - 2021-12-27

--- a/src/reuse/report.py
+++ b/src/reuse/report.py
@@ -365,15 +365,21 @@ class FileReport:
         spdx_info = project.spdx_info_of(path)
         for expression in spdx_info.spdx_expressions:
             for identifier in _LICENSING.license_keys(expression):
+                # A license expression akin to Apache-1.0+ should register
+                # correctly if LICENSES/Apache-1.0.txt exists.
+                identifiers = {identifier}
+                if identifier.endswith("+"):
+                    identifiers.add(identifier[:-1])
                 # Bad license
-                if identifier not in project.license_map:
+                if not identifiers.intersection(project.license_map):
                     report.bad_licenses.add(identifier)
                 # Missing license
-                if identifier not in project.licenses:
+                if not identifiers.intersection(project.licenses):
                     report.missing_licenses.add(identifier)
 
                 # Add license to report.
-                report.spdxfile.licenses_in_file.append(identifier)
+                for id_ in identifiers:
+                    report.spdxfile.licenses_in_file.append(id_)
 
         # Copyright text
         report.spdxfile.copyright = "\n".join(

--- a/src/reuse/report.py
+++ b/src/reuse/report.py
@@ -261,8 +261,15 @@ class ProjectReport:  # pylint: disable=too-many-instance-attributes
         if self._unused_licenses is not None:
             return self._unused_licenses
 
-        self._unused_licenses = {
+        # First collect licenses that are suspected to be unused.
+        suspected_unused_licenses = {
             lic for lic in self.licenses if lic not in self.used_licenses
+        }
+        # Remove false positives.
+        self._unused_licenses = {
+            lic
+            for lic in suspected_unused_licenses
+            if f"{lic}+" not in self.used_licenses
         }
         return self._unused_licenses
 
@@ -376,8 +383,7 @@ class FileReport:
                     report.missing_licenses.add(identifier)
 
                 # Add license to report.
-                for id_ in identifiers:
-                    report.spdxfile.licenses_in_file.append(id_)
+                report.spdxfile.licenses_in_file.append(identifier)
 
         # Copyright text
         report.spdxfile.copyright = "\n".join(

--- a/src/reuse/report.py
+++ b/src/reuse/report.py
@@ -248,7 +248,11 @@ class ProjectReport:  # pylint: disable=too-many-instance-attributes
         if self._used_licenses is not None:
             return self._used_licenses
 
-        self._used_licenses = set(self.licenses) - self.unused_licenses
+        self._used_licenses = {
+            lic
+            for file_report in self.file_reports
+            for lic in file_report.spdxfile.licenses_in_file
+        }
         return self._used_licenses
 
     @property
@@ -257,15 +261,9 @@ class ProjectReport:  # pylint: disable=too-many-instance-attributes
         if self._unused_licenses is not None:
             return self._unused_licenses
 
-        all_used_licenses = {
-            lic
-            for file_report in self.file_reports
-            for lic in file_report.spdxfile.licenses_in_file
-        }
         self._unused_licenses = {
-            lic for lic in self.licenses if lic not in all_used_licenses
+            lic for lic in self.licenses if lic not in self.used_licenses
         }
-
         return self._unused_licenses
 
     @property

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -76,6 +76,22 @@ def test_generate_file_report_file_bad_license(fake_repository):
     assert result.missing_licenses == {"fakelicense"}
 
 
+def test_generate_file_report_license_contains_plus(fake_repository):
+    """Given a license expression akin to Apache-1.0+, LICENSES/Apache-1.0.txt
+    should be an appropriate license file.
+    """
+    (fake_repository / "foo.py").write_text(
+        "SPDX" "-License-Identifier: Apache-1.0+"
+    )
+    (fake_repository / "LICENSES/Apache-1.0.txt").touch()
+    project = Project(fake_repository)
+    result = FileReport.generate(project, "foo.py")
+
+    assert result.spdxfile.copyright == ""
+    assert not result.bad_licenses
+    assert not result.missing_licenses
+
+
 def test_generate_file_report_exception(fake_repository):
     """Simple generate test to test if the exception is detected."""
     project = Project(fake_repository)

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -169,6 +169,29 @@ def test_generate_project_report_unused_license(
     assert result.unused_licenses == {"MIT"}
 
 
+def test_generate_project_report_unused_license_plus(
+    fake_repository, multiprocessing
+):
+    """Apache-1.0+ is not an unused license if LICENSES/Apache-1.0.txt
+    exists.
+
+    Furthermore, Apache-1.0+ is separately identified as a used license.
+    """
+    (fake_repository / "foo.py").write_text(
+        "SPDX" "-License-Identifier: Apache-1.0+"
+    )
+    (fake_repository / "bar.py").write_text(
+        "SPDX" "-License-Identifier: Apache-1.0"
+    )
+    (fake_repository / "LICENSES/Apache-1.0.txt").touch()
+
+    project = Project(fake_repository)
+    result = ProjectReport.generate(project, multiprocessing=multiprocessing)
+
+    assert not result.unused_licenses
+    assert {"Apache-1.0", "Apache-1.0+"}.issubset(result.used_licenses)
+
+
 def test_generate_project_report_bad_license_in_file(
     fake_repository, multiprocessing
 ):

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -192,6 +192,25 @@ def test_generate_project_report_unused_license_plus(
     assert {"Apache-1.0", "Apache-1.0+"}.issubset(result.used_licenses)
 
 
+def test_generate_project_report_unused_license_plus_only_plus(
+    fake_repository, multiprocessing
+):
+    """If Apache-1.0+ is the only declared license in the project,
+    LICENSES/Apache-1.0.txt should not be an unused license.
+    """
+    (fake_repository / "foo.py").write_text(
+        "SPDX" "-License-Identifier: Apache-1.0+"
+    )
+    (fake_repository / "LICENSES/Apache-1.0.txt").touch()
+
+    project = Project(fake_repository)
+    result = ProjectReport.generate(project, multiprocessing=multiprocessing)
+
+    assert not result.unused_licenses
+    assert "Apache-1.0+" in result.used_licenses
+    assert "Apache-1.0" not in result.used_licenses
+
+
 def test_generate_project_report_bad_license_in_file(
     fake_repository, multiprocessing
 ):


### PR DESCRIPTION
Fixes #123 
Fixes #275 

Example: if `Apache-1.0+` appears as a declared license, it should not be identified as missing, bad, or unused if `LICENSES/Apache-1.0.txt` exists. It is, however, identified separately as a used license.

This does **not** fix all of #123. `GPL-3.0+` and `GPL-3.0-or-later` are (still) recognised as separate licenses. I guess this is kind of in line with how SPDX treats GPL anyway. Do we want to fix this?

Furthermore, this patch allows for weird stuff like `GPL-3.0-or-later+`. I guess we can just ignore that weirdness.