### PR TITLE
feat: support capitalized .XML extension

### DIFF
--- a/src/reuse/_comment.py
+++ b/src/reuse/_comment.py
@@ -574,6 +574,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".tsx": JsxCommentStyle,
     ".vala": CCommentStyle,
     ".xml": HtmlCommentStyle,
+    ".XML": HtmlCommentStyle,
     ".xsh": PythonCommentStyle,
     ".xsl": PythonCommentStyle,
     ".yaml": PythonCommentStyle,


### PR DESCRIPTION
I encountered capitalized .XML extensions rather than the more typical lower
case .xml extensions. This commit adds that support.

Perhaps in the future we should add a property whether capitalization should be
considered or ignored.

Signed-off-by: Nico Rikken <nico.rikken@alliander.com>