### PR TITLE
Add alt text for README's shields

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 # reuse
 
-[![](https://img.shields.io/pypi/v/reuse.svg)](https://pypi.python.org/pypi/reuse)
-[![](https://img.shields.io/pypi/pyversions/reuse.svg)](https://pypi.python.org/pypi/reuse)
+[![The latest version of reuse can be found on PyPI.](https://img.shields.io/pypi/v/reuse.svg)](https://pypi.python.org/pypi/reuse)
+[![Information on what versions of Python reuse supports can be found on PyPI.](https://img.shields.io/pypi/pyversions/reuse.svg)](https://pypi.python.org/pypi/reuse)
 [![REUSE status](https://api.reuse.software/badge/github.com/fsfe/reuse-tool)](https://api.reuse.software/info/github.com/fsfe/reuse-tool)
-[![](https://img.shields.io/badge/readme_style-standard-brightgreen.svg)](https://github.com/RichardLitt/standard-readme)
+[![readme style standard](https://img.shields.io/badge/readme_style-standard-brightgreen.svg)](https://github.com/RichardLitt/standard-readme)
 
 > reuse is a tool for compliance with the [REUSE](https://reuse.software/)
 > recommendations.


### PR DESCRIPTION
Section 4.8.4.4 of the HTML Standard requires most img elements to have an alt
attribute that isn't empty[1]. Subsections of 4.8.4.4 offer instructions for
what to do in specific scenarios. None of the scenarios exactly match the
shields. Subsection 4.8.4.4.3 seems like the closest match[2], but we don't
know exactly what the shields will say. Subsection 4.8.4.4.2 is also
relevant[3].

1. https://html.spec.whatwg.org/multipage/images.html#alt
2. https://html.spec.whatwg.org/multipage/images.html#a-phrase-or-paragraph-with-an-alternative-graphical-representation:-charts,-diagrams,-graphs,-maps,-illustrations
3. https://html.spec.whatwg.org/multipage/images.html#a-link-or-button-containing-nothing-but-the-image