### PR TITLE
Allow creating .license file for write-protected files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ The versions follow [semantic versioning](https://semver.org).
 
 - Fix faulty file types:
   - Extensible Stylesheet Language (`.xsl`) actually uses HTML comment syntax
+- Allow creating .license file for write-protected files (#347)
 
 ### Security
 

--- a/src/reuse/header.py
+++ b/src/reuse/header.py
@@ -522,7 +522,7 @@ def add_arguments(parser) -> None:
         action="store_true",
         help=_("skip files with unrecognised comment styles"),
     )
-    parser.add_argument("path", action="store", nargs="+", type=PathType("r+"))
+    parser.add_argument("path", action="store", nargs="+", type=PathType("r"))
 
 
 def run(args, project: Project, out=sys.stdout) -> int:


### PR DESCRIPTION
Fixes #346 

But relaxes a check on all path arguments passed to addheader command.
There are no tests for graceful permission handling yet.

So this is WIP. Just wanted to let people know someone picked up the issue.