### PR TITLE
Vue.js single file component header support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The versions follow [semantic versioning](https://semver.org).
   - Markdown-linter config (`.mdlrc`)
   - AsciiDoc (`.adoc`, `.asc`, `.asciidoc`)
   - Handlebars (`.hbs`)
+  - Vue.js (`.vue`)
 
 - More file names are recognised:
   - SuperCollider (`archive.sctxar`)

--- a/src/reuse/_comment.py
+++ b/src/reuse/_comment.py
@@ -610,6 +610,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".tsx": JsxCommentStyle,
     ".ttl": PythonCommentStyle,  # Turtle/RDF
     ".vala": CCommentStyle,
+    ".vue": HtmlCommentStyle,
     ".xls": UncommentableCommentStyle,
     ".xlsx": UncommentableCommentStyle,
     ".xml": HtmlCommentStyle,


### PR DESCRIPTION
Vue.js single file components are using the HTML comment style, [see Vue.js doc](https://v3.vuejs.org/guide/single-file-component.html#what-about-separation-of-concerns)

closes #395 