### PR TITLE
Tidy up workflows and extend by multi-platform Docker image push

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -13,7 +13,7 @@ on:
     # - 1 (not with 0 though)
     # - latest"
     tags:
-      - 'v*.*.*'
+      - "v*.*.*"
     # Main branch will be "dev"
     branches:
       - main
@@ -53,7 +53,6 @@ jobs:
         run: |
           docker run -v "$(pwd):/data" reuse-debian
 
-
   # ===========================================================================
   # Build and push Docker images for tagged releases
   # ===========================================================================
@@ -63,7 +62,9 @@ jobs:
     # Depends on successful Docker build/test
     needs:
       - docker_test
-    if: ${{ github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/v') }}
+    if:
+      ${{ github.event_name != 'pull_request' && startsWith(github.ref,
+      'refs/tags/v') }}
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
@@ -129,7 +130,9 @@ jobs:
     needs:
       - docker_test
     # TODO: remove master when we switched to main
-    if: ${{ github.event_name != 'pull_request' && ( github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' ) }}
+    if:
+      ${{ github.event_name != 'pull_request' && ( github.ref ==
+      'refs/heads/main' || github.ref == 'refs/heads/master' ) }}
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -3,31 +3,178 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-name: Docker
+name: Docker Images - test, build and push
 
-on: [push, pull_request]
+on:
+  push:
+    # Tags will carry the tag's version, e.g. v1.2.3:
+    # - 1.2.3
+    # - 1.2
+    # - 1 (not with 0 though)
+    # - latest"
+    tags:
+      - 'v*.*.*'
+    # Main branch will be "dev"
+    branches:
+      - main
+      # TODO: remove as soon as master -> main branch
+      - master
+  # On PRs only do tests
+  pull_request:
 
 jobs:
-  docker:
+  # ===========================================================================
+  # Test Docker images
+  # ===========================================================================
+  docker_test:
+    name: Test the docker images
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
+      # Dockerfile
       - name: Build Dockerfile
         run: |
           docker build -t reuse .
       - name: Run Docker image
         run: |
           docker run -v "$(pwd):/data" reuse
+      # Dockerfile-extra
       - name: Build Dockerfile-extra
         run: |
           docker build -t reuse-extra --file Dockerfile-extra .
       - name: Run Docker extra image
         run: |
           docker run -v "$(pwd):/data" reuse-extra
+      # Dockerfile-debian
       - name: Build Dockerfile-debian
         run: |
           docker build -t reuse-debian --file Dockerfile-debian .
       - name: Run Docker debian image
         run: |
           docker run -v "$(pwd):/data" reuse-debian
+
+
+  # ===========================================================================
+  # Build and push Docker images for tagged releases
+  # ===========================================================================
+  docker_push_tag:
+    name: Push Docker image for tags to Docker Hub
+    runs-on: ubuntu-latest
+    # Depends on successful Docker build/test
+    needs:
+      - docker_test
+    if: ${{ github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/v') }}
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      # Dockerfile
+      - name: Default Docker - set metadata
+        id: meta_default
+        uses: docker/metadata-action@v3
+        with:
+          images: mxmehl/docker-ci-test
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
+      - name: Default Docker - build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta_default.outputs.tags }}
+          labels: ${{ steps.meta_default.outputs.labels }}
+
+      # Dockerfile-debian
+      - name: Debian Docker - set metadata
+        id: meta_debian
+        uses: docker/metadata-action@v3
+        with:
+          images: mxmehl/docker-ci-test
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
+          flavor: |
+            suffix=-debian,onlatest=true
+      - name: Debian Docker - build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile-debian
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta_debian.outputs.tags }}
+          labels: ${{ steps.meta_debian.outputs.labels }}
+
+  # ===========================================================================
+  # Build and push Docker images for main branch updated (dev tag)
+  # ===========================================================================
+  docker_push_dev:
+    name: Push Docker image for main branch to Docker Hub
+    runs-on: ubuntu-latest
+    # Depends on successful Docker build/test
+    needs:
+      - docker_test
+    # TODO: remove master when we switched to main
+    if: ${{ github.event_name != 'pull_request' && ( github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' ) }}
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      # Dockerfile
+      - name: Default Docker - set metadata
+        id: meta_default
+        uses: docker/metadata-action@v3
+        with:
+          images: mxmehl/docker-ci-test
+          tags: |
+            type=raw,value=dev
+      - name: Default Docker - build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta_default.outputs.tags }}
+          labels: ${{ steps.meta_default.outputs.labels }}
+
+      # Dockerfile-debian
+      - name: Debian Docker - set metadata
+        id: meta_debian
+        uses: docker/metadata-action@v3
+        with:
+          images: mxmehl/docker-ci-test
+          tags: |
+            type=raw,value=dev-debian
+      - name: Debian Docker - build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile-debian
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta_debian.outputs.tags }}
+          labels: ${{ steps.meta_debian.outputs.labels }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V. <https://fsfe.org>
+# SPDX-FileCopyrightText: 2022 Carmen Bianca Bakker <carmenbianca@fsfe.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+name: Docker
+
+on: [push, pull_request]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build Dockerfile
+        run: |
+          docker build -t reuse .
+      - name: Run Docker image
+        run: |
+          docker run -v "$(pwd):/data" reuse
+      - name: Build Dockerfile-extra
+        run: |
+          docker build -t reuse-extra --file Dockerfile-extra .
+      - name: Run Docker extra image
+        run: |
+          docker run -v "$(pwd):/data" reuse-extra
+      - name: Build Dockerfile-debian
+        run: |
+          docker build -t reuse-debian --file Dockerfile-debian .
+      - name: Run Docker debian image
+        run: |
+          docker run -v "$(pwd):/data" reuse-debian

--- a/.github/workflows/latesttag.yaml
+++ b/.github/workflows/latesttag.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-name: Verify latest tag
+name: Verify latest version tag on PyPI equals version on head of default branch
 
 on:
   schedule:

--- a/.github/workflows/pythonpackage.yaml
+++ b/.github/workflows/pythonpackage.yaml
@@ -104,27 +104,3 @@ jobs:
       - name: Create docs with Sphinx
         run: |
           make docs
-
-  docker:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Build Dockerfile
-        run: |
-          docker build -t reuse .
-      - name: Run Docker image
-        run: |
-          docker run -v "$(pwd):/data" reuse
-      - name: Build Dockerfile-extra
-        run: |
-          docker build -t reuse-extra --file Dockerfile-extra .
-      - name: Run Docker extra image
-        run: |
-          docker run -v "$(pwd):/data" reuse-extra
-      - name: Build Dockerfile-debian
-        run: |
-          docker build -t reuse-debian --file Dockerfile-debian .
-      - name: Run Docker debian image
-        run: |
-          docker run -v "$(pwd):/data" reuse-debian


### PR DESCRIPTION
- Move Docker out of pythonpackage
- Better describe latesttag
- Make docker workflow also push the Docker images to Dockerhub (as they made autobuild cost money)
- Publish docker images as amd64 and arm64. Fixes #449