### PR TITLE
Make reuse init reuse info present in pyproject.toml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ Jinja2==2.11.3
 license-expression==1.2
 python-debian==0.1.38
 requests==2.25.1
+toml==0.10.2
 
 setuptools==52.0.0
 setuptools-scm==5.0.1

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,8 @@ requirements = [
     "Jinja2",
     # Exactly what it says.
     "binaryornot",
+    # For reusing info from  pyproject.toml
+    "toml",
 ]
 
 test_requirements = ["pytest"]

--- a/tests/test_main_init.py
+++ b/tests/test_main_init.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: 2021 Chris Wesseling <chris.wesseling@xs4all.nl>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Tests for reuse._main: init"""
+
+from inspect import cleandoc
+
+from reuse._main import main
+
+
+def test_init_complete_pyproject_toml(empty_directory, stringio):
+    """reuse init should use info from pyproject.toml"""
+    repo = empty_directory
+    (repo / "pyproject.toml").write_text(
+        cleandoc(
+            """
+        [project]
+        name = "fake-repo"
+        discription = "Fake Repository"
+        authors = [
+            {name = "Mary Sue", email = "mary.sue@example.com"}
+        ]
+        dynamic = ["classifiers"]
+        license = {text = "GPL-3.0-or-later"}
+        requires-python = ">=3.8"
+        [project.urls]
+        homepage = "https://example.com"
+        """
+        )
+    )
+
+    result = main(["init"], out=stringio)
+    assert result == 0
+    assert "What" not in stringio
+    assert (
+        (repo / ".reuse/dep5").read_text()
+        == cleandoc(
+            """
+            Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+            Upstream-Name: fake-repo
+            Upstream-Contact: Mary Sue <mary.sue@example.com>
+            Source: https://example.com
+
+            # Sample paragraph, commented out:
+            #
+            # Files: src/*
+            # Copyright: $YEAR $NAME <$CONTACT>
+            # License: ...
+            """
+        )
+        + "\n"
+    )


### PR DESCRIPTION
I was using reuse on an existing project and was surprised `reuse init` didn't use the info from pyproject.toml, so I wrote a patch.

  See PEP 621 for the spec:
  https://www.python.org/dev/peps/pep-0621/