### PR TITLE
Make sure there's a newline at the end of .license files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,11 @@ The versions follow [semantic versioning](https://semver.org).
 
 ### Fixed
 
+- When `addheader` creates a `.license` file, that file now has a newline at the
+  end. (#477)
+
+- Cleaned up internal string manipulation. (#477)
+
 ### Security
 
 ## 0.14.0 - 2021-12-27

--- a/src/reuse/_comment.py
+++ b/src/reuse/_comment.py
@@ -57,7 +57,6 @@ class CommentStyle:
 
         :raises CommentCreateError: if *text* could not be commented.
         """
-        text = text.strip("\n")
         if force_multi or not cls.can_handle_single():
             return cls._create_comment_multi(text)
         return cls._create_comment_single(text)
@@ -72,9 +71,8 @@ class CommentStyle:
             raise CommentCreateError(
                 f"{cls} cannot create single-line comments"
             )
-        text = text.strip("\n")
         result = []
-        for line in text.splitlines():
+        for line in text.split("\n"):
             line_result = cls.SINGLE_LINE
             if line:
                 line_result += cls.INDENT_AFTER_SINGLE + line
@@ -91,10 +89,9 @@ class CommentStyle:
             raise CommentCreateError(
                 f"{cls} cannot create multi-line comments"
             )
-        text = text.strip("\n")
         result = []
         result.append(cls.MULTI_LINE[0])
-        for line in text.splitlines():
+        for line in text.split("\n"):
             if cls.MULTI_LINE[2] in text:
                 raise CommentCreateError(
                     f"'{line}' contains a premature comment delimiter"
@@ -114,8 +111,6 @@ class CommentStyle:
 
         :raises CommentParseError: if *text* could not be parsed.
         """
-        text = text.strip("\n")
-
         try:
             return cls._parse_comment_single(text)
         except CommentParseError:
@@ -130,7 +125,6 @@ class CommentStyle:
         """
         if not cls.can_handle_single():
             raise CommentParseError(f"{cls} cannot parse single-line comments")
-        text = text.strip("\n")
         result = []
 
         for line in text.splitlines():
@@ -144,6 +138,23 @@ class CommentStyle:
         return dedent(result)
 
     @classmethod
+    def _remove_middle_marker(cls, line: str) -> str:
+        if cls.MULTI_LINE[1]:
+            possible_line = line.lstrip()
+            prefix = cls.MULTI_LINE[1]
+            if possible_line.startswith(prefix):
+                line = possible_line.lstrip(prefix)
+                # Note to future self: line.removeprefix would be preferable
+                # here.
+                if line.startswith(cls.INDENT_AFTER_MIDDLE):
+                    line = line.replace(cls.INDENT_AFTER_MIDDLE, "", 1)
+            else:
+                _LOGGER.debug(
+                    "'%s' does not contain a middle comment marker", line
+                )
+        return line
+
+    @classmethod
     def _parse_comment_multi(cls, text: str) -> str:
         """Uncomment all lines in *text*, assuming they are commented by
         multi-line comments.
@@ -153,7 +164,6 @@ class CommentStyle:
         if not cls.can_handle_multi():
             raise CommentParseError(f"{cls} cannot parse multi-line comments")
 
-        text = text.strip("\n")
         result = []
         try:
             first, *lines, last = text.splitlines()
@@ -169,18 +179,10 @@ class CommentStyle:
                 f"'{first}' does not start with a comment marker"
             )
         first = first.lstrip(cls.MULTI_LINE[0])
-        first = first.strip()
+        first = first.lstrip()
 
         for line in lines:
-            if cls.MULTI_LINE[1]:
-                possible_line = line.lstrip(cls.INDENT_BEFORE_MIDDLE)
-                prefix = cls.MULTI_LINE[1]
-                if possible_line.startswith(prefix):
-                    line = possible_line.lstrip(prefix)
-                else:
-                    _LOGGER.debug(
-                        "'%s' does not contain a middle comment marker", line
-                    )
+            line = cls._remove_middle_marker(line)
             result.append(line)
 
         if last_is_first:
@@ -191,21 +193,13 @@ class CommentStyle:
                 f"'{last}' does not end with a comment delimiter"
             )
         last = last.rstrip(cls.MULTI_LINE[2])
