### PR TITLE
isort: fix CI warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ lint: ## check with pylint
 .PHONY: blackcheck
 blackcheck: ## check with black
 	black --check .
-	isort --check --recursive src/ tests/ *.py
+	isort --check src/ tests/ *.py
 
 .PHONY: black
 black: ## format with black


### PR DESCRIPTION
The --recursive option seems to be deprecated in version 5.0.0.

UserWarning: W0501: The following deprecated CLI flags were used and ignored: --recursive!
UserWarning: W0500: Please see the 5.0.0 Upgrade guide

Since requirements-dev.txt already points to a version more recent that
5.0, drop the CLI option.

Signed-off-by: Liam Beguin <liambeguin@gmail.com>