### PR TITLE
comment: add comment style for devicetree files

### DIFF
--- a/src/reuse/_comment.py
+++ b/src/reuse/_comment.py
@@ -465,6 +465,8 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".d": CCommentStyle,
     ".dart": CCommentStyle,
     ".di": CCommentStyle,
+    ".dts": CCommentStyle,
+    ".dtsi": CCommentStyle,
     ".el": LispCommentStyle,
     ".erl": TexCommentStyle,
     ".ex": PythonCommentStyle,


### PR DESCRIPTION
devicetree files (.dts, and .dtsi) use a C comment style.
Add support for them.

Link: https://www.devicetree.org/

Signed-off-by: Liam Beguin <liambeguin@gmail.com>