### PR TITLE
Preserve line endings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,8 @@ The versions follow [semantic versioning](https://semver.org).
 - `addheader` now checks whether a file is both readable and writeable instead
   of only writeable. (#241)
 
+- `addheader` now preserves line endings. (#308)
+
 ## 0.12.1 - 2020-12-17
 
 ### Fixed

--- a/src/reuse/_util.py
+++ b/src/reuse/_util.py
@@ -348,3 +348,14 @@ def print_incorrect_spdx_identifier(identifier: str, out=sys.stdout) -> None:
             "SPDX License Identifiers."
         )
     )
+
+
+def detect_line_endings(text: str) -> str:
+    """Return one of '\n', '\r' or '\r\n' depending on the line endings used in
+    *text*. Return os.linesep if there are no line endings.
+    """
+    line_endings = ["\r\n", "\r", "\n"]
+    for line_ending in line_endings:
+        if line_ending in text:
+            return line_ending
+    return os.linesep

--- a/src/reuse/header.py
+++ b/src/reuse/header.py
@@ -45,6 +45,7 @@ from ._util import (
     _determine_license_path,
     _determine_license_suffix_path,
     contains_spdx_info,
+    detect_line_endings,
     extract_spdx_info,
     make_copyright_line,
     spdx_identifier,
@@ -398,8 +399,13 @@ def _add_header_to_file(
             out.write("\n")
             return result
 
-    with path.open("r", encoding="utf-8") as fp:
+    with path.open("r", encoding="utf-8", newline="") as fp:
         text = fp.read()
+
+    # Detect and remember line endings for later conversion.
+    line_ending = detect_line_endings(text)
+    # Normalise line endings.
+    text = text.replace(line_ending, "\n")
 
     try:
         output = find_and_replace_header(
@@ -427,7 +433,7 @@ def _add_header_to_file(
         out.write("\n")
         result = 1
     else:
-        with path.open("w", encoding="utf-8") as fp:
+        with path.open("w", encoding="utf-8", newline=line_ending) as fp:
             fp.write(output)
         # TODO: This may need to be rephrased more elegantly.
         out.write(_("Successfully changed header of {path}").format(path=path))

--- a/src/reuse/header.py
+++ b/src/reuse/header.py
@@ -398,7 +398,7 @@ def _add_header_to_file(
             out.write("\n")
             return result
 
-    with path.open("rt", encoding="utf-8") as fp:
+    with path.open("r", encoding="utf-8") as fp:
         text = fp.read()
 
     try:
@@ -427,7 +427,7 @@ def _add_header_to_file(
         out.write("\n")
         result = 1
     else:
-        with path.open("wt", encoding="utf-8") as fp:
+        with path.open("w", encoding="utf-8") as fp:
             fp.write(output)
         # TODO: This may need to be rephrased more elegantly.
         out.write(_("Successfully changed header of {path}").format(path=path))

--- a/tests/test_main_addheader.py
+++ b/tests/test_main_addheader.py
@@ -8,7 +8,6 @@
 
 # pylint: disable=unused-argument
 
-import os
 from inspect import cleandoc
 
 import pytest
@@ -835,13 +834,15 @@ def test_addheader_force_multi_line_for_c(
     )
 
 
-@pytest.mark.parametrize("line_ending", ["\r\n", "\r", "\n", os.linesep])
+@pytest.mark.parametrize("line_ending", ["\r\n", "\r", "\n"])
 def test_addheader_line_endings(
     empty_directory, stringio, mock_date_today, line_ending
 ):
     """Given a file with a certain type of line ending, preserve it."""
     simple_file = empty_directory / "foo.py"
-    simple_file.write_text(f"hello{line_ending}world")
+    simple_file.write_bytes(
+        line_ending.encode("utf-8").join([b"hello", b"world"])
+    )
 
     result = main(
         [

--- a/tests/test_main_addheader.py
+++ b/tests/test_main_addheader.py
@@ -8,6 +8,7 @@
 
 # pylint: disable=unused-argument
 
+import os
 from inspect import cleandoc
 
 import pytest
@@ -831,4 +832,45 @@ def test_addheader_force_multi_line_for_c(
             foo
             """
         ).replace("spdx", "SPDX")
+    )
+
+
+@pytest.mark.parametrize("line_ending", ["\r\n", "\r", "\n", os.linesep])
+def test_addheader_line_endings(
+    empty_directory, stringio, mock_date_today, line_ending
+):
+    """Given a file with a certain type of line ending, preserve it."""
+    simple_file = empty_directory / "foo.py"
+    simple_file.write_text(f"hello{line_ending}world")
+
+    result = main(
+        [
+            "addheader",
+            "--license",
+            "GPL-3.0-or-later",
+            "--copyright",
+            "Mary Sue",
+            "foo.py",
+        ],
+        out=stringio,
+    )
+
+    assert result == 0
+    with open(simple_file, newline="") as fp:
+        contents = fp.read()
+
+    assert (
+        contents
+        == cleandoc(
+            """
+            # spdx-FileCopyrightText: 2018 Mary Sue
+            #
+            # spdx-License-Identifier: GPL-3.0-or-later
+
+            hello
+            world
+            """
+        )
+        .replace("spdx", "SPDX")
+        .replace("\n", line_ending)
     )

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -380,3 +380,23 @@ def test_similar_spdx_identifiers():
     assert "GPL-3.0-or-later" in result
     assert "AGPL-3.0-or-later" in result
     assert "LGPL-3.0-or-later" in result
+
+
+def test_detect_line_endings_windows():
+    """Given a CRLF string, detect the line endings."""
+    assert _util.detect_line_endings("hello\r\nworld") == "\r\n"
+
+
+def test_detect_line_endings_mac():
+    """Given a CR string, detect the line endings."""
+    assert _util.detect_line_endings("hello\rworld") == "\r"
+
+
+def test_detect_line_endings_linux():
+    """Given a LF string, detect the line endings."""
+    assert _util.detect_line_endings("hello\nworld") == "\n"
+
+
+def test_detect_line_endings_no_newlines():
+    """Given a file without line endings, default to os.linesep."""
+    assert _util.detect_line_endings("hello world") == os.linesep


### PR DESCRIPTION
Fixes #308 

The implementation is rather naive. Approximately:

1. Check whether `\r\n`, `\r`, or `\n` occurs at all in a file, in that order.
2. If yes to any of the above, assume that that's the line ending for the entire file.
3. Convert the string buffer to `\n` line endings for normal use inside of Python.
4. Do REUSE stuff.
5. Convert the string buffer back to the detected line endings when writing to a file.

It works, though.