### PR TITLE
Optionally determine copyright year via Git

### DIFF
--- a/src/reuse/header.py
+++ b/src/reuse/header.py
@@ -391,9 +391,9 @@ def _add_header_to_file(
     # pylint: disable=too-many-arguments
     result = 0
     if style is not None:
-        style = NAME_STYLE_MAP[style]
+        style: CommentStyle = NAME_STYLE_MAP[style]
     else:
-        style = _get_comment_style(path)
+        style: CommentStyle = _get_comment_style(path)
         if style is None:
             out.write(_("Skipped unrecognised file {path}").format(path=path))
             out.write("\n")


### PR DESCRIPTION
I was looking for a similar functionality as #297 and decided to just code it in to the tool instead of wrapping the python API in another tool. I've split the changes up into two: the first is just an extract-function refactor that is a prerequisite for doing per-file years without code duplication.

I'm using GitPython, though mostly just as a wrapper for finding git and calling it in a nice way, because I couldn't figure out how to get the log "natively" thru git-python, I'm pretty new to using it (this is only my second project using it). It's an optional dependency, the command-line argument "--use-first-commit-year" only shows up if it's loadable.

Right now, I have it set up so that if you pass "--use-first-commit-year", it will use whatever year is earliest, of the earliest author year on the file or the specified/defaulted-to-today year. (It does do --follow, but it checks every commit's date, in case something is out of order for some reason. A loop was cheap and easy and meant I didn't have to think about pipelines across platforms) So if you put the LICENSE year which might be the one from the start of the project, the argument is essentially a no-op since no commits were authored before then  (as happened to me when I was trying this on https://github.com/ValveSoftware/openvr ). I have this marked with TODO because I'm not sure which is the best option.

Fixes #297 