### PR TITLE
Extend .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,4 +2,19 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+# SPDX resources
 /src/reuse/resources/*.json
+
+# Additional paths in which third-party code/files are located
+.env
+.pytest_cache/
+.tox/
+.venv
+build/
+dist/
+docs/_build/
+env.bak/
+env/
+ENV/
+venv.bak/
+venv/


### PR DESCRIPTION
Some people have a `/venv` which makes `make prettier` go though all files there.

You could theoretically also make prettier just be based on `.gitignore`, but that would then not ignore the SPDX files.

So given this, the while .prettierignore file probably has to be extended to catch locally ignored files, e.g. .Python, dist, lib, .cache or whatever, that are currently caught by .gitignore.

@carmenbianca What do you think?