### PR TITLE
Ignore more SPDX file formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ The versions follow [semantic versioning](https://semver.org).
 
   - V-Lang (#432)
 
+- Ignore all SPDX files with their typical formats and extensions (#494).
+
 ### Changed
 
 - Use `setuptools` instead of the deprecated `distutils` which will be removed

--- a/src/reuse/__init__.py
+++ b/src/reuse/__init__.py
@@ -53,11 +53,20 @@ _IGNORE_FILE_PATTERNS = [
     re.compile(r"^\.gitkeep$"),
     re.compile(r"^\.hgtags$"),
     re.compile(r".*\.license$"),
-    re.compile(r".*\.spdx$"),
     # Workaround for https://github.com/fsfe/reuse-tool/issues/229
     re.compile(r"^CAL-1.0(-Combined-Work-Exception)?(\..+)?$"),
     re.compile(r"^SHL-2.1(\..+)?$"),
 ]
+
+_IGNORE_SPDX_PATTERNS = [
+    # SPDX files from
+    # https://spdx.github.io/spdx-spec/conformance/#44-standard-data-format-requirements
+    re.compile(r".*\.spdx$"),
+    re.compile(r".*\.spdx.(rdf|json|xml|ya?ml)$"),
+]
+
+# Combine SPDX patterns into file patterns to ease default ignore usage
+_IGNORE_FILE_PATTERNS.extend(_IGNORE_SPDX_PATTERNS)
 
 #: Simple structure for holding SPDX information.
 #:

--- a/src/reuse/spdx.py
+++ b/src/reuse/spdx.py
@@ -9,6 +9,7 @@ import logging
 import sys
 from gettext import gettext as _
 
+from . import _IGNORE_SPDX_PATTERNS
 from ._util import PathType
 from .project import Project
 from .report import ProjectReport
@@ -28,9 +29,19 @@ def run(args, project: Project, out=sys.stdout) -> int:
     with contextlib.ExitStack() as stack:
         if args.file:
             out = stack.enter_context(args.file.open("w", encoding="utf-8"))
-            if args.file.suffix != ".spdx":
+            spdxfile = [
+                pattern
+                for pattern in _IGNORE_SPDX_PATTERNS
+                if pattern.match(args.file.name)
+            ]
+            if not spdxfile:
+                # pylint: disable=line-too-long
                 _LOGGER.warning(
-                    _("'{path}' does not end with .spdx").format(path=out.name)
+                    _(
+                        "'{path}' does not match a common SPDX file pattern. Find"
+                        " the suggested naming conventions here:"
+                        " https://spdx.github.io/spdx-spec/conformance/#44-standard-data-format-requirements"
+                    ).format(path=out.name)
                 )
 
         report = ProjectReport.generate(

--- a/src/reuse/spdx.py
+++ b/src/reuse/spdx.py
@@ -29,12 +29,10 @@ def run(args, project: Project, out=sys.stdout) -> int:
     with contextlib.ExitStack() as stack:
         if args.file:
             out = stack.enter_context(args.file.open("w", encoding="utf-8"))
-            spdxfile = [
-                pattern
+            if not any(
+                pattern.match(args.file.name)
                 for pattern in _IGNORE_SPDX_PATTERNS
-                if pattern.match(args.file.name)
-            ]
-            if not spdxfile:
+            ):
                 # pylint: disable=line-too-long
                 _LOGGER.warning(
                     _(


### PR DESCRIPTION
Fixes #442

The regexes could also be combined to `.*\.spdx(.(rdf|json|xml|ya?ml))?$` but I figured that this may rather increase confusion. One could also simplify `ya?ml` to `yaml|yml` but I think that's still an easy one.