### PR TITLE
add encoding to open() calls

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,12 +45,12 @@ fallback_version = "0.14.0"
 
 def readme_md():
     """Return contents of README.md"""
-    return open("README.md").read()
+    return open("README.md", encoding="utf-8").read()
 
 
 def changelog_md():
     """Return contents of CHANGELOG.md"""
-    return open("CHANGELOG.md").read()
+    return open("CHANGELOG.md", encoding="utf-8").read()
 
 
 class BuildTrans(cmd.Command):

--- a/src/reuse/_licenses.py
+++ b/src/reuse/_licenses.py
@@ -24,7 +24,7 @@ def _load_license_list(file_name):
     from https://github.com/spdx/license-list-data
     """
     licenses_map = {}
-    with open(file_name, "r") as lics:
+    with open(file_name, "r", encoding="utf-8") as lics:
         licenses = json.load(lics)
         version = licenses["licenseListVersion"].split(".")
         for lic in licenses["licenses"]:
@@ -39,7 +39,7 @@ def _load_exception_list(file_name):
     from https://github.com/spdx/license-list-data
     """
     exceptions_map = {}
-    with open(file_name, "r") as excs:
+    with open(file_name, "r", encoding="utf-8") as excs:
         exceptions = json.load(excs)
         version = exceptions["licenseListVersion"].split(".")
         for exc in exceptions["exceptions"]:

--- a/src/reuse/_util.py
+++ b/src/reuse/_util.py
@@ -239,7 +239,7 @@ def _checksum(path: PathLike) -> str:
     path = Path(path)
 
     file_sha1 = sha1()
-    with path.open("rb") as fp:
+    with path.open("rb", encoding="utf-8") as fp:
         for chunk in iter(lambda: fp.read(128 * file_sha1.block_size), b""):
             file_sha1.update(chunk)
 

--- a/src/reuse/download.py
+++ b/src/reuse/download.py
@@ -72,7 +72,7 @@ def put_license_in_file(spdx_identifier: str, destination: PathLike) -> None:
         raise FileExistsError(errno.EEXIST, "File exists", str(destination))
 
     text = download_license(spdx_identifier)
-    with destination.open("w") as fp:
+    with destination.open("w", encoding="utf-8") as fp:
         fp.write(header)
         fp.write(text)
 

--- a/src/reuse/project.py
+++ b/src/reuse/project.py
@@ -145,7 +145,7 @@ class Project:
                 )
 
         # Search the file for SPDX information.
-        with path.open("rb") as fp:
+        with path.open("rb", encoding="utf-8") as fp:
             try:
                 file_result = extract_spdx_info(
                     decoded_text_from_binary(fp, size=_HEADER_BYTES)

--- a/src/reuse/project.py
+++ b/src/reuse/project.py
@@ -215,12 +215,15 @@ class Project:
         if self._copyright_val == 0:
             copyright_path = self.root / ".reuse/dep5"
             try:
-                with copyright_path.open() as fp:
+                with copyright_path.open(encoding="utf-8") as fp:
                     self._copyright_val = Copyright(fp)
             except OSError:
                 _LOGGER.debug("no .reuse/dep5 file, or could not read it")
             except DebianError:
                 _LOGGER.exception(_(".reuse/dep5 has syntax errors"))
+            except UnicodeError as err:
+                _LOGGER.exception(_(".reuse/dep5 reading aborted with unicode / utf-8 issue"))
+                _LOGGER.exception(err)
 
             # This check is a bit redundant, but otherwise I'd have to repeat
             # this line under each exception.

--- a/src/reuse/report.py
+++ b/src/reuse/report.py
@@ -169,7 +169,7 @@ class ProjectReport:  # pylint: disable=too-many-instance-attributes
                 out.write(f"LicenseID: {lic}\n")
                 out.write("LicenseName: NOASSERTION\n")
 
-                with (Path(self.path) / path).open() as fp:
+                with (Path(self.path) / path).open(encoding="utf-8") as fp:
                     out.write(f"ExtractedText: <text>{fp.read()}</text>\n")
 
         return out.getvalue()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -260,7 +260,7 @@ def submodule_repository(
 @pytest.fixture(scope="session")
 def copyright():
     """Create a dep5 Copyright object."""
-    with (RESOURCES_DIRECTORY / "fake_repository/.reuse/dep5").open() as fp:
+    with (RESOURCES_DIRECTORY / "fake_repository/.reuse/dep5").open(encoding="utf-8") as fp:
         return Copyright(fp)
 
 

--- a/tests/test_main_addheader.py
+++ b/tests/test_main_addheader.py
@@ -921,7 +921,7 @@ def test_addheader_line_endings(
     )
 
     assert result == 0
-    with open(simple_file, newline="") as fp:
+    with open(simple_file, newline="", encoding="utf-8") as fp:
         contents = fp.read()
 
     assert (


### PR DESCRIPTION
This PR contains two commits.

https://github.com/fsfe/reuse-tool/commit/94226e9d4d836ab3770483627bc76580442ad373 fixes the issue described in https://github.com/fsfe/reuse-tool/issues/454

https://github.com/fsfe/reuse-tool/commit/f168ccd3dfec313f9abb183bf92f893a7e007509 adds encoding to all `open()` that I found via grep (ignoring 2 cases that are definitely not relevant).

It may also be good to add tests for that issue, but adding such tests is not trivial because we need to mock and manipulate some system specific stuff. I do not know the code base of the reuse tool well enough to implement this.