### PR TITLE
message to stderr if output IOErrors in lint

### DIFF
--- a/src/reuse/lint.py
+++ b/src/reuse/lint.py
@@ -334,4 +334,9 @@ def run(args, project: Project, out=sys.stdout):
     )
     result = lint(report, out=out)
 
-    return 0 if result else 1
+    try:
+        result = lint(report, out=out)
+        return 0 if result else 1
+    except BrokenPipeError:
+        print(_('(reuse lint output truncated)'), file = sys.stderr)
+        return 1


### PR DESCRIPTION
This is a specific fix for #266 that only covers the `lint()` output

Written by @fwolfst.