### PR TITLE
Make update-resources pull from latest stable release

### DIFF
--- a/.github/workflows/license_list_up_to_date.py
+++ b/.github/workflows/license_list_up_to_date.py
@@ -8,30 +8,43 @@ up-to-date.
 For convenience, also overwrite the files.
 """
 
+import argparse
 import json
 import sys
 import urllib.request
 from pathlib import Path
 
-from packaging import version
-
-API_URL = "https://api.github.com/repos/spdx/license-list-data/tags"
+API_URL = "https://api.github.com/repos/spdx/license-list-data/releases/latest"
 URLS = {
+    # pylint: disable=line-too-long
     "exceptions.json": "https://raw.githubusercontent.com/spdx/license-list-data/{tag}/json/exceptions.json",
     "licenses.json": "https://raw.githubusercontent.com/spdx/license-list-data/{tag}/json/licenses.json",
 }
 
 
+# Fetch arguments
+parser = argparse.ArgumentParser(
+    description="Check and update included SPDX licenses and exceptions"
+)
+parser.add_argument(
+    "-d",
+    "--download",
+    action="store_true",
+    help="if newer licenses/exceptions are found, download them to the repo",
+)
+args = parser.parse_args()
+
+
 def latest_tag():
+    """Find out the tag name of latest stable release of the repo"""
     with urllib.request.urlopen(API_URL) as response:
         contents = response.read().decode("utf-8")
     dictionary = json.loads(contents)
-    tags = [item["name"] for item in dictionary]
-    sorted_tags = sorted(tags, key=version.parse)
-    return sorted_tags[-1]
+    return dictionary["tag_name"]
 
 
-def main():
+def main(args_):
+    """Compare local and remote files, and download if not matching"""
     result = 0
 
     tag = latest_tag()
@@ -40,18 +53,22 @@ def main():
     for file_, url in URLS.items():
         url = url.format(tag=tag)
         path = Path(f"src/reuse/resources/{file_}")
-        local_contents = path.read_text()
+        local_contents = path.read_text(encoding="utf-8")
 
         with urllib.request.urlopen(url) as response:
             remote_contents = response.read().decode("utf-8")
         if remote_contents == local_contents:
             print(f"{file_} is up-to-date")
         else:
-            result = 1
-            print(f"{file_} is not up-to-date")
-            path.write_text(remote_contents)
+            if args_.download:
+                print(f"{file_} is not up-to-date, downloading newer release")
+                path.write_text(remote_contents, encoding="utf-8")
+            else:
+                result = 1
+                print(f"{file_} is not up-to-date")
+
     return result
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(main(args))

--- a/.github/workflows/license_list_up_to_date.yaml
+++ b/.github/workflows/license_list_up_to_date.yaml
@@ -19,10 +19,6 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: 3.x
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install requests
       - name: Verify that the license lists are up-to-date
         run: |
           python .github/workflows/license_list_up_to_date.py

--- a/Makefile
+++ b/Makefile
@@ -126,11 +126,8 @@ install: uninstall install-requirements  ## install reuse
 	python setup.py install
 
 .PHONY: update-resources
-update-resources:  ## update spdx data files
-	curl https://raw.githubusercontent.com/spdx/license-list-data/master/json/licenses.json \
-		> src/reuse/resources/licenses.json
-	curl https://raw.githubusercontent.com/spdx/license-list-data/master/json/exceptions.json \
-		> src/reuse/resources/exceptions.json
+update-resources: ## update spdx data files
+	python .github/workflows/license_list_up_to_date.py --download
 
 .PHONY: develop
 develop: uninstall install-dev-requirements  ## install source directory


### PR DESCRIPTION
Fixes #490

I use a different Github API than @carmenbianca introduced in #489 that directly outputs the latest stable release (no draft or pre-release) and shows the connected tag.

~~Also bumps the SPDX license list data to 3.16, released today.~~