### PR TITLE
Don't depend on distutils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,23 @@ The versions follow [semantic versioning](https://semver.org).
 ### Security
 -->
 
+## Unreleased - YYYY-MM-DD
+
+### Added
+
+### Changed
+
+- Use `setuptools` instead of the deprecated `distutils` which will be removed
+  with Python 3.12 (#451)
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
 ## 0.14.0 - 2021-12-27
 
 Happy holidays! This is mainly a maintenance release fixing some subcommands and

--- a/setup.py
+++ b/setup.py
@@ -8,11 +8,10 @@ import glob
 import platform
 import shutil
 import subprocess
-from distutils import cmd
 from pathlib import Path
 from warnings import warn
 
-from setuptools import setup
+from setuptools import setup, Command
 from setuptools.command.build_py import build_py
 
 requirements = [
@@ -53,7 +52,7 @@ def changelog_md():
     return open("CHANGELOG.md").read()
 
 
-class BuildTrans(cmd.Command):
+class BuildTrans(Command):
     """Command for compiling the .mo files."""
 
     user_options = []

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import subprocess
 from pathlib import Path
 from warnings import warn
 
-from setuptools import setup, Command
+from setuptools import Command, setup
 from setuptools.command.build_py import build_py
 
 requirements = [


### PR DESCRIPTION
distutils is going away soon, and the reuse tool's `setup.py` depends on it for the `cmd.Command` class. Fortunately, setuptools vendors `distutils.cmd.Command` as `setuptools.Command`, and has for a long time. (I checked as far back as setuptools 49; it was already there.)

Fixes #450 
