### PR TITLE
Recommend installation via pipx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ The versions follow [semantic versioning](https://semver.org).
 
 ### Added
 
+- Recommendations for installation/run methods: package managers and pipx (#457)
+
 ### Changed
 
 - Use `setuptools` instead of the deprecated `distutils` which will be removed

--- a/README.md
+++ b/README.md
@@ -82,7 +82,10 @@ guarantee for completeness.
 
 ### Run via pipx (Recommended)
 
-The following one-liner both installs and runs this tool from [PyPI](https://pypi.org/project/reuse/) via [pipx](https://pypa.github.io/pipx/):
+The following one-liner both installs and runs this tool from
+[PyPI](https://pypi.org/project/reuse/) via
+[pipx](https://pypa.github.io/pipx/):
+
 ```bash
 pipx run reuse lint
 ```

--- a/README.md
+++ b/README.md
@@ -63,14 +63,7 @@ In this screencast, we are going to follow the
 
 ## Install
 
-### Run via pipx
-
-The following one-liner both installs and runs this tool from [PyPI](https://pypi.org/project/reuse/) via [pipx](https://pypa.github.io/pipx/):
-```bash
-pipx run reuse lint
-```
-
-### Installation via package managers
+### Installation via package managers (Recommended)
 
 There are packages available for easy install on some operating systems. You are
 welcome to help us package this tool for more distributions!
@@ -86,6 +79,13 @@ welcome to help us package this tool for more distributions!
 An automatically generated list can be found at
 [repology.org](https://repology.org/project/reuse/versions), without any
 guarantee for completeness.
+
+### Run via pipx (Recommended)
+
+The following one-liner both installs and runs this tool from [PyPI](https://pypi.org/project/reuse/) via [pipx](https://pypa.github.io/pipx/):
+```bash
+pipx run reuse lint
+```
 
 ### Installation via pip
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ In this screencast, we are going to follow the
 
 ## Install
 
+### Run via pipx
+
+The following one-liner both installs and runs this tool from [PyPI](https://pypi.org/project/reuse/) via [pipx](https://pypa.github.io/pipx/):
+```bash
+pipx run reuse lint
+```
+
 ### Installation via package managers
 
 There are packages available for easy install on some operating systems. You are


### PR DESCRIPTION
Managing python, pip and virtual environments can be too much work sometimes especially for a project that is not itself written in python. pipx is a convenient shortcut, but people unfamiliar with the python ecosystem might not even know it exists. To mitigate this I have added an example of running your tool via pipx to your readme.