### PR TITLE
Sanitize xargs input in scripts documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ The versions follow [semantic versioning](https://semver.org).
 
 ### Fixed
 
+- Sanitize xargs input in scripts documentation
+
 ### Security
 
 ## 1.0.0 - 2022-05-19

--- a/docs/scripts.rst
+++ b/docs/scripts.rst
@@ -183,7 +183,7 @@ These elements can be combined into a single command:
 
 .. code-block:: console
 
-  $ git diff --name-only --cached | xargs reuse addheader -c "$(git config --get user.name) <$(git config --get user.email)>"
+  $ git diff --name-only --cached | xargs -I {} reuse addheader -c "$(git config --get user.name) <$(git config --get user.email)>" "{}"
 
 .. SPDX-SnippetEnd
 


### PR DESCRIPTION
The xargs command listed in the scripts section of the documentation
uses the unsanitized input from the `git diff` command. This breaks when
files have spaces in their filename. By using the `-I` flag the input
can be quoted.

Signed-off-by: Nico Rikken <nico.rikken@alliander.com>