### PR TITLE
Improve extra Docker image, add a Debian-based

### DIFF
--- a/.github/workflows/pythonpackage.yaml
+++ b/.github/workflows/pythonpackage.yaml
@@ -137,3 +137,15 @@ jobs:
       - name: Run Docker image
         run: |
           docker run -v "$(pwd):/data" reuse
+      - name: Build Dockerfile-extra
+        run: |
+          docker build -t reuse-extra --file Dockerfile-extra .
+      - name: Run Docker extra image
+        run: |
+          docker run -v "$(pwd):/data" reuse-extra
+      - name: Build Dockerfile-debian
+        run: |
+          docker build -t reuse-debian --file Dockerfile-debian .
+      - name: Run Docker debian image
+        run: |
+          docker run -v "$(pwd):/data" reuse-debian

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ The versions follow [semantic versioning](https://semver.org).
 
 - `addheader` ignores case when matching file extensions and names. (#359)
 
+- Provide `latest-debian` as Docker Hub tag, created by `Dockerfile-debian`. (#321)
+
 - More file types are recognised:
 
   - Javascript modules (`.mjs`)

--- a/Dockerfile-debian
+++ b/Dockerfile-debian
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2021 Free Software Foundation Europe e.V. <https://fsfe.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Like normal Dockerfile, but based on python:slim (Debian) to ease compliance
+
+# Create a base image that has dependencies installed.
+FROM python:slim AS base
+
+RUN apt-get update \
+    && apt-get install -y git mercurial \
+    && rm -rf /var/lib/apt/lists/*
+
+# Build reuse into a virtualenv
+FROM base AS build
+
+WORKDIR /reuse-tool
+
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+COPY . /reuse-tool/
+
+RUN pip3 install -r requirements.txt
+RUN pip3 install .
+
+
+# Copy over the virtualenv and use it
+FROM base
+COPY --from=build /opt/venv /opt/venv
+
+ENV VIRTUAL_ENV=/opt/venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+WORKDIR /data
+
+ENTRYPOINT ["reuse"]
+CMD ["lint"]

--- a/Dockerfile-extra
+++ b/Dockerfile-extra
@@ -2,7 +2,36 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-# Use fsfe/reuse:latest as a base, and install additional packages on top
-FROM fsfe/reuse:latest
+# Like normal Dockerfile, but install additional packages on top
 
-RUN apk --no-cache add openssh-client
+# Create a base image that has dependencies installed.
+FROM alpine:3.11 AS base
+
+RUN apk --no-cache add git mercurial python3 openssh-client
+
+# Build reuse into a virtualenv
+FROM base AS build
+
+WORKDIR /reuse-tool
+
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+COPY . /reuse-tool/
+
+RUN pip3 install -r requirements.txt
+RUN pip3 install .
+
+
+# Copy over the virtualenv and use it
+FROM base
+COPY --from=build /opt/venv /opt/venv
+
+ENV VIRTUAL_ENV=/opt/venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+WORKDIR /data
+
+ENTRYPOINT ["reuse"]
+CMD ["lint"]

--- a/README.md
+++ b/README.md
@@ -181,6 +181,14 @@ You can also provide additional arguments, like so:
 docker run --rm --volume $(pwd):/data fsfe/reuse --include-submodules spdx -o out.spdx
 ```
 
+There are a number of tags available:
+- `latest` is the most recent stable release.
+- `dev` follows the `master` branch of this repository. Up-to-date, but
+  potentially unstable.
+- `latest-extra` has a few extra packages installed, currently `openssh-client`.
+- `latest-debian` is based on `python:slim`. It is larger, but may be better
+  suited for license compliance.
+
 ### Run as pre-commit hook
 
 You can automatically run `reuse lint` on every commit as a pre-commit hook for


### PR DESCRIPTION
This makes the tag `latest-extra` build like the normal file with the extra packages, and not use `fsfe/reuse:latest` as base.

Additionally, it creates a new Dockerfile using `python:slim-buster` as base. It's ~200% larger but should be easier to comply with as alpine has its issues in this regard.