### PR TITLE
Rename Mary Sue to Jane Doe

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -46,6 +46,7 @@ Contributors
 
 - Tuomas Siipola
 
+- Gri-ffin <gameshunter359@gmail.com>
 
 Translators
 -----------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,12 +104,12 @@ def fake_repository(tmpdir_factory) -> Path:
 
     # Adding this here to avoid conflict in main project.
     (directory / "src/exception.py").write_text(
-        "SPDX-FileCopyrightText: 2017 Mary Sue\n"
+        "SPDX-FileCopyrightText: 2017 Jane Doe\n"
         "SPDX"
         "-License-Identifier: GPL-3.0-or-later WITH Autoconf-exception-3.0"
     )
     (directory / "src/custom.py").write_text(
-        "SPDX-FileCopyrightText: 2017 Mary Sue\n"
+        "SPDX-FileCopyrightText: 2017 Jane Doe\n"
         "SPDX"
         "-License-Identifier: LicenseRef-custom"
     )
@@ -132,7 +132,7 @@ def _repo_contents(
         "# SPDX"
         "-License-Identifier: CC0-1.0\n"
         "# SPDX"
-        "-FileCopyrightText: 2017 Mary Sue\n"
+        "-FileCopyrightText: 2017 Jane Doe\n"
         "*.pyc\nbuild"
     )
     (fake_repository / ignore_filename).write_text(gitignore)

--- a/tests/resources/fake_repository/.reuse/dep5
+++ b/tests/resources/fake_repository/.reuse/dep5
@@ -1,8 +1,8 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: Some project
-Upstream-Contact: Mary Sue
+Upstream-Contact: Jane Doe
 Source: https://example.com/
 
 Files: doc/*
-Copyright: 2017 Mary Sue
+Copyright: 2017 Jane Doe
 License: CC0-1.0

--- a/tests/resources/fake_repository/src/source_code.c
+++ b/tests/resources/fake_repository/src/source_code.c
@@ -1,4 +1,4 @@
-/* SPDX-FileCopyrightText: 2017 Mary Sue */
+/* SPDX-FileCopyrightText: 2017 Jane Doe */
 
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 

--- a/tests/resources/fake_repository/src/source_code.html
+++ b/tests/resources/fake_repository/src/source_code.html
@@ -1,4 +1,4 @@
-<!-- SPDX-FileCopyrightText: 2017 Mary Sue -->
+<!-- SPDX-FileCopyrightText: 2017 Jane Doe -->
 <!-- SPDX-License-Identifier: GPL-3.0-or-later -->
 
 <p>Hello, world!</p>

