### PR TITLE
Suggest valid SPDX identifiers based on prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ The versions follow [semantic versioning](https://semver.org).
 
 - `--quiet` switch to the `lint` command
 - `supported-licenses` command that lists all licenses supported by REUSE
+- Better suggestions for faulty SPDX license identifiers in `download` and
+  `init` (#416)
 
 ### Changed
 

--- a/src/reuse/_util.py
+++ b/src/reuse/_util.py
@@ -317,7 +317,7 @@ def similar_spdx_identifiers(identifier: str) -> List[str]:
 
     for valid_identifier in ALL_NON_DEPRECATED_MAP:
         distance = SequenceMatcher(
-            a=identifier.lower(), b=valid_identifier.lower()
+            a=identifier.lower(), b=valid_identifier[: len(identifier)].lower()
         ).ratio()
         if distance > 0.75:
             suggestions.append(valid_identifier)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -381,13 +381,20 @@ def test_decoded_text_from_binary_crlf():
     assert _util.decoded_text_from_binary(BytesIO(encoded)) == "Hello\nworld"
 
 
-def test_similar_spdx_identifiers():
+def test_similar_spdx_identifiers_typo():
     """Given a misspelt SPDX License Identifier, suggest a better one."""
     result = _util.similar_spdx_identifiers("GPL-3.0-or-lter")
 
     assert "GPL-3.0-or-later" in result
     assert "AGPL-3.0-or-later" in result
     assert "LGPL-3.0-or-later" in result
+
+
+def test_similar_spdx_identifiers_prefix():
+    """Given a misspelt SPDX License Identifier, suggest a better one."""
+    result = _util.similar_spdx_identifiers("CC0")
+
+    assert "CC0-1.0" in result
 
 
 def test_detect_line_endings_windows():

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -391,7 +391,7 @@ def test_similar_spdx_identifiers_typo():
 
 
 def test_similar_spdx_identifiers_prefix():
-    """Given a misspelt SPDX License Identifier, suggest a better one."""
+    """Given an incomplete SPDX License Identifier, suggest a better one."""
     result = _util.similar_spdx_identifiers("CC0")
 
     assert "CC0-1.0" in result


### PR DESCRIPTION
Related to #364. Entering invalid identifiers like `CC0` and `GPL` will now suggest valid identifiers which start with the inputted string while typos are still detected as before.