### PR TITLE
Fix format call in sdpx_info_of

### DIFF
--- a/src/reuse/project.py
+++ b/src/reuse/project.py
@@ -155,7 +155,7 @@ class Project:
                     _(
                         "'{path}' holds an SPDX expression that cannot be"
                         " parsed, skipping the file"
-                    ).format(path)
+                    ).format(path=path)
                 )
 
         return SpdxInfo(


### PR DESCRIPTION
Hi,

I noticed a little error in one of the calls to format, in `spdx_info_of`.

With the current code, if that call gets executed it will result in a `KeyError` exception.