--- a/tests/resources/fake_repository/src/source_code.jinja2
+++ b/tests/resources/fake_repository/src/source_code.jinja2
@@ -1,4 +1,4 @@
-{# SPDX-FileCopyrightText: 2017 Mary Sue #}
+{# SPDX-FileCopyrightText: 2017 Jane Doe #}
 {# SPDX-License-Identifier: GPL-3.0-or-later #}
 
 <p>Hello, world!</p>

--- a/tests/resources/fake_repository/src/source_code.py
+++ b/tests/resources/fake_repository/src/source_code.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017 Mary Sue
+# SPDX-FileCopyrightText: 2017 Jane Doe
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -24,11 +24,11 @@ from reuse.header import (
 def test_create_header_simple():
     """Create a super simple header."""
     spdx_info = SpdxInfo(
-        {"GPL-3.0-or-later"}, {"SPDX" "-FileCopyrightText: Mary Sue"}
+        {"GPL-3.0-or-later"}, {"SPDX" "-FileCopyrightText: Jane Doe"}
     )
     expected = cleandoc(
         """
-        # spdx-FileCopyrightText: Mary Sue
+        # spdx-FileCopyrightText: Jane Doe
         #
         # spdx-License-Identifier: GPL-3.0-or-later
         """
@@ -40,13 +40,13 @@ def test_create_header_simple():
 def test_create_header_template_simple(template_simple):
     """Create a header with a simple template."""
     spdx_info = SpdxInfo(
-        {"GPL-3.0-or-later"}, {"SPDX" "-FileCopyrightText: Mary Sue"}
+        {"GPL-3.0-or-later"}, {"SPDX" "-FileCopyrightText: Jane Doe"}
     )
     expected = cleandoc(
         """
         # Hello, world!
         #
-        # spdx-FileCopyrightText: Mary Sue
+        # spdx-FileCopyrightText: Jane Doe
         #
         # spdx-License-Identifier: GPL-3.0-or-later
         """
@@ -60,7 +60,7 @@ def test_create_header_template_simple(template_simple):
 def test_create_header_template_no_spdx(template_no_spdx):
     """Create a header with a template that does not have all SPDX info."""
     spdx_info = SpdxInfo(
-        {"GPL-3.0-or-later"}, {"SPDX" "-FileCopyrightText: Mary Sue"}
+        {"GPL-3.0-or-later"}, {"SPDX" "-FileCopyrightText: Jane Doe"}
     )
 
     with pytest.raises(MissingSpdxInfo):
@@ -70,13 +70,13 @@ def test_create_header_template_no_spdx(template_no_spdx):
 def test_create_header_template_commented(template_commented):
     """Create a header with an already-commented template."""
     spdx_info = SpdxInfo(
-        {"GPL-3.0-or-later"}, {"SPDX" "-FileCopyrightText: Mary Sue"}
+        {"GPL-3.0-or-later"}, {"SPDX" "-FileCopyrightText: Jane Doe"}
     )
     expected = cleandoc(
         """
         # Hello, world!
         #
-        # spdx-FileCopyrightText: Mary Sue
+        # spdx-FileCopyrightText: Jane Doe
         #
         # spdx-License-Identifier: GPL-3.0-or-later
         """
@@ -96,7 +96,7 @@ def test_create_header_template_commented(template_commented):
 def test_create_header_already_contains_spdx():
     """Create a new header from a header that already contains SPDX info."""
     spdx_info = SpdxInfo(
-        {"GPL-3.0-or-later"}, {"SPDX" "-FileCopyrightText: Mary Sue"}
+        {"GPL-3.0-or-later"}, {"SPDX" "-FileCopyrightText: Jane Doe"}
     )
     existing = cleandoc(
         """
@@ -108,7 +108,7 @@ def test_create_header_already_contains_spdx():
     expected = cleandoc(
         """
         # spdx-FileCopyrightText: John Doe
-        # spdx-FileCopyrightText: Mary Sue
+        # spdx-FileCopyrightText: Jane Doe
         #
         # spdx-License-Identifier: GPL-3.0-or-later
         # spdx-License-Identifier: MIT
@@ -121,7 +121,7 @@ def test_create_header_already_contains_spdx():
 def test_create_header_existing_is_wrong():
     """If the existing header contains errors, raise a CommentCreateError."""
     spdx_info = SpdxInfo(
-        {"GPL-3.0-or-later"}, {"SPDX" "-FileCopyrightText: Mary Sue"}
+        {"GPL-3.0-or-later"}, {"SPDX" "-FileCopyrightText: Jane Doe"}
     )
     existing = cleandoc(
         """
@@ -180,12 +180,12 @@ def test_create_header_remove_fluff():
 def test_find_and_replace_no_header():
     """Given text without header, add a header."""
     spdx_info = SpdxInfo(
-        {"GPL-3.0-or-later"}, {"SPDX" "-FileCopyrightText: Mary Sue"}
+        {"GPL-3.0-or-later"}, {"SPDX" "-FileCopyrightText: Jane Doe"}
     )
     text = "pass"
     expected = cleandoc(
         """
-        # spdx-FileCopyrightText: Mary Sue
+        # spdx-FileCopyrightText: Jane Doe
         #
         # spdx-License-Identifier: GPL-3.0-or-later
 
@@ -201,7 +201,7 @@ def test_find_and_replace_verbatim():
     spdx_info = SpdxInfo(set(), set())
     text = cleandoc(
         """
-        # spdx-FileCopyrightText: Mary Sue
+        # spdx-FileCopyrightText: Jane Doe
         #
         # spdx-License-Identifier: GPL-3.0-or-later
 
@@ -217,7 +217,7 @@ def test_find_and_replace_newline_before_header():
     preceding whitespace.
     """
     spdx_info = SpdxInfo(
-        {"GPL-3.0-or-later"}, {"SPDX" "-FileCopyrightText: Mary Sue"}
+        {"GPL-3.0-or-later"}, {"SPDX" "-FileCopyrightText: Jane Doe"}
     )
     text = cleandoc(
         """
@@ -230,7 +230,7 @@ def test_find_and_replace_newline_before_header():
     expected = cleandoc(
         """
         # spdx-FileCopyrightText: Jane Doe
-        # spdx-FileCopyrightText: Mary Sue
+        # spdx-FileCopyrightText: Jane Doe
         #
         # spdx-License-Identifier: GPL-3.0-or-later
 
@@ -244,7 +244,7 @@ def test_find_and_replace_newline_before_header():
 def test_find_and_replace_preserve_preceding():
     """When the SPDX header is in the middle of the file, keep it there."""
     spdx_info = SpdxInfo(
-        {"GPL-3.0-or-later"}, {"SPDX" "-FileCopyrightText: Mary Sue"}
+        {"GPL-3.0-or-later"}, {"SPDX" "-FileCopyrightText: Jane Doe"}
     )
     text = cleandoc(
         """
@@ -266,7 +266,7 @@ def test_find_and_replace_preserve_preceding():
             return bar
 
         # spdx-FileCopyrightText: Jane Doe
-        # spdx-FileCopyrightText: Mary Sue
+        # spdx-FileCopyrightText: Jane Doe
         #
         # spdx-License-Identifier: GPL-3.0-or-later
 
@@ -282,7 +282,7 @@ def test_find_and_replace_keep_shebang():
     it.
     """
     spdx_info = SpdxInfo(
-        {"GPL-3.0-or-later"}, {"SPDX" "-FileCopyrightText: Mary Sue"}
+        {"GPL-3.0-or-later"}, {"SPDX" "-FileCopyrightText: Jane Doe"}
     )
     text = cleandoc(
         """
@@ -298,7 +298,7 @@ def test_find_and_replace_keep_shebang():
         #!/usr/bin/env python3
 
         # spdx-FileCopyrightText: Jane Doe
-        # spdx-FileCopyrightText: Mary Sue
+        # spdx-FileCopyrightText: Jane Doe
         #
         # spdx-License-Identifier: GPL-3.0-or-later
 
@@ -371,7 +371,7 @@ def test_find_and_replace_keep_old_comment():
     licensing information, preserve it below the REUSE header.
     """
     spdx_info = SpdxInfo(
-        {"GPL-3.0-or-later"}, {"SPDX" "-FileCopyrightText: Mary Sue"}
+        {"GPL-3.0-or-later"}, {"SPDX" "-FileCopyrightText: Jane Doe"}
     )
     text = cleandoc(
         """
@@ -382,7 +382,7 @@ def test_find_and_replace_keep_old_comment():
     ).replace("spdx", "SPDX")
     expected = cleandoc(
         """
-        # spdx-FileCopyrightText: Mary Sue
+        # spdx-FileCopyrightText: Jane Doe
         #
         # spdx-License-Identifier: GPL-3.0-or-later
 
@@ -402,7 +402,7 @@ def test_find_and_replace_preserve_newline():
     text = (
         cleandoc(
             """
-            # spdx-FileCopyrightText: Mary Sue
+            # spdx-FileCopyrightText: Jane Doe
             #
             # spdx-License-Identifier: GPL-3.0-or-later
 

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -107,8 +107,8 @@ def test_create_header_already_contains_spdx():
     ).replace("spdx", "SPDX")
     expected = cleandoc(
         """
-        # spdx-FileCopyrightText: John Doe
         # spdx-FileCopyrightText: Jane Doe
+        # spdx-FileCopyrightText: John Doe
         #
         # spdx-License-Identifier: GPL-3.0-or-later
         # spdx-License-Identifier: MIT
@@ -217,7 +217,7 @@ def test_find_and_replace_newline_before_header():
     preceding whitespace.
     """
     spdx_info = SpdxInfo(
-        {"GPL-3.0-or-later"}, {"SPDX" "-FileCopyrightText: Jane Doe"}
+        {"GPL-3.0-or-later"}, {"SPDX" "-FileCopyrightText: John Doe"}
     )
     text = cleandoc(
         """
@@ -230,7 +230,7 @@ def test_find_and_replace_newline_before_header():
     expected = cleandoc(
         """
         # spdx-FileCopyrightText: Jane Doe
-        # spdx-FileCopyrightText: Jane Doe
+        # spdx-FileCopyrightText: John Doe
         #
         # spdx-License-Identifier: GPL-3.0-or-later
 
@@ -244,7 +244,7 @@ def test_find_and_replace_newline_before_header():
 def test_find_and_replace_preserve_preceding():
     """When the SPDX header is in the middle of the file, keep it there."""
     spdx_info = SpdxInfo(
-        {"GPL-3.0-or-later"}, {"SPDX" "-FileCopyrightText: Jane Doe"}
+        {"GPL-3.0-or-later"}, {"SPDX" "-FileCopyrightText: John Doe"}
     )
     text = cleandoc(
         """
@@ -266,7 +266,7 @@ def test_find_and_replace_preserve_preceding():
             return bar
 
         # spdx-FileCopyrightText: Jane Doe
-        # spdx-FileCopyrightText: Jane Doe
+        # spdx-FileCopyrightText: John Doe
         #
         # spdx-License-Identifier: GPL-3.0-or-later
 
@@ -282,7 +282,7 @@ def test_find_and_replace_keep_shebang():
     it.
     """
     spdx_info = SpdxInfo(
-        {"GPL-3.0-or-later"}, {"SPDX" "-FileCopyrightText: Jane Doe"}
+        {"GPL-3.0-or-later"}, {"SPDX" "-FileCopyrightText: John Doe"}
     )
     text = cleandoc(
         """
@@ -298,7 +298,7 @@ def test_find_and_replace_keep_shebang():
         #!/usr/bin/env python3
 
         # spdx-FileCopyrightText: Jane Doe
-        # spdx-FileCopyrightText: Jane Doe
+        # spdx-FileCopyrightText: John Doe
         #
         # spdx-License-Identifier: GPL-3.0-or-later
 

--- a/tests/test_main_addheader.py
+++ b/tests/test_main_addheader.py
@@ -28,7 +28,7 @@ def test_addheader_simple(fake_repository, stringio, mock_date_today):
             "--license",
             "GPL-3.0-or-later",
             "--copyright",
-            "Mary Sue",
+            "Jane Doe",
             "foo.py",
         ],
         out=stringio,
@@ -39,7 +39,7 @@ def test_addheader_simple(fake_repository, stringio, mock_date_today):
         simple_file.read_text()
         == cleandoc(
             """
-            # spdx-FileCopyrightText: 2018 Mary Sue
+            # spdx-FileCopyrightText: 2018 Jane Doe
             #
             # spdx-License-Identifier: GPL-3.0-or-later
 
@@ -62,7 +62,7 @@ def test_addheader_year(fake_repository, stringio):
             "--license",
             "GPL-3.0-or-later",
             "--copyright",
-            "Mary Sue",
+            "Jane Doe",
             "foo.py",
         ],
         out=stringio,
@@ -73,7 +73,7 @@ def test_addheader_year(fake_repository, stringio):
         simple_file.read_text()
         == cleandoc(
             """
-            # spdx-FileCopyrightText: 2016 Mary Sue
+            # spdx-FileCopyrightText: 2016 Jane Doe
             #
             # spdx-License-Identifier: GPL-3.0-or-later
 
@@ -95,7 +95,7 @@ def test_addheader_no_year(fake_repository, stringio):
             "--license",
             "GPL-3.0-or-later",
             "--copyright",
-            "Mary Sue",
+            "Jane Doe",
             "foo.py",
         ],
         out=stringio,
@@ -106,7 +106,7 @@ def test_addheader_no_year(fake_repository, stringio):
         simple_file.read_text()
         == cleandoc(
             """
-            # spdx-FileCopyrightText: Mary Sue
+            # spdx-FileCopyrightText: Jane Doe
             #
             # spdx-License-Identifier: GPL-3.0-or-later
 
@@ -127,7 +127,7 @@ def test_addheader_specify_style(fake_repository, stringio, mock_date_today):
             "--license",
             "GPL-3.0-or-later",
             "--copyright",
-            "Mary Sue",
+            "Jane Doe",
             "--style",
             "c",
             "foo.py",
@@ -140,7 +140,7 @@ def test_addheader_specify_style(fake_repository, stringio, mock_date_today):
         simple_file.read_text()
         == cleandoc(
             """
-            // spdx-FileCopyrightText: 2018 Mary Sue
+            // spdx-FileCopyrightText: 2018 Jane Doe
             //
             // spdx-License-Identifier: GPL-3.0-or-later
 
@@ -161,7 +161,7 @@ def test_addheader_implicit_style(fake_repository, stringio, mock_date_today):
             "--license",
             "GPL-3.0-or-later",
             "--copyright",
-            "Mary Sue",
+            "Jane Doe",
             "foo.js",
         ],
         out=stringio,
@@ -172,7 +172,7 @@ def test_addheader_implicit_style(fake_repository, stringio, mock_date_today):
         simple_file.read_text()
         == cleandoc(
             """
-            // spdx-FileCopyrightText: 2018 Mary Sue
+            // spdx-FileCopyrightText: 2018 Jane Doe
             //
             // spdx-License-Identifier: GPL-3.0-or-later
 
@@ -195,7 +195,7 @@ def test_addheader_implicit_style_filename(
             "--license",
             "GPL-3.0-or-later",
             "--copyright",
-            "Mary Sue",
+            "Jane Doe",
             "Makefile",
         ],
         out=stringio,
@@ -206,7 +206,7 @@ def test_addheader_implicit_style_filename(
         simple_file.read_text()
         == cleandoc(
             """
-            # spdx-FileCopyrightText: 2018 Mary Sue
+            # spdx-FileCopyrightText: 2018 Jane Doe
             #
             # spdx-License-Identifier: GPL-3.0-or-later
 
@@ -228,7 +228,7 @@ def test_addheader_unrecognised_style(fake_repository):
                 "--license",
                 "GPL-3.0-or-later",
                 "--copyright",
-                "Mary Sue",
+                "Jane Doe",
                 "foo.foo",
             ]
         )
@@ -245,7 +245,7 @@ def test_addheader_skip_unrecognised(fake_repository, stringio):
             "--license",
             "GPL-3.0-or-later",
             "--copyright",
-            "Mary Sue",
+            "Jane Doe",
             "--skip-unrecognised",
             "foo.foo",
         ],
@@ -269,7 +269,7 @@ def test_addheader_skip_unrecognised_and_style(
             "--license",
             "GPL-3.0-or-later",
             "--copyright",
-            "Mary Sue",
+            "Jane Doe",
             "--style=c",
             "--skip-unrecognised",
             "foo.foo",
@@ -306,7 +306,7 @@ def test_addheader_template_simple(
             "--license",
             "GPL-3.0-or-later",
             "--copyright",
-            "Mary Sue",
+            "Jane Doe",
             "--template",
             "mytemplate.jinja2",
             "foo.py",
@@ -321,7 +321,7 @@ def test_addheader_template_simple(
             """
             # Hello, world!
             #
-            # spdx-FileCopyrightText: 2018 Mary Sue
+            # spdx-FileCopyrightText: 2018 Jane Doe
             #
             # spdx-License-Identifier: GPL-3.0-or-later
 
@@ -348,7 +348,7 @@ def test_addheader_template_simple_multiple(
             "--license",
             "GPL-3.0-or-later",
             "--copyright",
-            "Mary Sue",
+            "Jane Doe",
             "--template",
             "mytemplate.jinja2",
         ]
@@ -364,7 +364,7 @@ def test_addheader_template_simple_multiple(
                 """
                 # Hello, world!
                 #
-                # spdx-FileCopyrightText: 2018 Mary Sue
+                # spdx-FileCopyrightText: 2018 Jane Doe
                 #
                 # spdx-License-Identifier: GPL-3.0-or-later
 
@@ -390,7 +390,7 @@ def test_addheader_template_no_spdx(
             "--license",
             "GPL-3.0-or-later",
             "--copyright",
-            "Mary Sue",
+            "Jane Doe",
             "--template",
             "mytemplate.jinja2",
             "foo.py",
@@ -419,7 +419,7 @@ def test_addheader_template_commented(
             "--license",
             "GPL-3.0-or-later",
             "--copyright",
-            "Mary Sue",
+            "Jane Doe",
             "--template",
             "mytemplate.commented.jinja2",
             "foo.c",
@@ -434,7 +434,7 @@ def test_addheader_template_commented(
             """
             # Hello, world!
             #
-            # spdx-FileCopyrightText: 2018 Mary Sue
+            # spdx-FileCopyrightText: 2018 Jane Doe
             #
             # spdx-License-Identifier: GPL-3.0-or-later
 
@@ -457,7 +457,7 @@ def test_addheader_template_nonexistant(fake_repository):
                 "--license",
                 "GPL-3.0-or-later",
                 "--copyright",
-                "Mary Sue",
+                "Jane Doe",
                 "--template",
                 "mytemplate.jinja2",
                 "foo.py",
@@ -482,7 +482,7 @@ def test_addheader_template_without_extension(
             "--license",
             "GPL-3.0-or-later",
             "--copyright",
-            "Mary Sue",
+            "Jane Doe",
             "--template",
             "mytemplate",
             "foo.py",
@@ -497,7 +497,7 @@ def test_addheader_template_without_extension(
             """
             # Hello, world!
             #
-            # spdx-FileCopyrightText: 2018 Mary Sue
+            # spdx-FileCopyrightText: 2018 Jane Doe
             #
             # spdx-License-Identifier: GPL-3.0-or-later
 
@@ -520,7 +520,7 @@ def test_addheader_binary(
             "--license",
             "GPL-3.0-or-later",
             "--copyright",
-            "Mary Sue",
+            "Jane Doe",
             "foo.png",
         ],
         out=stringio,
@@ -533,7 +533,7 @@ def test_addheader_binary(
         .strip()
         == cleandoc(
             """
-            spdx-FileCopyrightText: 2018 Mary Sue
+            spdx-FileCopyrightText: 2018 Jane Doe
 
             spdx-License-Identifier: GPL-3.0-or-later
             """
@@ -554,7 +554,7 @@ def test_addheader_uncommentable_json(
             "--license",
             "GPL-3.0-or-later",
             "--copyright",
-            "Mary Sue",
+            "Jane Doe",
             "foo.json",
         ],
         out=stringio,
@@ -565,7 +565,7 @@ def test_addheader_uncommentable_json(
         json_file.with_name(f"{json_file.name}.license").read_text().strip()
         == cleandoc(
             """
-            spdx-FileCopyrightText: 2018 Mary Sue
+            spdx-FileCopyrightText: 2018 Jane Doe
 
             spdx-License-Identifier: GPL-3.0-or-later
             """
@@ -586,7 +586,7 @@ def test_addheader_explicit_license(
             "--license",
             "GPL-3.0-or-later",
             "--copyright",
-            "Mary Sue",
+            "Jane Doe",
             "--explicit-license",
             "foo.py",
         ],
@@ -600,7 +600,7 @@ def test_addheader_explicit_license(
         .strip()
         == cleandoc(
             """
-            spdx-FileCopyrightText: 2018 Mary Sue
+            spdx-FileCopyrightText: 2018 Jane Doe
 
             spdx-License-Identifier: GPL-3.0-or-later
             """
@@ -626,7 +626,7 @@ def test_addheader_explicit_license_double(
             "--license",
             "GPL-3.0-or-later",
             "--copyright",
-            "Mary Sue",
+            "Jane Doe",
             "--explicit-license",
             "foo.txt",
         ],
@@ -639,7 +639,7 @@ def test_addheader_explicit_license_double(
         simple_file_license.read_text().strip()
         == cleandoc(
             """
-            spdx-FileCopyrightText: 2018 Mary Sue
+            spdx-FileCopyrightText: 2018 Jane Doe
 
             spdx-License-Identifier: GPL-3.0-or-later
             """
@@ -662,7 +662,7 @@ def test_addheader_explicit_license_unsupported_filetype(
             "--license",
             "GPL-3.0-or-later",
             "--copyright",
-            "Mary Sue",
+            "Jane Doe",
             "--explicit-license",
             "foo.txt",
         ],
@@ -676,7 +676,7 @@ def test_addheader_explicit_license_unsupported_filetype(
         .strip()
         == cleandoc(
             """
-            spdx-FileCopyrightText: 2018 Mary Sue
+            spdx-FileCopyrightText: 2018 Jane Doe
 
             spdx-License-Identifier: GPL-3.0-or-later
             """
@@ -701,7 +701,7 @@ def test_addheader_explicit_license_doesnt_write_to_file(
             "--license",
             "GPL-3.0-or-later",
             "--copyright",
-            "Mary Sue",
+            "Jane Doe",
             "--explicit-license",
             "foo.txt",
         ],
@@ -715,7 +715,7 @@ def test_addheader_explicit_license_doesnt_write_to_file(
         .strip()
         == cleandoc(
             """
-            spdx-FileCopyrightText: 2018 Mary Sue
+            spdx-FileCopyrightText: 2018 Jane Doe
 
             spdx-License-Identifier: GPL-3.0-or-later
             """
@@ -769,7 +769,7 @@ def test_addheader_license_file(fake_repository, stringio, mock_date_today):
             "--license",
             "GPL-3.0-or-later",
             "--copyright",
-            "Mary Sue",
+            "Jane Doe",
             "foo.py",
         ],
         out=stringio,
@@ -781,7 +781,7 @@ def test_addheader_license_file(fake_repository, stringio, mock_date_today):
         == cleandoc(
             """
             spdx-FileCopyrightText: 2016 Jane Doe
-            spdx-FileCopyrightText: 2018 Mary Sue
+            spdx-FileCopyrightText: 2018 Jane Doe
 
             spdx-License-Identifier: GPL-3.0-or-later
             """
@@ -799,7 +799,7 @@ def test_addheader_year_mutually_exclusive(fake_repository):
                 "--license",
                 "GPL-3.0-or-later",
                 "--copyright",
-                "Mary Sue",
+                "Jane Doe",
                 "--exclude-year",
                 "--year",
                 "2020",
@@ -817,7 +817,7 @@ def test_addheader_single_multi_line_mutually_exclusive(fake_repository):
                 "--license",
                 "GPL-3.0-or-later",
                 "--copyright",
-                "Mary Sue",
+                "Jane Doe",
                 "--single-line",
                 "--multi-line",
                 "src/source_code.c",
@@ -835,7 +835,7 @@ def test_addheader_multi_line_not_supported(fake_repository, skip_option):
                 "--license",
                 "GPL-3.0-or-later",
                 "--copyright",
-                "Mary Sue",
+                "Jane Doe",
                 "--multi-line",
                 skip_option,
                 "src/source_code.py",
@@ -853,7 +853,7 @@ def test_addheader_single_line_not_supported(fake_repository, skip_option):
                 "--license",
                 "GPL-3.0-or-later",
                 "--copyright",
-                "Mary Sue",
+                "Jane Doe",
                 "--single-line",
                 skip_option,
                 "src/source_code.html",
@@ -874,7 +874,7 @@ def test_addheader_force_multi_line_for_c(
             "--license",
             "GPL-3.0-or-later",
             "--copyright",
-            "Mary Sue",
+            "Jane Doe",
             "--multi-line",
             "foo.c",
         ],
@@ -887,7 +887,7 @@ def test_addheader_force_multi_line_for_c(
         == cleandoc(
             """
             /*
-             * spdx-FileCopyrightText: 2018 Mary Sue
+             * spdx-FileCopyrightText: 2018 Jane Doe
              *
              * spdx-License-Identifier: GPL-3.0-or-later
              */
@@ -914,7 +914,7 @@ def test_addheader_line_endings(
             "--license",
             "GPL-3.0-or-later",
             "--copyright",
-            "Mary Sue",
+            "Jane Doe",
             "foo.py",
         ],
         out=stringio,
@@ -928,7 +928,7 @@ def test_addheader_line_endings(
         contents
         == cleandoc(
             """
-            # spdx-FileCopyrightText: 2018 Mary Sue
+            # spdx-FileCopyrightText: 2018 Jane Doe
             #
             # spdx-License-Identifier: GPL-3.0-or-later
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -101,7 +101,7 @@ def test_all_files_symlinks(empty_directory):
     (empty_directory / "blob.license").write_text(
         cleandoc(
             """
-            spdx-FileCopyrightText: Mary Sue
+            spdx-FileCopyrightText: Jane Doe
 
             spdx-License-Identifier: GPL-3.0-or-later
             """
@@ -231,7 +231,7 @@ def test_spdx_info_of_only_copyright(fake_repository):
     up on that.
     """
     (fake_repository / "foo.py").write_text(
-        "SPDX-FileCopyrightText: 2017 Mary Sue"
+        "SPDX-FileCopyrightText: 2017 Jane Doe"
     )
     project = Project(fake_repository)
     spdx_info = project.spdx_info_of("foo.py")
@@ -239,7 +239,7 @@ def test_spdx_info_of_only_copyright(fake_repository):
     assert len(spdx_info.copyright_lines) == 1
     assert (
         spdx_info.copyright_lines.pop()
-        == "SPDX-FileCopyrightText: 2017 Mary Sue"
+        == "SPDX-FileCopyrightText: 2017 Jane Doe"
     )
 
 
@@ -255,7 +255,7 @@ def test_spdx_info_of_only_copyright_also_covered_by_debian(fake_repository):
     assert any(spdx_info.spdx_expressions)
     assert len(spdx_info.copyright_lines) == 2
     assert "SPDX-FileCopyrightText: in file" in spdx_info.copyright_lines
-    assert "2017 Mary Sue" in spdx_info.copyright_lines
+    assert "2017 Jane Doe" in spdx_info.copyright_lines
 
 
 def test_spdx_info_of_also_covered_by_dep5(fake_repository):
@@ -274,7 +274,7 @@ def test_spdx_info_of_also_covered_by_dep5(fake_repository):
     assert LicenseSymbol("MIT") in spdx_info.spdx_expressions
     assert LicenseSymbol("CC0-1.0") in spdx_info.spdx_expressions
     assert "SPDX-FileCopyrightText: in file" in spdx_info.copyright_lines
-    assert "2017 Mary Sue" in spdx_info.copyright_lines
+    assert "2017 Jane Doe" in spdx_info.copyright_lines
 
 
 def test_spdx_info_of_no_duplicates(empty_directory):
@@ -316,13 +316,13 @@ def test_license_file_detected(empty_directory):
     """
     (empty_directory / "foo.py").write_text("foo")
     (empty_directory / "foo.py.license").write_text(
-        "SPDX-FileCopyrightText: 2017 Mary Sue\nSPDX-License-Identifier: MIT\n"
+        "SPDX-FileCopyrightText: 2017 Jane Doe\nSPDX-License-Identifier: MIT\n"
     )
 
     project = Project(empty_directory)
     spdx_info = project.spdx_info_of("foo.py")
 
-    assert "SPDX-FileCopyrightText: 2017 Mary Sue" in spdx_info.copyright_lines
+    assert "SPDX-FileCopyrightText: 2017 Jane Doe" in spdx_info.copyright_lines
     assert LicenseSymbol("MIT") in spdx_info.spdx_expressions
 
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -32,7 +32,7 @@ def test_generate_file_report_file_simple(fake_repository):
     project = Project(fake_repository)
     result = FileReport.generate(project, "src/source_code.py")
     assert result.spdxfile.licenses_in_file == ["GPL-3.0-or-later"]
-    assert result.spdxfile.copyright == "SPDX-FileCopyrightText: 2017 Mary Sue"
+    assert result.spdxfile.copyright == "SPDX-FileCopyrightText: 2017 Jane Doe"
     assert not result.bad_licenses
     assert not result.missing_licenses
 
@@ -45,7 +45,7 @@ def test_generate_file_report_file_from_different_cwd(fake_repository):
         project, fake_repository / "src/source_code.py"
     )
     assert result.spdxfile.licenses_in_file == ["GPL-3.0-or-later"]
-    assert result.spdxfile.copyright == "SPDX-FileCopyrightText: 2017 Mary Sue"
+    assert result.spdxfile.copyright == "SPDX-FileCopyrightText: 2017 Jane Doe"
     assert not result.bad_licenses
     assert not result.missing_licenses
 
@@ -84,7 +84,7 @@ def test_generate_file_report_exception(fake_repository):
         "GPL-3.0-or-later",
         "Autoconf-exception-3.0",
     }
-    assert result.spdxfile.copyright == "SPDX-FileCopyrightText: 2017 Mary Sue"
+    assert result.spdxfile.copyright == "SPDX-FileCopyrightText: 2017 Jane Doe"
     assert not result.bad_licenses
     assert not result.missing_licenses
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -137,7 +137,7 @@ def test_copyright_from_dep5(copyright):
     """Verify that the glob in the dep5 file is matched."""
     result = _util._copyright_from_dep5("doc/foo.rst", copyright)
     assert LicenseSymbol("CC0-1.0") in result.spdx_expressions
-    assert "2017 Mary Sue" in result.copyright_lines
+    assert "2017 Jane Doe" in result.copyright_lines
 
 
 def test_make_copyright_line_simple():


### PR DESCRIPTION
I replaced all occurrences of Mary Sue to Jane Doe in all test files, I also found Mary Sue in the header of some source files,
but I replaced them due to you mentioning that you wanted to replace the name in all code base.

fixes #460