### PR TITLE
add spdx-symbol copyright style

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -75,6 +75,7 @@ With the argument ``--copyright-style`` it is posible to change the default
 .. code-block::
 
   spdx:           SPDX-FileCopyrightText: <year> <statement>
+  spdx-symbol:    SPDX-FileCopyrightText: © <year> <statement>
   string:         Copyright <year> <statement>
   string-c:       Copyright (C) <year> <statement>
   string-symbol:  Copyright © <year> <statement>

--- a/src/reuse/_util.py
+++ b/src/reuse/_util.py
@@ -56,6 +56,7 @@ _COPYRIGHT_PATTERNS = [
 
 _COPYRIGHT_STYLES = {
     "spdx": "SPDX-FileCopyrightText:",
+    "spdx-symbol": "SPDX-FileCopyrightText: ©",
     "string": "Copyright",
     "string-c": "Copyright (C)",
     "string-symbol": "Copyright ©",
@@ -221,7 +222,7 @@ def make_copyright_line(
     copyright_prefix = _COPYRIGHT_STYLES.get(copyright_style)
     if copyright_prefix is None:
         raise RuntimeError(
-            "Unexpected copyright syle: Need 'spdx', 'string', 'string-c',"
+            "Unexpected copyright syle: Need 'spdx', 'spdx-symbol', 'string', 'string-c',"
             "'string-symbol' or 'symbol'"
         )
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -170,6 +170,14 @@ def test_make_copyright_line_style_spdx_year():
     assert statement == "SPDX-FileCopyrightText: 2019 hello"
 
 
+def test_make_copyright_line_style_spdx_symbol_year():
+    """Given a simple statement, style and a year, make it a copyright line."""
+    statement = _util.make_copyright_line(
+        "hello", year=2019, copyright_style="spdx-symbol"
+    )
+    assert statement == "SPDX-FileCopyrightText: © 2019 hello"
+
+
 def test_make_copyright_line_style_string_year():
     """Given a simple statement, style and a year, make it a copyright line."""
     statement = _util.make_copyright_line(


### PR DESCRIPTION
The REUSE FAQ page [here](https://reuse.software/faq/#copyright-symbol) includes the copyright symbol along with the spdx key as a recommended copyright style, giving the following example:
```
SPDX-FileCopyrightText: © 2019 John Doe <joe@example.com>
```
The `addheader` subcommand's `--copyright-style` option takes `spdx` and `symbol` as options which will provide either the spdx key or the copyright symbol respectively, but doesn't have an option for using both together. This adds `spdx-symbol` as an option to do this.

Fixed #329