### PR TITLE
Add hyperlinks for GNU Guix and NixOS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ welcome to help us package this tool for more distributions!
 - Arch Linux: [reuse](https://archlinux.org/packages/community/any/reuse/)
 - Fedora: [reuse](https://apps.fedoraproject.org/packages/reuse)
 - openSUSE: [reuse](https://software.opensuse.org/package/reuse)
-- GNU Guix: [reuse](https://guix.gnu.org/packages/reuse-0.5.0/)
-- NixOS: [reuse](https://nixos.org/nixos/packages.html?attr=reuse)
+- GNU Guix: [reuse](https://guix.gnu.org/packages/reuse-0.13.0/)
+- NixOS: [reuse](https://search.nixos.org/packages?channel=21.05&from=0&size=50&sort=relevance&type=packages&query=reuse)
 
 ### Installation from source
 


### PR DESCRIPTION
The previous links were not working or showing 404 or simply redirected to a page which was not relevant anymore.
So just adding two new links.