### PR TITLE
Adjust versioned dependency on python-debian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,8 +64,8 @@ The versions follow [semantic versioning](https://semver.org).
 
 - Fixed a regression where unused licenses were not at all detected. (#285)
 
-- Declared dependency on `python-debian <= 0.1.38`. Later versions of the
-  dependency do not import on Windows. (#310)
+- Declared dependency on `python-debian != 0.1.39` on Windows. This version does
+  not import on Windows. (#310)
 
 - `MANIFEST.in` is now recognised instead of the incorrect `Manifest.in` by
   `addheader`. (#306)

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import glob
+import platform
 import shutil
 import subprocess
 from distutils import cmd
@@ -15,8 +16,10 @@ from setuptools import setup
 from setuptools.command.build_py import build_py
 
 requirements = [
-    # For parsing .reuse/dep5. TODO: Later versions do not work on Windows.
-    "python-debian <= 0.1.38",
+    # For parsing .reuse/dep5.
+    "python-debian"
+    if platform.system() != "Windows"
+    else "python-debian != 0.1.39",
     # For downloading from spdx/spdx-license-list-data. Could maybe use
     # standard library instead?
     "requests",


### PR DESCRIPTION
Fixes #311 

*Technically* we could exclude 0.1.39 only from Windows installs. It works just fine on Linux. That would mess with wheel installs, though.