-        last = last.rstrip(cls.INDENT_BEFORE_END)
-        last = last.strip()
-        if cls.MULTI_LINE[1] and last.startswith(cls.MULTI_LINE[1]):
-            last = last.lstrip(cls.MULTI_LINE[1])
-            last = last.lstrip()
+        last = last.rstrip()
+        last = cls._remove_middle_marker(last)
 
         result = "\n".join(result)
         result = dedent(result)
 
-        if result:
-            result = "\n".join((first, result, last))
-        else:
-            result = "\n".join((first, last))
-        result = result.strip("\n")
-        return result
+        return "\n".join(item for item in (first, result, last) if item)
 
     @classmethod
     def comment_at_first_character(cls, text: str) -> str:
@@ -308,11 +302,11 @@ class EmptyCommentStyle(CommentStyle):
 
     @classmethod
     def create_comment(cls, text: str, force_multi: bool = False) -> str:
-        return text.strip("\n")
+        return text
 
     @classmethod
     def parse_comment(cls, text: str) -> str:
-        return text.strip("\n")
+        return text
 
     @classmethod
     def comment_at_first_character(cls, text: str) -> str:

--- a/src/reuse/header.py
+++ b/src/reuse/header.py
@@ -22,7 +22,7 @@ from argparse import ArgumentParser
 from gettext import gettext as _
 from os import PathLike
 from pathlib import Path
-from typing import Iterable, List, NamedTuple, Optional, Sequence
+from typing import Iterable, List, NamedTuple, Optional, Sequence, Tuple
 
 from binaryornot.check import is_binary
 from boolean.boolean import ParseError
@@ -100,10 +100,10 @@ def _create_new_header(
     rendered = template.render(
         copyright_lines=sorted(spdx_info.copyright_lines),
         spdx_expressions=sorted(map(str, spdx_info.spdx_expressions)),
-    )
+    ).strip("\n")
 
     if template_is_commented:
