### PR TITLE
Support Markdown-linter config file

### DIFF
--- a/src/reuse/_comment.py
+++ b/src/reuse/_comment.py
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: 2020 Dmitry Bogatov
 # SPDX-FileCopyrightText: 2021 Alliander N.V. <https://alliander.com>
 # SPDX-FileCopyrightText: 2021 Alvar Penning
+# SPDX-FileCopyrightText: 2021 Robin Vobruba <hoijui.quaero@gmail.com>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/reuse/_comment.py
+++ b/src/reuse/_comment.py
@@ -593,6 +593,7 @@ FILENAME_COMMENT_STYLE_MAP = {
     ".gitignore": PythonCommentStyle,
     ".gitmodules": PythonCommentStyle,
     ".mailmap": PythonCommentStyle,
+    ".mdlrc": PythonCommentStyle,  # Markdown-linter config
     ".pylintrc": PythonCommentStyle,
     ".Renviron": PythonCommentStyle,
     ".Rprofile": PythonCommentStyle,


### PR DESCRIPTION
This solves #366 .
([previous/deprecated PR](https://github.com/fsfe/reuse-tool/pull/370))