### PR TITLE
Support Containerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ The versions follow [semantic versioning](https://semver.org).
   - ESLint (`.eslintignore` and `.eslintrc`)
   - NPM ignore (`.npmignore`)
   - Yarn package manager (`.yarn.lock` and `.yarnrc`)
+  - Podman container files (`Containerfile`)
 
 - `--quiet` switch to the `lint` command
 - `supported-licenses` command that lists all licenses supported by REUSE

--- a/src/reuse/_comment.py
+++ b/src/reuse/_comment.py
@@ -662,8 +662,8 @@ FILENAME_COMMENT_STYLE_MAP = {
     ".yarnrc": PythonCommentStyle,
     "archive.sctxar": UncommentableCommentStyle,  # SuperCollider global archive
     "CMakeLists.txt": PythonCommentStyle,
-    "Containerfile": PythonCommentStyle,
     "configure.ac": M4CommentStyle,
+    "Containerfile": PythonCommentStyle,
     "Dockerfile": PythonCommentStyle,
     "Doxyfile": PythonCommentStyle,
     "Gemfile": PythonCommentStyle,

--- a/src/reuse/_comment.py
+++ b/src/reuse/_comment.py
@@ -662,6 +662,7 @@ FILENAME_COMMENT_STYLE_MAP = {
     ".yarnrc": PythonCommentStyle,
     "archive.sctxar": UncommentableCommentStyle,  # SuperCollider global archive
     "CMakeLists.txt": PythonCommentStyle,
+    "Containerfile": PythonCommentStyle,
     "configure.ac": M4CommentStyle,
     "Dockerfile": PythonCommentStyle,
     "Doxyfile": PythonCommentStyle,


### PR DESCRIPTION
The podman tool supports now both Containerfile and Dockerfile. This is
another name for the same file format.

Fixes #447.