### PR TITLE
feat: better Gradle files support

### DIFF
--- a/src/reuse/_comment.py
+++ b/src/reuse/_comment.py
@@ -605,6 +605,8 @@ FILENAME_COMMENT_STYLE_MAP = {
     "configure.ac": M4CommentStyle,
     "go.mod": CCommentStyle,
     "go.sum": UncommentableCommentStyle,
+    "gradle-wrapper.properties": PythonCommentStyle,
+    "gradlew": PythonCommentStyle,
     "manifest": PythonCommentStyle,  # used by cdist
     "meson.build": PythonCommentStyle,
     "requirements.txt": PythonCommentStyle,


### PR DESCRIPTION
Improve the Gradle support by adding some more comment files for
`gradle-wrapper.properties` and `gradlew` as suggested in
https://github.com/fsfe/reuse-tool/issues/351

Signed-off-by: Nico Rikken <nico.rikken@alliander.com>