### PR TITLE
WIP: Verify paths to be writable

### DIFF
--- a/src/reuse/header.py
+++ b/src/reuse/header.py
@@ -15,6 +15,7 @@
 
 import datetime
 import logging
+import os
 import re
 import sys
 from argparse import ArgumentParser
@@ -320,6 +321,16 @@ def _is_uncommentable(path: Path) -> bool:
     return is_uncommentable or is_binary(str(path))
 
 
+def _verify_writable(paths: List[Path], parser: ArgumentParser):
+    for path in paths:
+        if not os.access(path, os.W_OK):
+            parser.error(
+                _(
+                    "'{path}' is not writable, please use --explicit-license"
+                ).format(path=path)
+            )
+
+
 def _verify_paths_line_handling(
     paths: List[Path],
     parser: ArgumentParser,
@@ -553,6 +564,7 @@ def run(args, project: Project, out=sys.stdout) -> int:
 
     # Verify line handling and comment styles before proceeding
     if args.style is None and not args.explicit_license:
+        _verify_writable(paths, args.parser)
         _verify_paths_line_handling(
             paths,
             args.parser,

--- a/tests/test_main_addheader.py
+++ b/tests/test_main_addheader.py
@@ -685,6 +685,30 @@ def test_addheader_explicit_license_unsupported_filetype(
     assert simple_file.read_text() == "Preserve this"
 
 
+def test_addheader_no_access_to_file(
+    fake_repository, stringio, mock_date_today
+):
+    """Adding a header to a file without write permissions and without
+    --explicit-license is given.
+    """
+    simple_file = fake_repository / "foo.txt"
+    simple_file.write_text("Preserve this")
+    simple_file.chmod(mode=stat.S_IREAD)
+
+    with pytest.raises(SystemExit) as e:
+        result = main(
+            [
+                "addheader",
+                "--license",
+                "GPL-3.0-or-later",
+                "--copyright",
+                "Mary Sue",
+                "foo.txt",
+            ],
+            out=stringio
+        )
+
+
 def test_addheader_explicit_license_doesnt_write_to_file(
     fake_repository, stringio, mock_date_today
 ):


### PR DESCRIPTION
To resolve the regression from #347 this code checks if files can
be written and throws an error otherwise.

Signed-off-by: Nico Rikken <nico@nicorikken.eu>