### PR TITLE
ignore meson subproject directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ The versions follow [semantic versioning](https://semver.org).
 
 - Recommendations for installation/run methods: package managers and pipx (#457)
 - Docker images for AArch64 (#478)
+- [Meson subprojects](https://mesonbuild.com/Subprojects.html) are now ignored
+  by default (#496)
 
 - More file types are recognised:
 

--- a/src/reuse/__init__.py
+++ b/src/reuse/__init__.py
@@ -45,6 +45,10 @@ _IGNORE_DIR_PATTERNS = [
     re.compile(r"^\.reuse$"),
 ]
 
+_IGNORE_MESON_PARENT_DIR_PATTERNS = [
+    re.compile(r"^subprojects$"),
+]
+
 _IGNORE_FILE_PATTERNS = [
     re.compile(r"^LICENSE"),
     re.compile(r"^COPYING"),

--- a/src/reuse/_main.py
+++ b/src/reuse/_main.py
@@ -74,6 +74,11 @@ def parser() -> argparse.ArgumentParser:
         help=_("do not skip over Git submodules"),
     )
     parser.add_argument(
+        "--include-meson-subprojects",
+        action="store_true",
+        help=_("do not skip over Meson subprojects"),
+    )
+    parser.add_argument(
         "--no-multiprocessing",
         action="store_true",
         help=_("do not use multiprocessing"),
@@ -263,6 +268,7 @@ def main(args: List[str] = None, out=sys.stdout) -> int:
     else:
         project = create_project()
     project.include_submodules = parsed_args.include_submodules
+    project.include_meson_subprojects = parsed_args.include_meson_subprojects
 
     return parsed_args.func(parsed_args, project, out)
 

--- a/src/reuse/project.py
+++ b/src/reuse/project.py
@@ -20,6 +20,7 @@ from license_expression import ExpressionError
 
 from . import (
     _IGNORE_DIR_PATTERNS,
+    _IGNORE_MESON_PARENT_DIR_PATTERNS,
     _IGNORE_FILE_PATTERNS,
     IdentifierNotFound,
     SpdxInfo,
@@ -45,7 +46,12 @@ class Project:
     interactions.
     """
 
-    def __init__(self, root: PathLike, include_submodules: bool = False):
+    def __init__(
+        self,
+        root: PathLike,
+        include_submodules: bool = False,
+        include_meson_subprojects: bool = False,
+    ):
         self._root = Path(root)
         if not self._root.is_dir():
             raise NotADirectoryError(f"{self._root} is no valid path")
@@ -67,6 +73,12 @@ class Project:
         # Use '0' as None, because None is a valid value...
         self._copyright_val = 0
         self.include_submodules = include_submodules
+
+        meson_build_path = self._root / "meson.build"
+        uses_meson = meson_build_path.is_file()
+        self.include_meson_subprojects = (
+            include_meson_subprojects and uses_meson
+        )
 
     def all_files(self, directory: PathLike = None) -> Iterator[Path]:
         """Yield all files in *directory* and its subdirectories.
@@ -174,6 +186,8 @@ class Project:
     def _is_path_ignored(self, path: Path) -> bool:
         """Is *path* ignored by some mechanism?"""
         name = path.name
+        parent_parts = path.parent.parts
+        parent_dir = parent_parts[-1] if len(parent_parts) > 0 else ""
         if path.is_file():
             for pattern in _IGNORE_FILE_PATTERNS:
                 if pattern.match(name):
@@ -182,6 +196,10 @@ class Project:
             for pattern in _IGNORE_DIR_PATTERNS:
                 if pattern.match(name):
                     return True
+            if not self.include_meson_subprojects:
+                for pattern in _IGNORE_MESON_PARENT_DIR_PATTERNS:
+                    if pattern.match(parent_dir):
+                        return True
 
         if self.vcs_strategy.is_ignored(path):
             return True

--- a/src/reuse/project.py
+++ b/src/reuse/project.py
@@ -20,8 +20,8 @@ from license_expression import ExpressionError
 
 from . import (
     _IGNORE_DIR_PATTERNS,
-    _IGNORE_MESON_PARENT_DIR_PATTERNS,
     _IGNORE_FILE_PATTERNS,
+    _IGNORE_MESON_PARENT_DIR_PATTERNS,
     IdentifierNotFound,
     SpdxInfo,
 )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -94,6 +94,97 @@ def test_lint_submodule_included_fail(submodule_repository, stringio):
     assert ":-(" in stringio.getvalue()
 
 
+def test_lint_meson_subprojects(fake_repository, stringio):
+    """Run a successful lint."""
+    (fake_repository / "meson.build").write_text(
+        "SPDX-FileCopyrightText: 2022 Jane Doe\n"
+        "SPDX-License-Identifier: CC0-1.0"
+    )
+    subprojects_dir = fake_repository / "subprojects"
+    subprojects_dir.mkdir()
+    libfoo_dir = subprojects_dir / "libfoo"
+    libfoo_dir.mkdir()
+		# ./subprojects/foo.wrap has license and linter succeeds
+    (subprojects_dir / "foo.wrap").write_text(
+        "SPDX-FileCopyrightText: 2022 Jane Doe\n"
+        "SPDX-License-Identifier: CC0-1.0"
+    )
+    # ./subprojects/libfoo/foo.c misses license but is ignored
+    (libfoo_dir / "foo.c").write_text("foo")
+    result = main(["lint"], out=stringio)
+
+    assert result == 0
+    assert ":-)" in stringio.getvalue()
+
+
+def test_lint_meson_subprojects_fail(fake_repository, stringio):
+    """Run a successful lint."""
+    (fake_repository / "meson.build").write_text(
+        "SPDX-FileCopyrightText: 2022 Jane Doe\n"
+        "SPDX-License-Identifier: CC0-1.0"
+    )
+    subprojects_dir = fake_repository / "subprojects"
+    subprojects_dir.mkdir()
+    libfoo_dir = subprojects_dir / "libfoo"
+    libfoo_dir.mkdir()
+		# ./subprojects/foo.wrap misses license and linter fails
+    (subprojects_dir / "foo.wrap").write_text("foo")
+    # ./subprojects/libfoo/foo.c misses license but is ignored
+    (libfoo_dir / "foo.c").write_text("foo")
+    result = main(["lint"], out=stringio)
+
+    assert result == 1
+    assert ":-(" in stringio.getvalue()
+
+
+def test_lint_meson_subprojects_included_fail(fake_repository, stringio):
+    """Run a successful lint."""
+    (fake_repository / "meson.build").write_text(
+        "SPDX-FileCopyrightText: 2022 Jane Doe\n"
+        "SPDX-License-Identifier: CC0-1.0"
+    )
+    subprojects_dir = fake_repository / "subprojects"
+    subprojects_dir.mkdir()
+    libfoo_dir = subprojects_dir / "libfoo"
+    libfoo_dir.mkdir()
+		# ./subprojects/foo.wrap has license
+    (subprojects_dir / "foo.wrap").write_text(
+        "SPDX-FileCopyrightText: 2022 Jane Doe\n"
+        "SPDX-License-Identifier: CC0-1.0"
+    )
+    # ./subprojects/libfoo/foo.c misses license and linter fails
+    (libfoo_dir / "foo.c").write_text("foo")
+    result = main(["--include-meson-subprojects", "lint"], out=stringio)
+
+    assert result == 1
+    assert ":-(" in stringio.getvalue()
+
+
+def test_lint_meson_subprojects_included(fake_repository, stringio):
+    """Run a successful lint."""
+    (fake_repository / "meson.build").write_text(
+        "SPDX-FileCopyrightText: 2022 Jane Doe\n"
+        "SPDX-License-Identifier: CC0-1.0"
+    )
+    subprojects_dir = fake_repository / "subprojects"
+    subprojects_dir.mkdir()
+    libfoo_dir = subprojects_dir / "libfoo"
+    libfoo_dir.mkdir()
+		# ./subprojects/foo.wrap has license
+    (subprojects_dir / "foo.wrap").write_text(
+        "SPDX-FileCopyrightText: 2022 Jane Doe\n"
+        "SPDX-License-Identifier: CC0-1.0"
+    )
+    # ./subprojects/libfoo/foo.c has license and linter succeeds
+    (libfoo_dir / "foo.c").write_text(
+        "SPDX-FileCopyrightText: 2022 Jane Doe\n"
+        "SPDX-License-Identifier: GPL-3.0-or-later"
+    )
+    result = main(["--include-meson-subprojects", "lint"], out=stringio)
+
+    assert result == 0
+    assert ":-)" in stringio.getvalue()
+
 def test_lint_fail(fake_repository, stringio):
     """Run a failed lint."""
     (fake_repository / "foo.py").write_text("foo")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -96,7 +96,7 @@ def test_lint_submodule_included_fail(submodule_repository, stringio):
 
 
 def test_lint_meson_subprojects(fake_repository, stringio):
-    """Run a successful lint."""
+    """Verify that subprojects are ignored."""
     (fake_repository / "meson.build").write_text(
         cleandoc(
             """
@@ -127,7 +127,7 @@ def test_lint_meson_subprojects(fake_repository, stringio):
 
 
 def test_lint_meson_subprojects_fail(fake_repository, stringio):
-    """Run a successful lint."""
+    """Verify that files in './subprojects' are not ignored."""
     (fake_repository / "meson.build").write_text(
         cleandoc(
             """
@@ -138,12 +138,8 @@ def test_lint_meson_subprojects_fail(fake_repository, stringio):
     )
     subprojects_dir = fake_repository / "subprojects"
     subprojects_dir.mkdir()
-    libfoo_dir = subprojects_dir / "libfoo"
-    libfoo_dir.mkdir()
     # ./subprojects/foo.wrap misses license and linter fails
     (subprojects_dir / "foo.wrap").write_text("foo")
-    # ./subprojects/libfoo/foo.c misses license but is ignored
-    (libfoo_dir / "foo.c").write_text("foo")
     result = main(["lint"], out=stringio)
 
     assert result == 1
@@ -151,7 +147,7 @@ def test_lint_meson_subprojects_fail(fake_repository, stringio):
 
 
 def test_lint_meson_subprojects_included_fail(fake_repository, stringio):
-    """Run a successful lint."""
+    """When Meson subprojects are included, fail on errors."""
     (fake_repository / "meson.build").write_text(
         cleandoc(
             """
@@ -160,19 +156,8 @@ def test_lint_meson_subprojects_included_fail(fake_repository, stringio):
             """
         ).replace("spdx", "SPDX")
     )
-    subprojects_dir = fake_repository / "subprojects"
-    subprojects_dir.mkdir()
-    libfoo_dir = subprojects_dir / "libfoo"
-    libfoo_dir.mkdir()
-    # ./subprojects/foo.wrap has license
-    (subprojects_dir / "foo.wrap").write_text(
-        cleandoc(
-            """
-            spdx-FileCopyrightText: 2022 Jane Doe
-            spdx-License-Identifier: CC0-1.0
-            """
-        ).replace("spdx", "SPDX")
-    )
+    libfoo_dir = fake_repository / "subprojects/libfoo"
+    libfoo_dir.mkdir(parents=True)
     # ./subprojects/libfoo/foo.c misses license and linter fails
     (libfoo_dir / "foo.c").write_text("foo")
     result = main(["--include-meson-subprojects", "lint"], out=stringio)
@@ -182,7 +167,7 @@ def test_lint_meson_subprojects_included_fail(fake_repository, stringio):
 
 
 def test_lint_meson_subprojects_included(fake_repository, stringio):
-    """Run a successful lint."""
+    """Successfully lint when Meson subprojects are included."""
     (fake_repository / "meson.build").write_text(
         cleandoc(
             """
@@ -191,19 +176,8 @@ def test_lint_meson_subprojects_included(fake_repository, stringio):
             """
         ).replace("spdx", "SPDX")
     )
-    subprojects_dir = fake_repository / "subprojects"
-    subprojects_dir.mkdir()
-    libfoo_dir = subprojects_dir / "libfoo"
-    libfoo_dir.mkdir()
-    # ./subprojects/foo.wrap has license
-    (subprojects_dir / "foo.wrap").write_text(
-        cleandoc(
-            """
-            spdx-FileCopyrightText: 2022 Jane Doe
-            spdx-License-Identifier: CC0-1.0
-            """
-        ).replace("spdx", "SPDX")
-    )
+    libfoo_dir = fake_repository / "subprojects/libfoo"
+    libfoo_dir.mkdir(parents=True)
     # ./subprojects/libfoo/foo.c has license and linter succeeds
     (libfoo_dir / "foo.c").write_text(
         cleandoc(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,6 +12,7 @@
 import errno
 import os
 import re
+from inspect import cleandoc
 from pathlib import Path
 from typing import Optional
 from unittest.mock import create_autospec
@@ -97,17 +98,25 @@ def test_lint_submodule_included_fail(submodule_repository, stringio):
 def test_lint_meson_subprojects(fake_repository, stringio):
     """Run a successful lint."""
     (fake_repository / "meson.build").write_text(
-        "SPDX-FileCopyrightText: 2022 Jane Doe\n"
-        "SPDX-License-Identifier: CC0-1.0"
+        cleandoc(
+            """
+            spdx-FileCopyrightText: 2022 Jane Doe
+            spdx-License-Identifier: CC0-1.0
+            """
+        ).replace("spdx", "SPDX")
     )
     subprojects_dir = fake_repository / "subprojects"
     subprojects_dir.mkdir()
     libfoo_dir = subprojects_dir / "libfoo"
     libfoo_dir.mkdir()
-		# ./subprojects/foo.wrap has license and linter succeeds
+    # ./subprojects/foo.wrap has license and linter succeeds
     (subprojects_dir / "foo.wrap").write_text(
-        "SPDX-FileCopyrightText: 2022 Jane Doe\n"
-        "SPDX-License-Identifier: CC0-1.0"
+        cleandoc(
+            """
+            spdx-FileCopyrightText: 2022 Jane Doe
+            spdx-License-Identifier: CC0-1.0
+            """
+        ).replace("spdx", "SPDX")
     )
     # ./subprojects/libfoo/foo.c misses license but is ignored
     (libfoo_dir / "foo.c").write_text("foo")
@@ -120,14 +129,18 @@ def test_lint_meson_subprojects(fake_repository, stringio):
 def test_lint_meson_subprojects_fail(fake_repository, stringio):
     """Run a successful lint."""
     (fake_repository / "meson.build").write_text(
-        "SPDX-FileCopyrightText: 2022 Jane Doe\n"
-        "SPDX-License-Identifier: CC0-1.0"
+        cleandoc(
+            """
+            spdx-FileCopyrightText: 2022 Jane Doe
+            spdx-License-Identifier: CC0-1.0
+            """
+        ).replace("spdx", "SPDX")
     )
     subprojects_dir = fake_repository / "subprojects"
     subprojects_dir.mkdir()
     libfoo_dir = subprojects_dir / "libfoo"
     libfoo_dir.mkdir()
-		# ./subprojects/foo.wrap misses license and linter fails
+    # ./subprojects/foo.wrap misses license and linter fails
     (subprojects_dir / "foo.wrap").write_text("foo")
     # ./subprojects/libfoo/foo.c misses license but is ignored
     (libfoo_dir / "foo.c").write_text("foo")
@@ -140,17 +153,25 @@ def test_lint_meson_subprojects_fail(fake_repository, stringio):
 def test_lint_meson_subprojects_included_fail(fake_repository, stringio):
     """Run a successful lint."""
     (fake_repository / "meson.build").write_text(
-        "SPDX-FileCopyrightText: 2022 Jane Doe\n"
-        "SPDX-License-Identifier: CC0-1.0"
+        cleandoc(
+            """
+            spdx-FileCopyrightText: 2022 Jane Doe
+            spdx-License-Identifier: CC0-1.0
+            """
+        ).replace("spdx", "SPDX")
     )
     subprojects_dir = fake_repository / "subprojects"
     subprojects_dir.mkdir()
     libfoo_dir = subprojects_dir / "libfoo"
     libfoo_dir.mkdir()
-		# ./subprojects/foo.wrap has license
+    # ./subprojects/foo.wrap has license
     (subprojects_dir / "foo.wrap").write_text(
-        "SPDX-FileCopyrightText: 2022 Jane Doe\n"
-        "SPDX-License-Identifier: CC0-1.0"
+        cleandoc(
+            """
+            spdx-FileCopyrightText: 2022 Jane Doe
+            spdx-License-Identifier: CC0-1.0
+            """
+        ).replace("spdx", "SPDX")
     )
     # ./subprojects/libfoo/foo.c misses license and linter fails
     (libfoo_dir / "foo.c").write_text("foo")
@@ -163,27 +184,40 @@ def test_lint_meson_subprojects_included_fail(fake_repository, stringio):
 def test_lint_meson_subprojects_included(fake_repository, stringio):
     """Run a successful lint."""
     (fake_repository / "meson.build").write_text(
-        "SPDX-FileCopyrightText: 2022 Jane Doe\n"
-        "SPDX-License-Identifier: CC0-1.0"
+        cleandoc(
+            """
+            spdx-FileCopyrightText: 2022 Jane Doe
+            spdx-License-Identifier: CC0-1.0
+            """
+        ).replace("spdx", "SPDX")
     )
     subprojects_dir = fake_repository / "subprojects"
     subprojects_dir.mkdir()
     libfoo_dir = subprojects_dir / "libfoo"
     libfoo_dir.mkdir()
-		# ./subprojects/foo.wrap has license
+    # ./subprojects/foo.wrap has license
     (subprojects_dir / "foo.wrap").write_text(
-        "SPDX-FileCopyrightText: 2022 Jane Doe\n"
-        "SPDX-License-Identifier: CC0-1.0"
+        cleandoc(
+            """
+            spdx-FileCopyrightText: 2022 Jane Doe
+            spdx-License-Identifier: CC0-1.0
+            """
+        ).replace("spdx", "SPDX")
     )
     # ./subprojects/libfoo/foo.c has license and linter succeeds
     (libfoo_dir / "foo.c").write_text(
-        "SPDX-FileCopyrightText: 2022 Jane Doe\n"
-        "SPDX-License-Identifier: GPL-3.0-or-later"
+        cleandoc(
+            """
+            spdx-FileCopyrightText: 2022 Jane Doe
+            spdx-License-Identifier: GPL-3.0-or-later
+            """
+        ).replace("spdx", "SPDX")
     )
     result = main(["--include-meson-subprojects", "lint"], out=stringio)
 
     assert result == 0
     assert ":-)" in stringio.getvalue()
+
 
 def test_lint_fail(fake_repository, stringio):
     """Run a failed lint."""


### PR DESCRIPTION
Meson subprojects should be handled similarly to git submodules. Meson
subprojects may actually be git submodules, but they may also just be
regular directories e.g. included via git subtree or via other means.

If the project of question uses meson as its build system, e.g. has the
following file:

    ./meson.build

Then directories in the subprojects root directory should be ignored by
default:

    ./subprojects/libfoo/foo.c
    ./subprojects/libbar/bar.c

Normal files in the subprojects root directory are normally parsed:

    ./subprojects/libfoo.wrap
    ./subprojects/libbar.wrap

This can be overriden with the command line switch:

    reuse --include-meson-subprojects lint

Relevant resources are at [1] and [2].

[1] https://mesonbuild.com/Subprojects.html
[2] https://mesonbuild.com/Wrap-dependency-system-manual.html