### PR TITLE
Add "supported-licenses" command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ The versions follow [semantic versioning](https://semver.org).
   - SuperCollider (`archive.sctxar`)
 
 - `--quiet` switch to the `lint` command
+- `supported-licenses` command that lists all licenses supported by REUSE
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ short summary:
 
 - `spdx` --- Generate an SPDX Document of all files in the project.
 
+- `supported-licenses` --- Prints all licenses supported by REUSE.
+
 ### Run in Docker
 
 The `fsfe/reuse` Docker image is available on

--- a/src/reuse/_main.py
+++ b/src/reuse/_main.py
@@ -19,6 +19,7 @@ from . import (
     init,
     lint,
     spdx,
+    supported_licenses,
 )
 from ._format import INDENT, fill_all, fill_paragraph
 from ._util import PathType, setup_logging
@@ -205,6 +206,15 @@ def parser() -> argparse.ArgumentParser:
         help=_("print the project's bill of materials in SPDX format"),
     )
 
+    add_command(
+        subparsers,
+        "supported-licenses",
+        supported_licenses.add_arguments,
+        supported_licenses.run,
+        help=_("list all supported SPDX licenses"),
+        aliases=["supported-licences"],
+    )
+
     return parser
 
 
@@ -216,6 +226,7 @@ def add_command(  # pylint: disable=too-many-arguments
     formatter_class=None,
     description: str = None,
     help: str = None,
+    aliases: list = None,
 ) -> None:
     """Add a subparser for a command."""
     if formatter_class is None:
@@ -225,6 +236,7 @@ def add_command(  # pylint: disable=too-many-arguments
         formatter_class=formatter_class,
         description=description,
         help=help,
+        aliases=aliases or [],
     )
     add_arguments_func(subparser)
     subparser.set_defaults(func=run_func)

--- a/src/reuse/supported_licenses.py
+++ b/src/reuse/supported_licenses.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2021 Free Software Foundation Europe e.V. <https://fsfe.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""supported-licenses command handler"""
+
+import sys
+
+from ._licenses import _LICENSES, _load_license_list
+from .project import Project
+
+# pylint: disable=unused-argument
+
+
+def add_arguments(parser) -> None:
+    """Add arguments to the parser."""
+
+
+def run(args, project: Project, out=sys.stdout):
+    """Print the supported SPDX licenses list"""
+
+    licenses = _load_license_list(_LICENSES)[1]
+
+    for license_id, license_info in licenses.items():
+        license_name = license_info["name"]
+        license_reference = license_info["reference"]
+        out.write(
+            "{: <40}\t{: <80}\t{: <50}\n".format(
+                license_id, license_name, license_reference
+            )
+        )
+
+    return 0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -10,6 +10,7 @@
 
 import errno
 import os
+import re
 from pathlib import Path
 from typing import Optional
 from unittest.mock import create_autospec
@@ -260,3 +261,15 @@ def test_download_custom_output_too_many(
         main(
             ["download", "-o", "foo", "0BSD", "GPL-3.0-or-later"], out=stringio
         )
+
+
+def test_supported_licenses(stringio):
+    """Invoke the supported-licenses command and check whether the result
+    contains at least one license in the expected format.
+    """
+
+    assert main(["supported-licenses"], out=stringio) == 0
+    assert re.search(
+        r"GPL-3\.0-or-later\s+GNU General Public License v3\.0 or later\s+https:\/\/spdx\.org\/licenses\/GPL-3\.0-or-later\.html\s+\n",
+        stringio.getvalue(),
+    )


### PR DESCRIPTION
Starting simple:
- new `supported-licenses` command
- prints all supported licences with id, name and reference
  - each one in a single line
  - the fields are tab separate

closes #363