### PR TITLE
Explicitly require setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,8 @@ requirements = [
     "Jinja2",
     # Exactly what it says.
     "binaryornot",
+    # For pkg_resources
+    "setuptools",
 ]
 
 test_requirements = ["pytest"]


### PR DESCRIPTION
`reuse/__init__.py` imports pkg_resources