### PR TITLE
Add support for meson_options.txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ The versions follow [semantic versioning](https://semver.org).
   - NPM ignore (`.npmignore`)
   - Yarn package manager (`.yarn.lock` and `.yarnrc`)
   - Podman container files (`Containerfile`)
+  - Meson options file (`meson_options.txt`)
 
 - `--quiet` switch to the `lint` command
 - `supported-licenses` command that lists all licenses supported by REUSE

--- a/src/reuse/_comment.py
+++ b/src/reuse/_comment.py
@@ -677,6 +677,7 @@ FILENAME_COMMENT_STYLE_MAP = {
     "MANIFEST.in": PythonCommentStyle,
     "manifest": PythonCommentStyle,  # used by cdist
     "meson.build": PythonCommentStyle,
+    "meson_options.txt": PythonCommentStyle,
     "Rakefile": PythonCommentStyle,
     "requirements.txt": PythonCommentStyle,
     "ROOT": MlCommentStyle,


### PR DESCRIPTION
We added support for meson.build file in #251 but we need also to
support meson_options.txt[1], used to add build options.

[1] https://mesonbuild.com/Build-options.html

Fixes #445.