### PR TITLE
Add support for AsciiDoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The versions follow [semantic versioning](https://semver.org).
   - Turtle/RDF (`.ttl`)
   - Nimble (`.nim.cfg`, `.nimble`)
   - Markdown-linter config (`.mdlrc`)
+  - AsciiDoc (`.adoc`, `.asc`, `asciidoc`)
 
 - More file names are recognised:
   - SuperCollider (`archive.sctxar`)

--- a/src/reuse/_comment.py
+++ b/src/reuse/_comment.py
@@ -438,11 +438,14 @@ class UncommentableCommentStyle(EmptyCommentStyle):
 #: A map of (common) file extensions against comment types.
 EXTENSION_COMMENT_STYLE_MAP = {
     ".adb": HaskellCommentStyle,
+    ".adoc": CCommentStyle,
     ".ads": HaskellCommentStyle,
     ".ahk": LispCommentStyle,
     ".ahkl": LispCommentStyle,
     ".applescript": AppleScriptCommentStyle,
     ".asax": AspxCommentStyle,
+    ".asc": CCommentStyle,
+    ".asciidoc": CCommentStyle,
     ".ashx": AspxCommentStyle,
     ".asmx": AspxCommentStyle,
     ".aspx": AspxCommentStyle,


### PR DESCRIPTION
https://docs.asciidoctor.org/asciidoc/latest/comments/

I'm afraid the C comment style only matches partially (multi line is different) but I'm not sure when multi line is chosen. I can also adapt to add a new style.

I chose the extensions that are listed here: https://asciidoctor.org/docs/asciidoc-recommended-practices/#document-extension