-        result = rendered.strip("\n")
+        result = rendered
     else:
         result = style.create_comment(rendered, force_multi=force_multi).strip(
             "\n"
@@ -173,7 +173,7 @@ def create_header(
         style=style,
         force_multi=force_multi,
     )
-    return new_header + "\n"
+    return new_header
 
 
 def _indices_of_newlines(text: str) -> Sequence[int]:
@@ -215,6 +215,21 @@ def _find_first_spdx_comment(
             )
 
     raise MissingSpdxInfo()
+
+
+def _extract_shebang(prefix: str, text: str) -> Tuple[str, str]:
+    """Remove all lines that start with the shebang prefix from *text*. Return a
+    tuple of (shebang, reduced_text).
+    """
+    shebang_lines = []
+    for line in text.splitlines():
+        if line.startswith(prefix):
+            shebang_lines.append(line)
+            text = text.replace(line, "", 1)
+        else:
+            shebang = "\n".join(shebang_lines)
+            break
+    return (shebang, text)
 
 
 def find_and_replace_header(
@@ -264,29 +279,20 @@ def find_and_replace_header(
 
     # Keep special first-line-of-file lines as the first line in the file,
     # or say, move our comments after it.
-    for (com_style, prefix) in [
-        (PythonCommentStyle, "#!"),
-        (HtmlCommentStyle, "<?xml"),
-    ]:
+    for prefix in (
+        prefix
+        for com_style, prefix in (
+            (PythonCommentStyle, "#!"),
+            (HtmlCommentStyle, "<?xml"),
+        )
+        if style is com_style
+    ):
         # Extract shebang from header and put it in before. It's a bit messy, but
         # it ends up working.
-        if style is not com_style:
-            continue
         if header.startswith(prefix) and not before.strip():
-            before = ""
-            for line in header.splitlines():
-                if line.startswith(prefix):
-                    before = before + "\n" + line
-                    header = header.replace(line, "", 1)
-                else:
-                    break
+            before, header = _extract_shebang(prefix, header)
         elif after.startswith(prefix) and not any((before, header)):
-            for line in after.splitlines():
-                if line.startswith(prefix):
-                    before = before + "\n" + line
-                    after = after.replace(line, "", 1)
-                else:
-                    break
+            before, after = _extract_shebang(prefix, after)
 
     header = create_header(
         spdx_info,
@@ -297,11 +303,11 @@ def find_and_replace_header(
         force_multi=force_multi,
     )
 
-    new_text = header.strip("\n")
+    new_text = f"{header}\n"
     if before.strip():
-        new_text = before.strip("\n") + "\n\n" + new_text
+        new_text = f"{before.rstrip()}\n\n{new_text}"
     if after.strip():
-        new_text = new_text + "\n\n" + after.lstrip("\n")
+        new_text = f"{new_text}\n{after.lstrip()}"
     return new_text
 
 

--- a/src/reuse/header.py
+++ b/src/reuse/header.py
@@ -460,6 +460,16 @@ def _add_header_to_file(
     return result
 
 
+def _verify_write_access(paths: Iterable[PathLike], parser: ArgumentParser):
+    not_writeable = [
+        str(path) for path in paths if not os.access(path, os.W_OK)
+    ]
+    if not_writeable:
+        parser.error(
+            _("can't write to '{}'").format("', '".join(not_writeable))
+        )
+
+
 def add_arguments(parser) -> None:
     """Add arguments to parser."""
     parser.add_argument(
@@ -634,13 +644,3 @@ def run(args, project: Project, out=sys.stdout) -> int:
         )
 
     return min(result, 1)
-
-
-def _verify_write_access(paths: Iterable[PathLike], parser: ArgumentParser):
-    not_writeable = [
-        str(path) for path in paths if not os.access(path, os.W_OK)
-    ]
-    if not_writeable:
-        parser.error(
-            _("can't write to '{}'").format("', '".join(not_writeable))
-        )

--- a/tests/test_comment.py
+++ b/tests/test_comment.py
@@ -523,18 +523,18 @@ def test_parse_comment_html():
     assert HtmlCommentStyle.parse_comment(text) == expected
 
 
+def test_create_comment_html_single():
+    """Creating a single-line HTML comment fails."""
+    with pytest.raises(CommentCreateError):
+        HtmlCommentStyle._create_comment_single("hello")
+
+
 def test_parse_comment_html_single_line():
     """Parse a single-line HTML comment."""
     text = "<!-- Hello world -->"
     expected = "Hello world"
 
     assert HtmlCommentStyle.parse_comment(text) == expected
-
-
-def test_create_comment_html_single():
-    """Creating a single-line HTML comment fails."""
-    with pytest.raises(CommentCreateError):
-        HtmlCommentStyle._create_comment_single("hello")
 
 
 def test_comment_at_first_character_python():

--- a/tests/test_comment.py
+++ b/tests/test_comment.py
@@ -158,10 +158,16 @@ def test_parse_comment_python_indented():
     assert PythonCommentStyle.parse_comment(text) == expected
 
 
-def test_create_comment_python_strip_newlines():
-    """Don't include unnecessary newlines in the comment."""
+def test_create_comment_python_dont_strip_newlines():
+    """Include newlines in the comment."""
     text = "\nhello\n"
-    expected = "# hello"
+    expected = cleandoc(
+        """
+        #
+        # hello
+        #
+        """
+    )
 
     assert PythonCommentStyle.create_comment(text) == expected
 
@@ -172,8 +178,8 @@ def test_create_comment_python_force_multi():
         PythonCommentStyle.create_comment("hello", force_multi=True)
 
 
-def test_parse_comment_python_strip_newlines():
-    """When given a comment, remove newlines before and after before parsing."""
+def test_parse_comment_python_fail_on_newline():
+    """If a provided comment does not start with the comment character, fail."""
     text = dedent(
         """
 
@@ -183,9 +189,8 @@ def test_parse_comment_python_strip_newlines():
 
         """
     )
-    expected = "\nhello\n"
-
-    assert PythonCommentStyle.parse_comment(text) == expected
+    with pytest.raises(CommentParseError):
+        assert PythonCommentStyle.parse_comment(text)
 
 
 def test_parse_comment_python_not_a_comment():
@@ -266,6 +271,45 @@ def test_create_comment_c_multi():
         /*
          * Hello
          * world
+         */
+        """
+    )
+
+    assert CCommentStyle.create_comment(text, force_multi=True) == expected
+
+
+def test_create_comment_c_multi_empty_newlines():
+    """Create a C comment that contains empty lines."""
+    text = cleandoc(
+        """
+        Hello
+
+        world
+        """
+    )
+    expected = cleandoc(
+        """
+        /*
+         * Hello
+         *
+         * world
+         */
+        """
+    )
+
+    assert CCommentStyle.create_comment(text, force_multi=True) == expected
+
+
+def test_create_comment_c_multi_surrounded_by_newlines():
+    """Create a C comment that is surrounded by empty lines."""
+    text = "\nHello\nworld\n"
+    expected = cleandoc(
+        """
+        /*
+         *
+         * Hello
+         * world
+         *
          */
         """
     )

--- a/tests/test_main_addheader.py
+++ b/tests/test_main_addheader.py
@@ -739,11 +739,22 @@ def test_addheader_license_file(fake_repository, stringio, mock_date_today):
     license_file.write_text(
         cleandoc(
             """
-            spdx-FileCopyrightText: 2016 Jane Doe
+            spdx-FileCopyrightText: 2016 John Doe
 
             Hello
             """
         ).replace("spdx", "SPDX")
+    )
+    expected = (
+        cleandoc(
+            """
+            spdx-FileCopyrightText: 2016 John Doe
+            spdx-FileCopyrightText: 2018 Jane Doe
+
+            spdx-License-Identifier: GPL-3.0-or-later
+            """
+        ).replace("spdx", "SPDX")
+        + "\n"
     )
 
     result = main(
@@ -759,17 +770,53 @@ def test_addheader_license_file(fake_repository, stringio, mock_date_today):
     )
 
     assert result == 0
-    assert (
-        license_file.read_text()
-        == cleandoc(
+    assert license_file.read_text() == expected
+    assert simple_file.read_text() == "foo"
+
+
+def test_addheader_license_file_only_one_newline(
+    fake_repository, stringio, mock_date_today
+):
+    """When a header is added to a .license file that already ends with a newline, the new header should end with a single newline."""
+    simple_file = fake_repository / "foo.py"
+    simple_file.write_text("foo")
+    license_file = fake_repository / "foo.py.license"
+    license_file.write_text(
+        cleandoc(
             """
-            spdx-FileCopyrightText: 2016 Jane Doe
+            spdx-FileCopyrightText: 2016 John Doe
+
+            Hello
+            """
+        ).replace("spdx", "SPDX")
+        + "\n"
+    )
+    expected = (
+        cleandoc(
+            """
+            spdx-FileCopyrightText: 2016 John Doe
             spdx-FileCopyrightText: 2018 Jane Doe
 
             spdx-License-Identifier: GPL-3.0-or-later
             """
         ).replace("spdx", "SPDX")
+        + "\n"
     )
+
+    result = main(
+        [
+            "addheader",
+            "--license",
+            "GPL-3.0-or-later",
+            "--copyright",
+            "Jane Doe",
+            "foo.py",
+        ],
+        out=stringio,
+    )
+
+    assert result == 0
+    assert license_file.read_text() == expected
     assert simple_file.read_text() == "foo"
 
 

--- a/tests/test_main_addheader.py
+++ b/tests/test_main_addheader.py
@@ -21,6 +21,15 @@ def test_addheader_simple(fake_repository, stringio, mock_date_today):
     """Add a header to a file that does not have one."""
     simple_file = fake_repository / "foo.py"
     simple_file.write_text("pass")
+    expected = cleandoc(
+        """
+        # spdx-FileCopyrightText: 2018 Jane Doe
+        #
+        # spdx-License-Identifier: GPL-3.0-or-later
+
+        pass
+        """
+    ).replace("spdx", "SPDX")
 
     result = main(
         [
@@ -35,24 +44,22 @@ def test_addheader_simple(fake_repository, stringio, mock_date_today):
     )
 
     assert result == 0
-    assert (
-        simple_file.read_text()
-        == cleandoc(
-            """
-            # spdx-FileCopyrightText: 2018 Jane Doe
-            #
-            # spdx-License-Identifier: GPL-3.0-or-later
-
-            pass
-            """
-        ).replace("spdx", "SPDX")
-    )
+    assert simple_file.read_text() == expected
 
 
 def test_addheader_year(fake_repository, stringio):
     """Add a header to a file with a custom year."""
     simple_file = fake_repository / "foo.py"
     simple_file.write_text("pass")
+    expected = cleandoc(
+        """
+        # spdx-FileCopyrightText: 2016 Jane Doe
+        #
+        # spdx-License-Identifier: GPL-3.0-or-later
+
+        pass
+        """
+    ).replace("spdx", "SPDX")
 
     result = main(
         [
@@ -69,24 +76,22 @@ def test_addheader_year(fake_repository, stringio):
     )
 
     assert result == 0
-    assert (
-        simple_file.read_text()
-        == cleandoc(
-            """
-            # spdx-FileCopyrightText: 2016 Jane Doe
-            #
-            # spdx-License-Identifier: GPL-3.0-or-later
-
-            pass
-            """
-        ).replace("spdx", "SPDX")
-    )
+    assert simple_file.read_text() == expected
 
 
 def test_addheader_no_year(fake_repository, stringio):
     """Add a header to a file without a year."""
     simple_file = fake_repository / "foo.py"
     simple_file.write_text("pass")
+    expected = cleandoc(
+        """
+        # spdx-FileCopyrightText: Jane Doe
+        #
+        # spdx-License-Identifier: GPL-3.0-or-later
+
+        pass
+        """
+    ).replace("spdx", "SPDX")
 
     result = main(
         [
@@ -102,24 +107,22 @@ def test_addheader_no_year(fake_repository, stringio):
     )
 
     assert result == 0
-    assert (
-        simple_file.read_text()
-        == cleandoc(
-            """
-            # spdx-FileCopyrightText: Jane Doe
-            #
-            # spdx-License-Identifier: GPL-3.0-or-later
-
-            pass
-            """
-        ).replace("spdx", "SPDX")
-    )
+    assert simple_file.read_text() == expected
 
 
 def test_addheader_specify_style(fake_repository, stringio, mock_date_today):
     """Add a header to a file that does not have one, using a custom style."""
     simple_file = fake_repository / "foo.py"
     simple_file.write_text("pass")
+    expected = cleandoc(
+        """
+        // spdx-FileCopyrightText: 2018 Jane Doe
+        //
+        // spdx-License-Identifier: GPL-3.0-or-later
+
+        pass
+        """
+    ).replace("spdx", "SPDX")
 
     result = main(
         [
@@ -136,24 +139,22 @@ def test_addheader_specify_style(fake_repository, stringio, mock_date_today):
     )
 
     assert result == 0
-    assert (
-        simple_file.read_text()
-        == cleandoc(
-            """
-            // spdx-FileCopyrightText: 2018 Jane Doe
-            //
-            // spdx-License-Identifier: GPL-3.0-or-later
-
-            pass
-            """
-        ).replace("spdx", "SPDX")
-    )
+    assert simple_file.read_text() == expected
 
 
 def test_addheader_implicit_style(fake_repository, stringio, mock_date_today):
     """Add a header to a file that has a recognised extension."""
     simple_file = fake_repository / "foo.js"
     simple_file.write_text("pass")
+    expected = cleandoc(
+        """
+        // spdx-FileCopyrightText: 2018 Jane Doe
+        //
+        // spdx-License-Identifier: GPL-3.0-or-later
+
+        pass
+        """
+    ).replace("spdx", "SPDX")
 
     result = main(
         [
@@ -168,18 +169,7 @@ def test_addheader_implicit_style(fake_repository, stringio, mock_date_today):
     )
 
     assert result == 0
-    assert (
-        simple_file.read_text()
-        == cleandoc(
-            """
-            // spdx-FileCopyrightText: 2018 Jane Doe
-            //
-            // spdx-License-Identifier: GPL-3.0-or-later
-
-            pass
-            """
-        ).replace("spdx", "SPDX")
-    )
+    assert simple_file.read_text() == expected
 
 
 def test_addheader_implicit_style_filename(
@@ -188,6 +178,15 @@ def test_addheader_implicit_style_filename(
     """Add a header to a filename that is recognised."""
     simple_file = fake_repository / "Makefile"
     simple_file.write_text("pass")
+    expected = cleandoc(
+        """
+        # spdx-FileCopyrightText: 2018 Jane Doe
+        #
+        # spdx-License-Identifier: GPL-3.0-or-later
+
+        pass
+        """
+    ).replace("spdx", "SPDX")
 
     result = main(
         [
@@ -202,18 +201,7 @@ def test_addheader_implicit_style_filename(
     )
 
     assert result == 0
-    assert (
-        simple_file.read_text()
-        == cleandoc(
-            """
-            # spdx-FileCopyrightText: 2018 Jane Doe
-            #
-            # spdx-License-Identifier: GPL-3.0-or-later
-
-            pass
-            """
-        ).replace("spdx", "SPDX")
-    )
+    assert simple_file.read_text() == expected
 
 
 def test_addheader_unrecognised_style(fake_repository):
@@ -299,6 +287,17 @@ def test_addheader_template_simple(
     template_file = fake_repository / ".reuse/templates/mytemplate.jinja2"
     template_file.parent.mkdir(parents=True, exist_ok=True)
     template_file.write_text(template_simple_source)
+    expected = cleandoc(
+        """
+        # Hello, world!
+        #
+        # spdx-FileCopyrightText: 2018 Jane Doe
+        #
+        # spdx-License-Identifier: GPL-3.0-or-later
+
+        pass
+        """
+    ).replace("spdx", "SPDX")
 
     result = main(
         [
@@ -315,20 +314,7 @@ def test_addheader_template_simple(
     )
 
     assert result == 0
-    assert (
-        simple_file.read_text()
-        == cleandoc(
-            """
-            # Hello, world!
-            #
-            # spdx-FileCopyrightText: 2018 Jane Doe
-            #
-            # spdx-License-Identifier: GPL-3.0-or-later
-
-            pass
-            """
-        ).replace("spdx", "SPDX")
-    )
+    assert simple_file.read_text() == expected
 
 
 def test_addheader_template_simple_multiple(
@@ -358,20 +344,18 @@ def test_addheader_template_simple_multiple(
 
     assert result == 0
     for simple_file in simple_files:
-        assert (
-            simple_file.read_text()
-            == cleandoc(
-                """
-                # Hello, world!
-                #
-                # spdx-FileCopyrightText: 2018 Jane Doe
-                #
-                # spdx-License-Identifier: GPL-3.0-or-later
+        expected = cleandoc(
+            """
+            # Hello, world!
+            #
+            # spdx-FileCopyrightText: 2018 Jane Doe
+            #
+            # spdx-License-Identifier: GPL-3.0-or-later
 
-                pass
-                """
-            ).replace("spdx", "SPDX")
-        )
+            pass
+            """
+        ).replace("spdx", "SPDX")
+        assert simple_file.read_text() == expected
 
 
 def test_addheader_template_no_spdx(
@@ -412,6 +396,17 @@ def test_addheader_template_commented(
     )
     template_file.parent.mkdir(parents=True, exist_ok=True)
     template_file.write_text(template_commented_source)
+    expected = cleandoc(
+        """
+        # Hello, world!
+        #
+        # spdx-FileCopyrightText: 2018 Jane Doe
+        #
+        # spdx-License-Identifier: GPL-3.0-or-later
+
+        pass
+        """
+    ).replace("spdx", "SPDX")
 
     result = main(
         [
@@ -428,20 +423,7 @@ def test_addheader_template_commented(
     )
 
     assert result == 0
-    assert (
-        simple_file.read_text()
-        == cleandoc(
-            """
-            # Hello, world!
-            #
-            # spdx-FileCopyrightText: 2018 Jane Doe
-            #
-            # spdx-License-Identifier: GPL-3.0-or-later
-
-            pass
-            """
-        ).replace("spdx", "SPDX")
-    )
+    assert simple_file.read_text() == expected
 
 
 def test_addheader_template_nonexistant(fake_repository):
@@ -475,6 +457,17 @@ def test_addheader_template_without_extension(
     template_file = fake_repository / ".reuse/templates/mytemplate.jinja2"
     template_file.parent.mkdir(parents=True, exist_ok=True)
     template_file.write_text(template_simple_source)
+    expected = cleandoc(
+        """
+        # Hello, world!
+        #
+        # spdx-FileCopyrightText: 2018 Jane Doe
+        #
+        # spdx-License-Identifier: GPL-3.0-or-later
+
+        pass
+        """
+    ).replace("spdx", "SPDX")
 
     result = main(
         [
@@ -491,20 +484,7 @@ def test_addheader_template_without_extension(
     )
 
     assert result == 0
-    assert (
-        simple_file.read_text()
-        == cleandoc(
-            """
-            # Hello, world!
-            #
-            # spdx-FileCopyrightText: 2018 Jane Doe
-            #
-            # spdx-License-Identifier: GPL-3.0-or-later
-
-            pass
-            """
-        ).replace("spdx", "SPDX")
-    )
+    assert simple_file.read_text() == expected
 
 
 def test_addheader_binary(
@@ -513,6 +493,13 @@ def test_addheader_binary(
     """Add a header to a .license file if the file is a binary."""
     binary_file = fake_repository / "foo.png"
     binary_file.write_bytes(binary_string)
+    expected = cleandoc(
+        """
+        spdx-FileCopyrightText: 2018 Jane Doe
+
+        spdx-License-Identifier: GPL-3.0-or-later
+        """
+    ).replace("spdx", "SPDX")
 
     result = main(
         [
@@ -531,13 +518,7 @@ def test_addheader_binary(
         binary_file.with_name(f"{binary_file.name}.license")
         .read_text()
         .strip()
-        == cleandoc(
-            """
-            spdx-FileCopyrightText: 2018 Jane Doe
-
-            spdx-License-Identifier: GPL-3.0-or-later
-            """
-        ).replace("spdx", "SPDX")
+        == expected
     )
 
 
@@ -547,6 +528,13 @@ def test_addheader_uncommentable_json(
     """Add a header to a .license file if the file is uncommentable, e.g., JSON."""
     json_file = fake_repository / "foo.json"
     json_file.write_text('{"foo": 23, "bar": 42}')
+    expected = cleandoc(
+        """
+        spdx-FileCopyrightText: 2018 Jane Doe
+
+        spdx-License-Identifier: GPL-3.0-or-later
+        """
+    ).replace("spdx", "SPDX")
 
     result = main(
         [
@@ -563,13 +551,7 @@ def test_addheader_uncommentable_json(
     assert result == 0
     assert (
         json_file.with_name(f"{json_file.name}.license").read_text().strip()
-        == cleandoc(
-            """
-            spdx-FileCopyrightText: 2018 Jane Doe
-
-            spdx-License-Identifier: GPL-3.0-or-later
-            """
-        ).replace("spdx", "SPDX")
+        == expected
     )
 
 
@@ -579,6 +561,13 @@ def test_addheader_explicit_license(
     """Add a header to a .license file if --explicit-license is given."""
     simple_file = fake_repository / "foo.py"
     simple_file.write_text("pass")
+    expected = cleandoc(
+        """
+        spdx-FileCopyrightText: 2018 Jane Doe
+
+        spdx-License-Identifier: GPL-3.0-or-later
+        """
+    ).replace("spdx", "SPDX")
 
     result = main(
         [
@@ -598,13 +587,7 @@ def test_addheader_explicit_license(
         simple_file.with_name(f"{simple_file.name}.license")
         .read_text()
         .strip()
-        == cleandoc(
-            """
-            spdx-FileCopyrightText: 2018 Jane Doe
-
-            spdx-License-Identifier: GPL-3.0-or-later
-            """
-        ).replace("spdx", "SPDX")
+        == expected
     )
     assert simple_file.read_text() == "pass"
 
@@ -619,6 +602,13 @@ def test_addheader_explicit_license_double(
 
     simple_file.write_text("foo")
     simple_file_license.write_text("foo")
+    expected = cleandoc(
+        """
+        spdx-FileCopyrightText: 2018 Jane Doe
+
+        spdx-License-Identifier: GPL-3.0-or-later
+        """
+    ).replace("spdx", "SPDX")
 
     result = main(
         [
@@ -635,16 +625,7 @@ def test_addheader_explicit_license_double(
 
     assert result == 0
     assert not simple_file_license_license.exists()
-    assert (
-        simple_file_license.read_text().strip()
-        == cleandoc(
-            """
-            spdx-FileCopyrightText: 2018 Jane Doe
-
-            spdx-License-Identifier: GPL-3.0-or-later
-            """
-        ).replace("spdx", "SPDX")
-    )
+    assert simple_file_license.read_text().strip() == expected
 
 
 def test_addheader_explicit_license_unsupported_filetype(
@@ -655,6 +636,13 @@ def test_addheader_explicit_license_unsupported_filetype(
     """
     simple_file = fake_repository / "foo.txt"
     simple_file.write_text("Preserve this")
+    expected = cleandoc(
+        """
+        spdx-FileCopyrightText: 2018 Jane Doe
+
+        spdx-License-Identifier: GPL-3.0-or-later
+        """
+    ).replace("spdx", "SPDX")
 
     result = main(
         [
@@ -674,13 +662,7 @@ def test_addheader_explicit_license_unsupported_filetype(
         simple_file.with_name(f"{simple_file.name}.license")
         .read_text()
         .strip()
-        == cleandoc(
-            """
-            spdx-FileCopyrightText: 2018 Jane Doe
-
-            spdx-License-Identifier: GPL-3.0-or-later
-            """
-        ).replace("spdx", "SPDX")
+        == expected
     )
     assert simple_file.read_text() == "Preserve this"
 
@@ -694,6 +676,13 @@ def test_addheader_explicit_license_doesnt_write_to_file(
     simple_file = fake_repository / "foo.txt"
     simple_file.write_text("Preserve this")
     simple_file.chmod(mode=stat.S_IREAD)
+    expected = cleandoc(
+        """
+        spdx-FileCopyrightText: 2018 Jane Doe
+
+        spdx-License-Identifier: GPL-3.0-or-later
+        """
+    ).replace("spdx", "SPDX")
 
     result = main(
         [
@@ -713,13 +702,7 @@ def test_addheader_explicit_license_doesnt_write_to_file(
         simple_file.with_name(f"{simple_file.name}.license")
         .read_text()
         .strip()
-        == cleandoc(
-            """
-            spdx-FileCopyrightText: 2018 Jane Doe
-
-            spdx-License-Identifier: GPL-3.0-or-later
-            """
-        ).replace("spdx", "SPDX")
+        == expected
     )
     assert simple_file.read_text() == "Preserve this"
 
@@ -867,6 +850,17 @@ def test_addheader_force_multi_line_for_c(
     """--multi-line forces a multi-line comment for C."""
     simple_file = fake_repository / "foo.c"
     simple_file.write_text("foo")
+    expected = cleandoc(
+        """
+                /*
+                 * spdx-FileCopyrightText: 2018 Jane Doe
+                 *
+                 * spdx-License-Identifier: GPL-3.0-or-later
+                 */
+
+                foo
+                """
+    ).replace("spdx", "SPDX")
 
     result = main(
         [
@@ -882,20 +876,7 @@ def test_addheader_force_multi_line_for_c(
     )
 
     assert result == 0
-    assert (
-        simple_file.read_text()
-        == cleandoc(
-            """
-            /*
-             * spdx-FileCopyrightText: 2018 Jane Doe
-             *
-             * spdx-License-Identifier: GPL-3.0-or-later
-             */
-
-            foo
-            """
-        ).replace("spdx", "SPDX")
-    )
+    assert simple_file.read_text() == expected
 
 
 @pytest.mark.parametrize("line_ending", ["\r\n", "\r", "\n"])
@@ -906,6 +887,20 @@ def test_addheader_line_endings(
     simple_file = empty_directory / "foo.py"
     simple_file.write_bytes(
         line_ending.encode("utf-8").join([b"hello", b"world"])
+    )
+    expected = (
+        cleandoc(
+            """
+            # spdx-FileCopyrightText: 2018 Jane Doe
+            #
+            # spdx-License-Identifier: GPL-3.0-or-later
+
+            hello
+            world
+            """
+        )
+        .replace("spdx", "SPDX")
+        .replace("\n", line_ending)
     )
 
     result = main(
@@ -924,18 +919,4 @@ def test_addheader_line_endings(
     with open(simple_file, newline="") as fp:
         contents = fp.read()
 
-    assert (
-        contents
-        == cleandoc(
-            """
-            # spdx-FileCopyrightText: 2018 Jane Doe
-            #
-            # spdx-License-Identifier: GPL-3.0-or-later
-
-            hello
-            world
-            """
-        )
-        .replace("spdx", "SPDX")
-        .replace("\n", line_ending)
-    )
+    assert contents == expected


### PR DESCRIPTION
Will fix #187 once I've worked out all the details. I began by doing some refactoring in `_comment` to stop stripping all the text. I'll continue by removing the stripping from `header`, and then finally we'll get somewhere hopefully.