### PR TITLE
Add isort to pre commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,18 @@ repos:
     rev: stable
     hooks:
       - id: black
+  - repo: https://github.com/pycqa/isort
+    rev: 5.9.3
+    hooks:
+      - id: isort
+        name: isort (python)
+        types: [python]
+      - id: isort
+        name: isort (cython)
+        types: [cython]
+      - id: isort
+        name: isort (pyi)
+        types: [pyi]
   - repo: local
     hooks:
       - id: pylint


### PR DESCRIPTION
When working on #418, one of my commits tripped on isort in CI. This should prevent this from happening in the future.