### PR TITLE
Revert "Allow creating .license file for write-protected files (#347)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,6 @@ The versions follow [semantic versioning](https://semver.org).
 
 - Fix faulty file types:
   - Extensible Stylesheet Language (`.xsl`) actually uses HTML comment syntax
-- Allow creating .license file for write-protected files (#347)
 
 ### Security
 

--- a/src/reuse/header.py
+++ b/src/reuse/header.py
@@ -522,7 +522,7 @@ def add_arguments(parser) -> None:
         action="store_true",
         help=_("skip files with unrecognised comment styles"),
     )
-    parser.add_argument("path", action="store", nargs="+", type=PathType("r"))
+    parser.add_argument("path", action="store", nargs="+", type=PathType("r+"))
 
 
 def run(args, project: Project, out=sys.stdout) -> int:

--- a/tests/test_main_addheader.py
+++ b/tests/test_main_addheader.py
@@ -8,7 +8,6 @@
 
 # pylint: disable=unused-argument
 
-import stat
 from inspect import cleandoc
 
 import pytest
@@ -655,45 +654,6 @@ def test_addheader_explicit_license_unsupported_filetype(
     """
     simple_file = fake_repository / "foo.txt"
     simple_file.write_text("Preserve this")
-
-    result = main(
-        [
-            "addheader",
-            "--license",
-            "GPL-3.0-or-later",
-            "--copyright",
-            "Mary Sue",
-            "--explicit-license",
-            "foo.txt",
-        ],
-        out=stringio,
-    )
-
-    assert result == 0
-    assert (
-        simple_file.with_name(f"{simple_file.name}.license")
-        .read_text()
-        .strip()
-        == cleandoc(
-            """
-            spdx-FileCopyrightText: 2018 Mary Sue
-
-            spdx-License-Identifier: GPL-3.0-or-later
-            """
-        ).replace("spdx", "SPDX")
-    )
-    assert simple_file.read_text() == "Preserve this"
-
-
-def test_addheader_explicit_license_doesnt_write_to_file(
-    fake_repository, stringio, mock_date_today
-):
-    """Adding a header to a .license file if --explicit-license is given,
-    doesn't require write permission to the file, just the directory.
-    """
-    simple_file = fake_repository / "foo.txt"
-    simple_file.write_text("Preserve this")
-    simple_file.chmod(mode=stat.S_IREAD)
 
     result = main(
         [


### PR DESCRIPTION
There was an regression due to #347 as discussed in #398 This pull requests reverts the merge to restore the working. If we can't get to a working solution in thread #398 this revert can be merged.

This reverts commit d546b1449aea93ac1bffe677e430e1bc004c8435.

Signed-off-by: Nico Rikken <nico@nicorikken.eu>