### PR TITLE
Use ignore blocks instead of hacks

### DIFF
--- a/src/reuse/_util.py
+++ b/src/reuse/_util.py
@@ -53,7 +53,7 @@ _END_PATTERN = r"{}$".format(  # pylint: disable=consider-using-f-string
     )
 )
 _IDENTIFIER_PATTERN = re.compile(
-    r"SPDX" "-License-Identifier:[ \t]+(.*?)" + _END_PATTERN, re.MULTILINE
+    r"SPDX-License-Identifier:[ \t]+(.*?)" + _END_PATTERN, re.MULTILINE
 )
 _COPYRIGHT_PATTERNS = [
     re.compile(

--- a/src/reuse/_util.py
+++ b/src/reuse/_util.py
@@ -74,12 +74,14 @@ _COPYRIGHT_PATTERNS = [
 ]
 
 _COPYRIGHT_STYLES = {
+    # REUSE-IgnoreStart
     "spdx": "SPDX-FileCopyrightText:",
     "spdx-symbol": "SPDX-FileCopyrightText: ©",
     "string": "Copyright",
     "string-c": "Copyright (C)",
     "string-symbol": "Copyright ©",
     "symbol": "©",
+    # REUSE-IgnoreEnd
 }
 
 # Amount of bytes that we assume will be big enough to contain the entire

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,7 @@ CWD = Path.cwd()
 TESTS_DIRECTORY = Path(__file__).parent.resolve()
 RESOURCES_DIRECTORY = TESTS_DIRECTORY / "resources"
 
+# REUSE-IgnoreStart
 
 def pytest_configure():
     """Called after command line options have been parsed and all plugins and
@@ -350,3 +351,5 @@ def mock_date_today(monkeypatch):
     date = create_autospec(datetime.date)
     date.today.return_value = datetime.date(2018, 1, 1)
     monkeypatch.setattr(datetime, "date", date)
+
+# REUSE-IgnoreEnd

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,14 +106,12 @@ def fake_repository(tmpdir_factory) -> Path:
     # Adding this here to avoid conflict in main project.
     (directory / "src/exception.py").write_text(
         "SPDX-FileCopyrightText: 2017 Jane Doe\n"
-        "SPDX"
-        "-License-Identifier: GPL-3.0-or-later WITH Autoconf-exception-3.0",
+        "SPDX-License-Identifier: GPL-3.0-or-later WITH Autoconf-exception-3.0",
         encoding="utf-8",
     )
     (directory / "src/custom.py").write_text(
         "SPDX-FileCopyrightText: 2017 Jane Doe\n"
-        "SPDX"
-        "-License-Identifier: LicenseRef-custom",
+        "SPDX-License-Identifier: LicenseRef-custom",
         encoding="utf-8",
     )
 
@@ -132,10 +130,8 @@ def _repo_contents(
     with a prefix line in the ignore file.
     """
     gitignore = ignore_prefix + (
-        "# SPDX"
-        "-License-Identifier: CC0-1.0\n"
-        "# SPDX"
-        "-FileCopyrightText: 2017 Jane Doe\n"
+        "# SPDX-License-Identifier: CC0-1.0\n"
+        "# SPDX-FileCopyrightText: 2017 Jane Doe\n"
         "*.pyc\nbuild"
     )
     (fake_repository / ignore_filename).write_text(gitignore)
@@ -209,11 +205,11 @@ def submodule_repository(
     """Create a git repository that contains a submodule."""
     header = cleandoc(
         """
-            spdx-FileCopyrightText: 2019 Jane Doe
+            SPDX-FileCopyrightText: 2019 Jane Doe
 
-            spdx-License-Identifier: CC0-1.0
+            SPDX-License-Identifier: CC0-1.0
             """
-    ).replace("spdx", "SPDX")
+    )
 
     submodule = Path(str(tmpdir_factory.mktemp("submodule")))
     (submodule / "foo.py").write_text(header, encoding="utf-8")
@@ -293,7 +289,7 @@ def template_simple_source():
         {% endfor %}
 
         {% for expression in spdx_expressions %}
-        spdx-License-Identifier: {{ expression }}
+        SPDX-License-Identifier: {{ expression }}
         {% endfor %}
         """.replace(
             "spdx-Lic", "SPDX-Lic"
@@ -333,7 +329,7 @@ def template_commented_source():
         {% endfor %}
         #
         {% for expression in spdx_expressions %}
-        # spdx-License-Identifier: {{ expression }}
+        # SPDX-License-Identifier: {{ expression }}
         {% endfor %}
         """.replace(
             "spdx-Lic", "SPDX-Lic"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,7 @@ RESOURCES_DIRECTORY = TESTS_DIRECTORY / "resources"
 
 # REUSE-IgnoreStart
 
+
 def pytest_configure():
     """Called after command line options have been parsed and all plugins and
     initial conftest files been loaded.
@@ -351,5 +352,6 @@ def mock_date_today(monkeypatch):
     date = create_autospec(datetime.date)
     date.today.return_value = datetime.date(2018, 1, 1)
     monkeypatch.setattr(datetime, "date", date)
+
 
 # REUSE-IgnoreEnd

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -17,6 +17,7 @@ from reuse.header import MissingSpdxInfo, create_header, find_and_replace_header
 
 # REUSE-IgnoreStart
 
+
 def test_create_header_simple():
     """Create a super simple header."""
     spdx_info = SpdxInfo(
@@ -409,5 +410,6 @@ def test_find_and_replace_preserve_newline():
     )
 
     assert find_and_replace_header(text, spdx_info) == text
+
 
 # REUSE-IgnoreEnd

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -15,19 +15,18 @@ from reuse import SpdxInfo
 from reuse._comment import CCommentStyle, CommentCreateError
 from reuse.header import MissingSpdxInfo, create_header, find_and_replace_header
 
-
 def test_create_header_simple():
     """Create a super simple header."""
     spdx_info = SpdxInfo(
-        {"GPL-3.0-or-later"}, {"SPDX" "-FileCopyrightText: Jane Doe"}
+        {"GPL-3.0-or-later"}, {"SPDX-FileCopyrightText: Jane Doe"}
     )
     expected = cleandoc(
         """
-        # spdx-FileCopyrightText: Jane Doe
+        # SPDX-FileCopyrightText: Jane Doe
         #
-        # spdx-License-Identifier: GPL-3.0-or-later
+        # SPDX-License-Identifier: GPL-3.0-or-later
         """
-    ).replace("spdx", "SPDX")
+    )
 
     assert create_header(spdx_info).strip() == expected
 
@@ -35,17 +34,17 @@ def test_create_header_simple():
 def test_create_header_template_simple(template_simple):
     """Create a header with a simple template."""
     spdx_info = SpdxInfo(
-        {"GPL-3.0-or-later"}, {"SPDX" "-FileCopyrightText: Jane Doe"}
+        {"GPL-3.0-or-later"}, {"SPDX-FileCopyrightText: Jane Doe"}
     )
     expected = cleandoc(
         """
         # Hello, world!
         #
-        # spdx-FileCopyrightText: Jane Doe
+        # SPDX-FileCopyrightText: Jane Doe
         #
-        # spdx-License-Identifier: GPL-3.0-or-later
+        # SPDX-License-Identifier: GPL-3.0-or-later
         """
-    ).replace("spdx", "SPDX")
+    )
 
     assert (
         create_header(spdx_info, template=template_simple).strip() == expected
@@ -55,7 +54,7 @@ def test_create_header_template_simple(template_simple):
 def test_create_header_template_no_spdx(template_no_spdx):
     """Create a header with a template that does not have all SPDX info."""
     spdx_info = SpdxInfo(
-        {"GPL-3.0-or-later"}, {"SPDX" "-FileCopyrightText: Jane Doe"}
+        {"GPL-3.0-or-later"}, {"SPDX-FileCopyrightText: Jane Doe"}
     )
 
     with pytest.raises(MissingSpdxInfo):
@@ -65,17 +64,17 @@ def test_create_header_template_no_spdx(template_no_spdx):
 def test_create_header_template_commented(template_commented):
     """Create a header with an already-commented template."""
     spdx_info = SpdxInfo(
-        {"GPL-3.0-or-later"}, {"SPDX" "-FileCopyrightText: Jane Doe"}
+        {"GPL-3.0-or-later"}, {"SPDX-FileCopyrightText: Jane Doe"}
     )
     expected = cleandoc(
         """
         # Hello, world!
         #
-        # spdx-FileCopyrightText: Jane Doe
+        # SPDX-FileCopyrightText: Jane Doe
         #
-        # spdx-License-Identifier: GPL-3.0-or-later
+        # SPDX-License-Identifier: GPL-3.0-or-later
         """
-    ).replace("spdx", "SPDX")
+    )
 
     assert (
         create_header(
@@ -91,24 +90,24 @@ def test_create_header_template_commented(template_commented):
 def test_create_header_already_contains_spdx():
     """Create a new header from a header that already contains SPDX info."""
     spdx_info = SpdxInfo(
-        {"GPL-3.0-or-later"}, {"SPDX" "-FileCopyrightText: Jane Doe"}
+        {"GPL-3.0-or-later"}, {"SPDX-FileCopyrightText: Jane Doe"}
     )
     existing = cleandoc(
         """
-        # spdx-FileCopyrightText: John Doe
+        # SPDX-FileCopyrightText: John Doe
         #
-        # spdx-License-Identifier: MIT
+        # SPDX-License-Identifier: MIT
         """
-    ).replace("spdx", "SPDX")
+    )
     expected = cleandoc(
         """
-        # spdx-FileCopyrightText: Jane Doe
-        # spdx-FileCopyrightText: John Doe
+        # SPDX-FileCopyrightText: Jane Doe
+        # SPDX-FileCopyrightText: John Doe
         #
-        # spdx-License-Identifier: GPL-3.0-or-later
-        # spdx-License-Identifier: MIT
+        # SPDX-License-Identifier: GPL-3.0-or-later
+        # SPDX-License-Identifier: MIT
         """
-    ).replace("spdx", "SPDX")
+    )
 
     assert create_header(spdx_info, header=existing).strip() == expected
 
@@ -116,15 +115,15 @@ def test_create_header_already_contains_spdx():
 def test_create_header_existing_is_wrong():
     """If the existing header contains errors, raise a CommentCreateError."""
     spdx_info = SpdxInfo(
-        {"GPL-3.0-or-later"}, {"SPDX" "-FileCopyrightText: Jane Doe"}
+        {"GPL-3.0-or-later"}, {"SPDX-FileCopyrightText: Jane Doe"}
     )
     existing = cleandoc(
         """
-        # spdx-FileCopyrightText: John Doe
+        # SPDX-FileCopyrightText: John Doe
         #
-        # spdx-License-Identifier: MIT AND OR 0BSD
+        # SPDX-License-Identifier: MIT AND OR 0BSD
         """
-    ).replace("spdx", "SPDX")
+    )
 
     with pytest.raises(CommentCreateError):
         create_header(spdx_info, header=existing)
@@ -142,9 +141,9 @@ def test_create_header_old_syntax():
         """
         # Copyright John Doe
         #
-        # spdx-License-Identifier: GPL-3.0-or-later
+        # SPDX-License-Identifier: GPL-3.0-or-later
         """
-    ).replace("spdx", "SPDX")
+    )
 
     assert create_header(spdx_info, header=existing).strip() == expected
 
@@ -154,20 +153,20 @@ def test_create_header_remove_fluff():
     spdx_info = SpdxInfo({"GPL-3.0-or-later"}, set())
     existing = cleandoc(
         """
-        # spdx-FileCopyrightText: John Doe
+        # SPDX-FileCopyrightText: John Doe
         #
         # Hello, world!
 
         pass
         """
-    ).replace("spdx", "SPDX")
+    )
     expected = cleandoc(
         """
         # SPDX-FileCopyrightText: John Doe
         #
-        # spdx-License-Identifier: GPL-3.0-or-later
+        # SPDX-License-Identifier: GPL-3.0-or-later
         """
-    ).replace("spdx", "SPDX")
+    )
 
     assert create_header(spdx_info, header=existing).strip() == expected
 
@@ -175,18 +174,18 @@ def test_create_header_remove_fluff():
 def test_find_and_replace_no_header():
     """Given text without header, add a header."""
     spdx_info = SpdxInfo(
-        {"GPL-3.0-or-later"}, {"SPDX" "-FileCopyrightText: Jane Doe"}
+        {"GPL-3.0-or-later"}, {"SPDX-FileCopyrightText: Jane Doe"}
     )
     text = "pass"
     expected = cleandoc(
         """
-        # spdx-FileCopyrightText: Jane Doe
+        # SPDX-FileCopyrightText: Jane Doe
         #
-        # spdx-License-Identifier: GPL-3.0-or-later
+        # SPDX-License-Identifier: GPL-3.0-or-later
 
         pass
         """
-    ).replace("spdx", "SPDX")
+    )
 
     assert find_and_replace_header(text, spdx_info) == expected
 
@@ -196,13 +195,13 @@ def test_find_and_replace_verbatim():
     spdx_info = SpdxInfo(set(), set())
     text = cleandoc(
         """
-        # spdx-FileCopyrightText: Jane Doe
+        # SPDX-FileCopyrightText: Jane Doe
         #
-        # spdx-License-Identifier: GPL-3.0-or-later
+        # SPDX-License-Identifier: GPL-3.0-or-later
 
         pass
         """
-    ).replace("spdx", "SPDX")
+    )
 
     assert find_and_replace_header(text, spdx_info) == text
 
@@ -212,26 +211,26 @@ def test_find_and_replace_newline_before_header():
     preceding whitespace.
     """
     spdx_info = SpdxInfo(
-        {"GPL-3.0-or-later"}, {"SPDX" "-FileCopyrightText: John Doe"}
+        {"GPL-3.0-or-later"}, {"SPDX-FileCopyrightText: John Doe"}
     )
     text = cleandoc(
         """
-        # spdx-FileCopyrightText: Jane Doe
+        # SPDX-FileCopyrightText: Jane Doe
 
         pass
         """
-    ).replace("spdx", "SPDX")
+    )
     text = "\n" + text
     expected = cleandoc(
         """
-        # spdx-FileCopyrightText: Jane Doe
-        # spdx-FileCopyrightText: John Doe
+        # SPDX-FileCopyrightText: Jane Doe
+        # SPDX-FileCopyrightText: John Doe
         #
-        # spdx-License-Identifier: GPL-3.0-or-later
+        # SPDX-License-Identifier: GPL-3.0-or-later
 
         pass
         """
-    ).replace("spdx", "SPDX")
+    )
 
     assert find_and_replace_header(text, spdx_info) == expected
 
@@ -239,7 +238,7 @@ def test_find_and_replace_newline_before_header():
 def test_find_and_replace_preserve_preceding():
     """When the SPDX header is in the middle of the file, keep it there."""
     spdx_info = SpdxInfo(
-        {"GPL-3.0-or-later"}, {"SPDX" "-FileCopyrightText: John Doe"}
+        {"GPL-3.0-or-later"}, {"SPDX-FileCopyrightText: John Doe"}
     )
     text = cleandoc(
         """
@@ -248,11 +247,11 @@ def test_find_and_replace_preserve_preceding():
         def foo(bar):
             return bar
 
-        # spdx-FileCopyrightText: Jane Doe
+        # SPDX-FileCopyrightText: Jane Doe
 
         pass
         """
-    ).replace("spdx", "SPDX")
+    )
     expected = cleandoc(
         """
         # Hello, world!
@@ -260,14 +259,14 @@ def test_find_and_replace_preserve_preceding():
         def foo(bar):
             return bar
 
-        # spdx-FileCopyrightText: Jane Doe
-        # spdx-FileCopyrightText: John Doe
+        # SPDX-FileCopyrightText: Jane Doe
+        # SPDX-FileCopyrightText: John Doe
         #
-        # spdx-License-Identifier: GPL-3.0-or-later
+        # SPDX-License-Identifier: GPL-3.0-or-later
 
         pass
         """
-    ).replace("spdx", "SPDX")
+    )
 
     assert find_and_replace_header(text, spdx_info) == expected
 
@@ -277,29 +276,29 @@ def test_find_and_replace_keep_shebang():
     it.
     """
     spdx_info = SpdxInfo(
-        {"GPL-3.0-or-later"}, {"SPDX" "-FileCopyrightText: John Doe"}
+        {"GPL-3.0-or-later"}, {"SPDX-FileCopyrightText: John Doe"}
     )
     text = cleandoc(
         """
         #!/usr/bin/env python3
 
-        # spdx-FileCopyrightText: Jane Doe
+        # SPDX-FileCopyrightText: Jane Doe
 
         pass
         """
-    ).replace("spdx", "SPDX")
+    )
     expected = cleandoc(
         """
         #!/usr/bin/env python3
 
-        # spdx-FileCopyrightText: Jane Doe
-        # spdx-FileCopyrightText: John Doe
+        # SPDX-FileCopyrightText: Jane Doe
+        # SPDX-FileCopyrightText: John Doe
         #
-        # spdx-License-Identifier: GPL-3.0-or-later
+        # SPDX-License-Identifier: GPL-3.0-or-later
 
         pass
         """
-    ).replace("spdx", "SPDX")
+    )
 
     assert find_and_replace_header(text, spdx_info) == expected
 
@@ -313,23 +312,23 @@ def test_find_and_replace_separate_shebang():
         """
         #!/usr/bin/env python3
         #!nix-shell -p python3
-        # spdx-FileCopyrightText: Jane Doe
+        # SPDX-FileCopyrightText: Jane Doe
 
         pass
         """
-    ).replace("spdx", "SPDX")
+    )
     expected = cleandoc(
         """
         #!/usr/bin/env python3
         #!nix-shell -p python3
 
-        # spdx-FileCopyrightText: Jane Doe
+        # SPDX-FileCopyrightText: Jane Doe
         #
-        # spdx-License-Identifier: GPL-3.0-or-later
+        # SPDX-License-Identifier: GPL-3.0-or-later
 
         pass
         """
-    ).replace("spdx", "SPDX")
+    )
 
     assert find_and_replace_header(text, spdx_info) == expected
 
@@ -350,13 +349,13 @@ def test_find_and_replace_only_shebang():
         """
         #!/usr/bin/env python3
 
-        # spdx-License-Identifier: GPL-3.0-or-later
+        # SPDX-License-Identifier: GPL-3.0-or-later
 
         # Hello, world!
 
         pass
         """
-    ).replace("spdx", "SPDX")
+    )
 
     assert find_and_replace_header(text, spdx_info) == expected
 
@@ -366,7 +365,7 @@ def test_find_and_replace_keep_old_comment():
     licensing information, preserve it below the REUSE header.
     """
     spdx_info = SpdxInfo(
-        {"GPL-3.0-or-later"}, {"SPDX" "-FileCopyrightText: Jane Doe"}
+        {"GPL-3.0-or-later"}, {"SPDX-FileCopyrightText: Jane Doe"}
     )
     text = cleandoc(
         """
@@ -374,18 +373,18 @@ def test_find_and_replace_keep_old_comment():
 
         pass
         """
-    ).replace("spdx", "SPDX")
+    )
     expected = cleandoc(
         """
-        # spdx-FileCopyrightText: Jane Doe
+        # SPDX-FileCopyrightText: Jane Doe
         #
-        # spdx-License-Identifier: GPL-3.0-or-later
+        # SPDX-License-Identifier: GPL-3.0-or-later
 
         # Hello, world!
 
         pass
         """
-    ).replace("spdx", "SPDX")
+    )
 
     assert find_and_replace_header(text, spdx_info) == expected
 
@@ -397,13 +396,13 @@ def test_find_and_replace_preserve_newline():
     text = (
         cleandoc(
             """
-            # spdx-FileCopyrightText: Jane Doe
+            # SPDX-FileCopyrightText: Jane Doe
             #
-            # spdx-License-Identifier: GPL-3.0-or-later
+            # SPDX-License-Identifier: GPL-3.0-or-later
 
             pass
             """
-        ).replace("spdx", "SPDX")
+        )
         + "\n"
     )
 

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -15,6 +15,8 @@ from reuse import SpdxInfo
 from reuse._comment import CCommentStyle, CommentCreateError
 from reuse.header import MissingSpdxInfo, create_header, find_and_replace_header
 
+# REUSE-IgnoreStart
+
 def test_create_header_simple():
     """Create a super simple header."""
     spdx_info = SpdxInfo(
@@ -407,3 +409,5 @@ def test_find_and_replace_preserve_newline():
     )
 
     assert find_and_replace_header(text, spdx_info) == text
+
+# REUSE-IgnoreEnd

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -82,10 +82,8 @@ def test_lint_deprecated(fake_repository, stringio):
         fake_repository / "LICENSES/GPL-3.0.txt",
     )
     (fake_repository / "foo.py").write_text(
-        "SPDX"
-        "-License-Identifier: GPL-3.0\n"
-        "SPDX"
-        "-FileCopyrightText: Jane Doe"
+        "SPDX-License-Identifier: GPL-3.0\n"
+        "SPDX-FileCopyrightText: Jane Doe"
     )
 
     project = Project(fake_repository)
@@ -99,7 +97,7 @@ def test_lint_deprecated(fake_repository, stringio):
 def test_lint_bad_license(fake_repository, stringio):
     """A bad license is detected."""
     (fake_repository / "foo.py").write_text(
-        "SPDX" "-License-Identifier: bad-license"
+        "SPDX-License-Identifier: bad-license"
     )
     project = Project(fake_repository)
     report = ProjectReport.generate(project)
@@ -112,7 +110,7 @@ def test_lint_bad_license(fake_repository, stringio):
 
 def test_lint_missing_licenses(fake_repository, stringio):
     """A missing license is detected."""
-    (fake_repository / "foo.py").write_text("SPDX" "-License-Identifier: MIT")
+    (fake_repository / "foo.py").write_text("SPDX-License-Identifier: MIT")
     project = Project(fake_repository)
     report = ProjectReport.generate(project)
     result = lint_missing_licenses(report, out=stringio)

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -35,6 +35,7 @@ posix = pytest.mark.skipif(not is_posix, reason="Windows not supported")
 
 # REUSE-IgnoreStart
 
+
 def test_lint_simple(fake_repository):
     """Extremely simple test for lint."""
     project = Project(fake_repository)
@@ -84,8 +85,7 @@ def test_lint_deprecated(fake_repository, stringio):
         fake_repository / "LICENSES/GPL-3.0.txt",
     )
     (fake_repository / "foo.py").write_text(
-        "SPDX-License-Identifier: GPL-3.0\n"
-        "SPDX-FileCopyrightText: Jane Doe"
+        "SPDX-License-Identifier: GPL-3.0\n" "SPDX-FileCopyrightText: Jane Doe"
     )
 
     project = Project(fake_repository)
@@ -155,5 +155,6 @@ def test_lint_files_without_copyright_and_licensing(fake_repository, stringio):
 
     assert "foo.py" in str(list(result)[0])
     assert "foo.py" in stringio.getvalue()
+
 
 # REUSE-IgnoreEnd

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -33,6 +33,8 @@ cpython = pytest.mark.skipif(
 posix = pytest.mark.skipif(not is_posix, reason="Windows not supported")
 
 
+# REUSE-IgnoreStart
+
 def test_lint_simple(fake_repository):
     """Extremely simple test for lint."""
     project = Project(fake_repository)
@@ -153,3 +155,5 @@ def test_lint_files_without_copyright_and_licensing(fake_repository, stringio):
 
     assert "foo.py" in str(list(result)[0])
     assert "foo.py" in stringio.getvalue()
+
+# REUSE-IgnoreEnd

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -85,7 +85,7 @@ def test_lint_deprecated(fake_repository, stringio):
         fake_repository / "LICENSES/GPL-3.0.txt",
     )
     (fake_repository / "foo.py").write_text(
-        "SPDX-License-Identifier: GPL-3.0\n" "SPDX-FileCopyrightText: Jane Doe"
+        "SPDX-License-Identifier: GPL-3.0\nSPDX-FileCopyrightText: Jane Doe"
     )
 
     project = Project(fake_repository)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -24,8 +24,8 @@ from reuse import download
 from reuse._main import main
 from reuse._util import GIT_EXE, HG_EXE
 
-
 # REUSE-IgnoreStart
+
 
 @pytest.fixture(params=[True, False])
 def optional_git_exe(request, monkeypatch) -> Optional[str]:
@@ -374,5 +374,6 @@ def test_supported_licenses(stringio):
         r"GPL-3\.0-or-later\s+GNU General Public License v3\.0 or later\s+https:\/\/spdx\.org\/licenses\/GPL-3\.0-or-later\.html\s+\n",
         stringio.getvalue(),
     )
+
 
 # REUSE-IgnoreEnd

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -25,6 +25,8 @@ from reuse._main import main
 from reuse._util import GIT_EXE, HG_EXE
 
 
+# REUSE-IgnoreStart
+
 @pytest.fixture(params=[True, False])
 def optional_git_exe(request, monkeypatch) -> Optional[str]:
     """Run the test with or without git."""
@@ -372,3 +374,5 @@ def test_supported_licenses(stringio):
         r"GPL-3\.0-or-later\s+GNU General Public License v3\.0 or later\s+https:\/\/spdx\.org\/licenses\/GPL-3\.0-or-later\.html\s+\n",
         stringio.getvalue(),
     )
+
+# REUSE-IgnoreEnd

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -100,10 +100,10 @@ def test_lint_meson_subprojects(fake_repository, stringio):
     (fake_repository / "meson.build").write_text(
         cleandoc(
             """
-            spdx-FileCopyrightText: 2022 Jane Doe
-            spdx-License-Identifier: CC0-1.0
+            SPDX-FileCopyrightText: 2022 Jane Doe
+            SPDX-License-Identifier: CC0-1.0
             """
-        ).replace("spdx", "SPDX")
+        )
     )
     subprojects_dir = fake_repository / "subprojects"
     subprojects_dir.mkdir()
@@ -113,10 +113,10 @@ def test_lint_meson_subprojects(fake_repository, stringio):
     (subprojects_dir / "foo.wrap").write_text(
         cleandoc(
             """
-            spdx-FileCopyrightText: 2022 Jane Doe
-            spdx-License-Identifier: CC0-1.0
+            SPDX-FileCopyrightText: 2022 Jane Doe
+            SPDX-License-Identifier: CC0-1.0
             """
-        ).replace("spdx", "SPDX")
+        )
     )
     # ./subprojects/libfoo/foo.c misses license but is ignored
     (libfoo_dir / "foo.c").write_text("foo")
@@ -131,10 +131,10 @@ def test_lint_meson_subprojects_fail(fake_repository, stringio):
     (fake_repository / "meson.build").write_text(
         cleandoc(
             """
-            spdx-FileCopyrightText: 2022 Jane Doe
-            spdx-License-Identifier: CC0-1.0
+            SPDX-FileCopyrightText: 2022 Jane Doe
+            SPDX-License-Identifier: CC0-1.0
             """
-        ).replace("spdx", "SPDX")
+        )
     )
     subprojects_dir = fake_repository / "subprojects"
     subprojects_dir.mkdir()
@@ -151,10 +151,10 @@ def test_lint_meson_subprojects_included_fail(fake_repository, stringio):
     (fake_repository / "meson.build").write_text(
         cleandoc(
             """
-            spdx-FileCopyrightText: 2022 Jane Doe
-            spdx-License-Identifier: CC0-1.0
+            SPDX-FileCopyrightText: 2022 Jane Doe
+            SPDX-License-Identifier: CC0-1.0
             """
-        ).replace("spdx", "SPDX")
+        )
     )
     libfoo_dir = fake_repository / "subprojects/libfoo"
     libfoo_dir.mkdir(parents=True)
@@ -171,10 +171,10 @@ def test_lint_meson_subprojects_included(fake_repository, stringio):
     (fake_repository / "meson.build").write_text(
         cleandoc(
             """
-            spdx-FileCopyrightText: 2022 Jane Doe
-            spdx-License-Identifier: CC0-1.0
+            SPDX-FileCopyrightText: 2022 Jane Doe
+            SPDX-License-Identifier: CC0-1.0
             """
-        ).replace("spdx", "SPDX")
+        )
     )
     libfoo_dir = fake_repository / "subprojects/libfoo"
     libfoo_dir.mkdir(parents=True)
@@ -182,10 +182,10 @@ def test_lint_meson_subprojects_included(fake_repository, stringio):
     (libfoo_dir / "foo.c").write_text(
         cleandoc(
             """
-            spdx-FileCopyrightText: 2022 Jane Doe
-            spdx-License-Identifier: GPL-3.0-or-later
+            SPDX-FileCopyrightText: 2022 Jane Doe
+            SPDX-License-Identifier: GPL-3.0-or-later
             """
-        ).replace("spdx", "SPDX")
+        )
     )
     result = main(["--include-meson-subprojects", "lint"], out=stringio)
 

--- a/tests/test_main_addheader.py
+++ b/tests/test_main_addheader.py
@@ -17,6 +17,8 @@ import pytest
 from reuse._main import main
 
 
+# REUSE-IgnoreStart
+
 # TODO: Replace this test with a monkeypatched test
 def test_addheader_simple(fake_repository, stringio, mock_date_today):
     """Add a header to a file that does not have one."""
@@ -1143,3 +1145,5 @@ def test_addheader_recursive_contains_unrecognised(
         )
 
     assert "Jane Doe" not in (fake_repository / "baz/foo.py").read_text()
+
+# REUSE-IgnoreEnd

--- a/tests/test_main_addheader.py
+++ b/tests/test_main_addheader.py
@@ -24,13 +24,13 @@ def test_addheader_simple(fake_repository, stringio, mock_date_today):
     simple_file.write_text("pass")
     expected = cleandoc(
         """
-        # spdx-FileCopyrightText: 2018 Jane Doe
+        # SPDX-FileCopyrightText: 2018 Jane Doe
         #
-        # spdx-License-Identifier: GPL-3.0-or-later
+        # SPDX-License-Identifier: GPL-3.0-or-later
 
         pass
         """
-    ).replace("spdx", "SPDX")
+    )
 
     result = main(
         [
@@ -54,13 +54,13 @@ def test_addheader_year(fake_repository, stringio):
     simple_file.write_text("pass")
     expected = cleandoc(
         """
-        # spdx-FileCopyrightText: 2016 Jane Doe
+        # SPDX-FileCopyrightText: 2016 Jane Doe
         #
-        # spdx-License-Identifier: GPL-3.0-or-later
+        # SPDX-License-Identifier: GPL-3.0-or-later
 
         pass
         """
-    ).replace("spdx", "SPDX")
+    )
 
     result = main(
         [
@@ -86,13 +86,13 @@ def test_addheader_no_year(fake_repository, stringio):
     simple_file.write_text("pass")
     expected = cleandoc(
         """
-        # spdx-FileCopyrightText: Jane Doe
+        # SPDX-FileCopyrightText: Jane Doe
         #
-        # spdx-License-Identifier: GPL-3.0-or-later
+        # SPDX-License-Identifier: GPL-3.0-or-later
 
         pass
         """
-    ).replace("spdx", "SPDX")
+    )
 
     result = main(
         [
@@ -117,13 +117,13 @@ def test_addheader_specify_style(fake_repository, stringio, mock_date_today):
     simple_file.write_text("pass")
     expected = cleandoc(
         """
-        // spdx-FileCopyrightText: 2018 Jane Doe
+        // SPDX-FileCopyrightText: 2018 Jane Doe
         //
-        // spdx-License-Identifier: GPL-3.0-or-later
+        // SPDX-License-Identifier: GPL-3.0-or-later
 
         pass
         """
-    ).replace("spdx", "SPDX")
+    )
 
     result = main(
         [
@@ -149,13 +149,13 @@ def test_addheader_implicit_style(fake_repository, stringio, mock_date_today):
     simple_file.write_text("pass")
     expected = cleandoc(
         """
-        // spdx-FileCopyrightText: 2018 Jane Doe
+        // SPDX-FileCopyrightText: 2018 Jane Doe
         //
-        // spdx-License-Identifier: GPL-3.0-or-later
+        // SPDX-License-Identifier: GPL-3.0-or-later
 
         pass
         """
-    ).replace("spdx", "SPDX")
+    )
 
     result = main(
         [
@@ -181,13 +181,13 @@ def test_addheader_implicit_style_filename(
     simple_file.write_text("pass")
     expected = cleandoc(
         """
-        # spdx-FileCopyrightText: 2018 Jane Doe
+        # SPDX-FileCopyrightText: 2018 Jane Doe
         #
-        # spdx-License-Identifier: GPL-3.0-or-later
+        # SPDX-License-Identifier: GPL-3.0-or-later
 
         pass
         """
-    ).replace("spdx", "SPDX")
+    )
 
     result = main(
         [
@@ -292,13 +292,13 @@ def test_addheader_template_simple(
         """
         # Hello, world!
         #
-        # spdx-FileCopyrightText: 2018 Jane Doe
+        # SPDX-FileCopyrightText: 2018 Jane Doe
         #
-        # spdx-License-Identifier: GPL-3.0-or-later
+        # SPDX-License-Identifier: GPL-3.0-or-later
 
         pass
         """
-    ).replace("spdx", "SPDX")
+    )
 
     result = main(
         [
@@ -349,13 +349,13 @@ def test_addheader_template_simple_multiple(
             """
             # Hello, world!
             #
-            # spdx-FileCopyrightText: 2018 Jane Doe
+            # SPDX-FileCopyrightText: 2018 Jane Doe
             #
-            # spdx-License-Identifier: GPL-3.0-or-later
+            # SPDX-License-Identifier: GPL-3.0-or-later
 
             pass
             """
-        ).replace("spdx", "SPDX")
+        )
         assert simple_file.read_text() == expected
 
 
@@ -401,13 +401,13 @@ def test_addheader_template_commented(
         """
         # Hello, world!
         #
-        # spdx-FileCopyrightText: 2018 Jane Doe
+        # SPDX-FileCopyrightText: 2018 Jane Doe
         #
-        # spdx-License-Identifier: GPL-3.0-or-later
+        # SPDX-License-Identifier: GPL-3.0-or-later
 
         pass
         """
-    ).replace("spdx", "SPDX")
+    )
 
     result = main(
         [
@@ -462,13 +462,13 @@ def test_addheader_template_without_extension(
         """
         # Hello, world!
         #
-        # spdx-FileCopyrightText: 2018 Jane Doe
+        # SPDX-FileCopyrightText: 2018 Jane Doe
         #
-        # spdx-License-Identifier: GPL-3.0-or-later
+        # SPDX-License-Identifier: GPL-3.0-or-later
 
         pass
         """
-    ).replace("spdx", "SPDX")
+    )
 
     result = main(
         [
@@ -496,11 +496,11 @@ def test_addheader_binary(
     binary_file.write_bytes(binary_string)
     expected = cleandoc(
         """
-        spdx-FileCopyrightText: 2018 Jane Doe
+        SPDX-FileCopyrightText: 2018 Jane Doe
 
-        spdx-License-Identifier: GPL-3.0-or-later
+        SPDX-License-Identifier: GPL-3.0-or-later
         """
-    ).replace("spdx", "SPDX")
+    )
 
     result = main(
         [
@@ -531,11 +531,11 @@ def test_addheader_uncommentable_json(
     json_file.write_text('{"foo": 23, "bar": 42}')
     expected = cleandoc(
         """
-        spdx-FileCopyrightText: 2018 Jane Doe
+        SPDX-FileCopyrightText: 2018 Jane Doe
 
-        spdx-License-Identifier: GPL-3.0-or-later
+        SPDX-License-Identifier: GPL-3.0-or-later
         """
-    ).replace("spdx", "SPDX")
+    )
 
     result = main(
         [
@@ -564,11 +564,11 @@ def test_addheader_force_dot_license(
     simple_file.write_text("pass")
     expected = cleandoc(
         """
-        spdx-FileCopyrightText: 2018 Jane Doe
+        SPDX-FileCopyrightText: 2018 Jane Doe
 
-        spdx-License-Identifier: GPL-3.0-or-later
+        SPDX-License-Identifier: GPL-3.0-or-later
         """
-    ).replace("spdx", "SPDX")
+    )
 
     result = main(
         [
@@ -605,11 +605,11 @@ def test_addheader_force_dot_license_identical_to_explicit_license(
         path.write_text("pass")
     expected = cleandoc(
         """
-        spdx-FileCopyrightText: 2018 Jane Doe
+        SPDX-FileCopyrightText: 2018 Jane Doe
 
-        spdx-License-Identifier: GPL-3.0-or-later
+        SPDX-License-Identifier: GPL-3.0-or-later
         """
-    ).replace("spdx", "SPDX")
+    )
 
     for arg, path in zip(("--force-dot-license", "--explicit-license"), files):
         main(
@@ -645,11 +645,11 @@ def test_addheader_force_dot_license_double(
     simple_file_license.write_text("foo")
     expected = cleandoc(
         """
-        spdx-FileCopyrightText: 2018 Jane Doe
+        SPDX-FileCopyrightText: 2018 Jane Doe
 
-        spdx-License-Identifier: GPL-3.0-or-later
+        SPDX-License-Identifier: GPL-3.0-or-later
         """
-    ).replace("spdx", "SPDX")
+    )
 
     result = main(
         [
@@ -679,11 +679,11 @@ def test_addheader_force_dot_license_unsupported_filetype(
     simple_file.write_text("Preserve this")
     expected = cleandoc(
         """
-        spdx-FileCopyrightText: 2018 Jane Doe
+        SPDX-FileCopyrightText: 2018 Jane Doe
 
-        spdx-License-Identifier: GPL-3.0-or-later
+        SPDX-License-Identifier: GPL-3.0-or-later
         """
-    ).replace("spdx", "SPDX")
+    )
 
     result = main(
         [
@@ -717,11 +717,11 @@ def test_addheader_force_dot_license_doesnt_write_to_file(
     simple_file.chmod(mode=stat.S_IREAD)
     expected = cleandoc(
         """
-        spdx-FileCopyrightText: 2018 Jane Doe
+        SPDX-FileCopyrightText: 2018 Jane Doe
 
-        spdx-License-Identifier: GPL-3.0-or-later
+        SPDX-License-Identifier: GPL-3.0-or-later
         """
-    ).replace("spdx", "SPDX")
+    )
 
     result = main(
         [
@@ -776,21 +776,21 @@ def test_addheader_license_file(fake_repository, stringio, mock_date_today):
     license_file.write_text(
         cleandoc(
             """
-            spdx-FileCopyrightText: 2016 John Doe
+            SPDX-FileCopyrightText: 2016 John Doe
 
             Hello
             """
-        ).replace("spdx", "SPDX")
+        )
     )
     expected = (
         cleandoc(
             """
-            spdx-FileCopyrightText: 2016 John Doe
-            spdx-FileCopyrightText: 2018 Jane Doe
+            SPDX-FileCopyrightText: 2016 John Doe
+            SPDX-FileCopyrightText: 2018 Jane Doe
 
-            spdx-License-Identifier: GPL-3.0-or-later
+            SPDX-License-Identifier: GPL-3.0-or-later
             """
-        ).replace("spdx", "SPDX")
+        )
         + "\n"
     )
 
@@ -823,22 +823,22 @@ def test_addheader_license_file_only_one_newline(
     license_file.write_text(
         cleandoc(
             """
-            spdx-FileCopyrightText: 2016 John Doe
+            SPDX-FileCopyrightText: 2016 John Doe
 
             Hello
             """
-        ).replace("spdx", "SPDX")
+        )
         + "\n"
     )
     expected = (
         cleandoc(
             """
-            spdx-FileCopyrightText: 2016 John Doe
-            spdx-FileCopyrightText: 2018 Jane Doe
+            SPDX-FileCopyrightText: 2016 John Doe
+            SPDX-FileCopyrightText: 2018 Jane Doe
 
-            spdx-License-Identifier: GPL-3.0-or-later
+            SPDX-License-Identifier: GPL-3.0-or-later
             """
-        ).replace("spdx", "SPDX")
+        )
         + "\n"
     )
 
@@ -939,14 +939,14 @@ def test_addheader_force_multi_line_for_c(
     expected = cleandoc(
         """
                 /*
-                 * spdx-FileCopyrightText: 2018 Jane Doe
+                 * SPDX-FileCopyrightText: 2018 Jane Doe
                  *
-                 * spdx-License-Identifier: GPL-3.0-or-later
+                 * SPDX-License-Identifier: GPL-3.0-or-later
                  */
 
                 foo
                 """
-    ).replace("spdx", "SPDX")
+    )
 
     result = main(
         [
@@ -977,16 +977,14 @@ def test_addheader_line_endings(
     expected = (
         cleandoc(
             """
-            # spdx-FileCopyrightText: 2018 Jane Doe
+            # SPDX-FileCopyrightText: 2018 Jane Doe
             #
-            # spdx-License-Identifier: GPL-3.0-or-later
+            # SPDX-License-Identifier: GPL-3.0-or-later
 
             hello
             world
             """
-        )
-        .replace("spdx", "SPDX")
-        .replace("\n", line_ending)
+        ).replace("\n", line_ending)
     )
 
     result = main(
@@ -1016,22 +1014,22 @@ def test_addheader_skip_existing(fake_repository, stringio, mock_date_today):
         (fake_repository / path).write_text("pass")
     expected_foo = cleandoc(
         """
-        # spdx-FileCopyrightText: 2018 Jane Doe
+        # SPDX-FileCopyrightText: 2018 Jane Doe
         #
-        # spdx-License-Identifier: GPL-3.0-or-later
+        # SPDX-License-Identifier: GPL-3.0-or-later
 
         pass
         """
-    ).replace("spdx", "SPDX")
+    )
     expected_bar = cleandoc(
         """
-        # spdx-FileCopyrightText: 2018 John Doe
+        # SPDX-FileCopyrightText: 2018 John Doe
         #
-        # spdx-License-Identifier: MIT
+        # SPDX-License-Identifier: MIT
 
         pass
         """
-    ).replace("spdx", "SPDX")
+    )
 
     main(
         [
@@ -1069,9 +1067,9 @@ def test_addheader_recursive(fake_repository, stringio, mock_date_today):
     (fake_repository / "src/one/two/foo.py").write_text(
         cleandoc(
             """
-            # spdx-License-Identifier: GPL-3.0-or-later
+            # SPDX-License-Identifier: GPL-3.0-or-later
             """
-        ).replace("spdx", "SPDX")
+        )
     )
     (fake_repository / "src/hello.py").touch()
     (fake_repository / "src/one/world.py").touch()
@@ -1092,7 +1090,7 @@ def test_addheader_recursive(fake_repository, stringio, mock_date_today):
     for path in (fake_repository / "src").glob("src/**"):
         content = path.read_text()
         assert (
-            "spdx-FileCopyrightText: 2018 Joe Somebody".replace("spdx", "SPDX")
+            "SPDX-FileCopyrightText: 2018 Joe Somebody"
             in content
         )
 

--- a/tests/test_main_addheader.py
+++ b/tests/test_main_addheader.py
@@ -16,7 +16,6 @@ import pytest
 
 from reuse._main import main
 
-
 # REUSE-IgnoreStart
 
 # TODO: Replace this test with a monkeypatched test
@@ -976,9 +975,8 @@ def test_addheader_line_endings(
     simple_file.write_bytes(
         line_ending.encode("utf-8").join([b"hello", b"world"])
     )
-    expected = (
-        cleandoc(
-            """
+    expected = cleandoc(
+        """
             # SPDX-FileCopyrightText: 2018 Jane Doe
             #
             # SPDX-License-Identifier: GPL-3.0-or-later
@@ -986,8 +984,7 @@ def test_addheader_line_endings(
             hello
             world
             """
-        ).replace("\n", line_ending)
-    )
+    ).replace("\n", line_ending)
 
     result = main(
         [
@@ -1091,10 +1088,7 @@ def test_addheader_recursive(fake_repository, stringio, mock_date_today):
 
     for path in (fake_repository / "src").glob("src/**"):
         content = path.read_text()
-        assert (
-            "SPDX-FileCopyrightText: 2018 Joe Somebody"
-            in content
-        )
+        assert "SPDX-FileCopyrightText: 2018 Joe Somebody" in content
 
     assert "Joe Somebody" not in (fake_repository / "bar/bar.py").read_text()
     assert result == 0
@@ -1145,5 +1139,6 @@ def test_addheader_recursive_contains_unrecognised(
         )
 
     assert "Jane Doe" not in (fake_repository / "baz/foo.py").read_text()
+
 
 # REUSE-IgnoreEnd

--- a/tests/test_main_addheader_merge.py
+++ b/tests/test_main_addheader_merge.py
@@ -35,13 +35,13 @@ def test_addheader_merge_copyrights_simple(fake_repository, stringio):
         simple_file.read_text()
         == cleandoc(
             """
-            # spdx-FileCopyrightText: 2016 Mary Sue
+            # SPDX-FileCopyrightText: 2016 Mary Sue
             #
-            # spdx-License-Identifier: GPL-3.0-or-later
+            # SPDX-License-Identifier: GPL-3.0-or-later
 
             pass
             """
-        ).replace("spdx", "SPDX")
+        )
     )
 
     result = main(
@@ -64,13 +64,13 @@ def test_addheader_merge_copyrights_simple(fake_repository, stringio):
         simple_file.read_text()
         == cleandoc(
             """
-            # spdx-FileCopyrightText: 2016 - 2018 Mary Sue
+            # SPDX-FileCopyrightText: 2016 - 2018 Mary Sue
             #
-            # spdx-License-Identifier: GPL-3.0-or-later
+            # SPDX-License-Identifier: GPL-3.0-or-later
 
             pass
             """
-        ).replace("spdx", "SPDX")
+        )
     )
 
 
@@ -124,15 +124,15 @@ def test_addheader_merge_copyrights_multi_prefix(fake_repository, stringio):
             # Copyright (C) 2017 Mary Sue
             # Copyright (C) 2018 Mary Sue
             # Copyright (C) 2019 Mary Sue
-            # spdx-FileCopyrightText: 2010 Mary Sue
-            # spdx-FileCopyrightText: 2011 Mary Sue
-            # spdx-FileCopyrightText: 2012 Mary Sue
+            # SPDX-FileCopyrightText: 2010 Mary Sue
+            # SPDX-FileCopyrightText: 2011 Mary Sue
+            # SPDX-FileCopyrightText: 2012 Mary Sue
             #
-            # spdx-License-Identifier: GPL-3.0-or-later
+            # SPDX-License-Identifier: GPL-3.0-or-later
 
             pass
             """
-        ).replace("spdx", "SPDX")
+        )
     )
 
     result = main(
@@ -157,9 +157,9 @@ def test_addheader_merge_copyrights_multi_prefix(fake_repository, stringio):
             """
             # Copyright (C) 2010 - 2019 Mary Sue
             #
-            # spdx-License-Identifier: GPL-3.0-or-later
+            # SPDX-License-Identifier: GPL-3.0-or-later
 
             pass
             """
-        ).replace("spdx", "SPDX")
+        )
     )

--- a/tests/test_main_addheader_merge.py
+++ b/tests/test_main_addheader_merge.py
@@ -9,8 +9,8 @@ from inspect import cleandoc
 
 from reuse._main import main
 
-
 # REUSE-IgnoreStart
+
 
 def test_addheader_merge_copyrights_simple(fake_repository, stringio):
     """Add multiple headers to a file with merge copyrights."""
@@ -33,17 +33,14 @@ def test_addheader_merge_copyrights_simple(fake_repository, stringio):
     )
 
     assert result == 0
-    assert (
-        simple_file.read_text()
-        == cleandoc(
-            """
+    assert simple_file.read_text() == cleandoc(
+        """
             # SPDX-FileCopyrightText: 2016 Mary Sue
             #
             # SPDX-License-Identifier: GPL-3.0-or-later
 
             pass
             """
-        )
     )
 
     result = main(
@@ -62,17 +59,14 @@ def test_addheader_merge_copyrights_simple(fake_repository, stringio):
     )
 
     assert result == 0
-    assert (
-        simple_file.read_text()
-        == cleandoc(
-            """
+    assert simple_file.read_text() == cleandoc(
+        """
             # SPDX-FileCopyrightText: 2016 - 2018 Mary Sue
             #
             # SPDX-License-Identifier: GPL-3.0-or-later
 
             pass
             """
-        )
     )
 
 
@@ -117,10 +111,8 @@ def test_addheader_merge_copyrights_multi_prefix(fake_repository, stringio):
 
         assert result == 0
 
-    assert (
-        simple_file.read_text()
-        == cleandoc(
-            """
+    assert simple_file.read_text() == cleandoc(
+        """
             # Copyright (C) 2015 Mary Sue
             # Copyright (C) 2016 Mary Sue
             # Copyright (C) 2017 Mary Sue
@@ -134,7 +126,6 @@ def test_addheader_merge_copyrights_multi_prefix(fake_repository, stringio):
 
             pass
             """
-        )
     )
 
     result = main(
@@ -153,17 +144,15 @@ def test_addheader_merge_copyrights_multi_prefix(fake_repository, stringio):
     )
 
     assert result == 0
-    assert (
-        simple_file.read_text()
-        == cleandoc(
-            """
+    assert simple_file.read_text() == cleandoc(
+        """
             # Copyright (C) 2010 - 2019 Mary Sue
             #
             # SPDX-License-Identifier: GPL-3.0-or-later
 
             pass
             """
-        )
     )
+
 
 # REUSE-IgnoreEnd

--- a/tests/test_main_addheader_merge.py
+++ b/tests/test_main_addheader_merge.py
@@ -10,6 +10,8 @@ from inspect import cleandoc
 from reuse._main import main
 
 
+# REUSE-IgnoreStart
+
 def test_addheader_merge_copyrights_simple(fake_repository, stringio):
     """Add multiple headers to a file with merge copyrights."""
     simple_file = fake_repository / "foo.py"
@@ -163,3 +165,5 @@ def test_addheader_merge_copyrights_multi_prefix(fake_repository, stringio):
             """
         )
     )
+
+# REUSE-IgnoreEnd

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -100,11 +100,11 @@ def test_all_files_symlinks(empty_directory):
     (empty_directory / "blob.license").write_text(
         cleandoc(
             """
-            spdx-FileCopyrightText: Jane Doe
+            SPDX-FileCopyrightText: Jane Doe
 
-            spdx-License-Identifier: GPL-3.0-or-later
+            SPDX-License-Identifier: GPL-3.0-or-later
             """
-        ).replace("spdx", "SPDX")
+        )
     )
     (empty_directory / "symlink").symlink_to("blob")
     project = Project(empty_directory)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -30,6 +30,7 @@ RESOURCES_DIRECTORY = TESTS_DIRECTORY / "resources"
 
 # REUSE-IgnoreStart
 
+
 def test_project_not_a_directory(empty_directory):
     """Cannot create a Project without a valid directory."""
     (empty_directory / "foo.py").write_text("foo")
@@ -377,5 +378,6 @@ def test_relative_from_root_no_shared_base_path(empty_directory):
     assert project.relative_from_root(
         Path(f"{project.root.name}/src/hello.py")
     ) == Path("src/hello.py")
+
 
 # REUSE-IgnoreEnd

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -28,6 +28,8 @@ TESTS_DIRECTORY = Path(__file__).parent.resolve()
 RESOURCES_DIRECTORY = TESTS_DIRECTORY / "resources"
 
 
+# REUSE-IgnoreStart
+
 def test_project_not_a_directory(empty_directory):
     """Cannot create a Project without a valid directory."""
     (empty_directory / "foo.py").write_text("foo")
@@ -375,3 +377,5 @@ def test_relative_from_root_no_shared_base_path(empty_directory):
     assert project.relative_from_root(
         Path(f"{project.root.name}/src/hello.py")
     ) == Path("src/hello.py")
+
+# REUSE-IgnoreEnd

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -25,6 +25,8 @@ cpython = pytest.mark.skipif(
 posix = pytest.mark.skipif(not is_posix, reason="Windows not supported")
 
 
+# REUSE-IgnoreStart
+
 def test_generate_file_report_file_simple(fake_repository):
     """An extremely simple generate test, just to see if the function doesn't
     crash.
@@ -278,3 +280,5 @@ def test_bill_of_materials(fake_repository, multiprocessing):
     report = ProjectReport.generate(project, multiprocessing=multiprocessing)
     # TODO: Actually do something
     report.bill_of_materials()
+
+# REUSE-IgnoreEnd

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -27,6 +27,7 @@ posix = pytest.mark.skipif(not is_posix, reason="Windows not supported")
 
 # REUSE-IgnoreStart
 
+
 def test_generate_file_report_file_simple(fake_repository):
     """An extremely simple generate test, just to see if the function doesn't
     crash.
@@ -280,5 +281,6 @@ def test_bill_of_materials(fake_repository, multiprocessing):
     report = ProjectReport.generate(project, multiprocessing=multiprocessing)
     # TODO: Actually do something
     report.bill_of_materials()
+
 
 # REUSE-IgnoreEnd

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -53,7 +53,7 @@ def test_generate_file_report_file_from_different_cwd(fake_repository):
 def test_generate_file_report_file_missing_license(fake_repository):
     """Simple generate test with a missing license."""
     (fake_repository / "foo.py").write_text(
-        "SPDX" "-License-Identifier: BSD-3-Clause"
+        "SPDX-License-Identifier: BSD-3-Clause"
     )
     project = Project(fake_repository)
     result = FileReport.generate(project, "foo.py")
@@ -66,7 +66,7 @@ def test_generate_file_report_file_missing_license(fake_repository):
 def test_generate_file_report_file_bad_license(fake_repository):
     """Simple generate test with a bad license."""
     (fake_repository / "foo.py").write_text(
-        "SPDX" "-License-Identifier: fakelicense"
+        "SPDX-License-Identifier: fakelicense"
     )
     project = Project(fake_repository)
     result = FileReport.generate(project, "foo.py")
@@ -81,7 +81,7 @@ def test_generate_file_report_license_contains_plus(fake_repository):
     should be an appropriate license file.
     """
     (fake_repository / "foo.py").write_text(
-        "SPDX" "-License-Identifier: Apache-1.0+"
+        "SPDX-License-Identifier: Apache-1.0+"
     )
     (fake_repository / "LICENSES/Apache-1.0.txt").touch()
     project = Project(fake_repository)
@@ -178,10 +178,10 @@ def test_generate_project_report_unused_license_plus(
     Furthermore, Apache-1.0+ is separately identified as a used license.
     """
     (fake_repository / "foo.py").write_text(
-        "SPDX" "-License-Identifier: Apache-1.0+"
+        "SPDX-License-Identifier: Apache-1.0+"
     )
     (fake_repository / "bar.py").write_text(
-        "SPDX" "-License-Identifier: Apache-1.0"
+        "SPDX-License-Identifier: Apache-1.0"
     )
     (fake_repository / "LICENSES/Apache-1.0.txt").touch()
 
@@ -199,7 +199,7 @@ def test_generate_project_report_unused_license_plus_only_plus(
     LICENSES/Apache-1.0.txt should not be an unused license.
     """
     (fake_repository / "foo.py").write_text(
-        "SPDX" "-License-Identifier: Apache-1.0+"
+        "SPDX-License-Identifier: Apache-1.0+"
     )
     (fake_repository / "LICENSES/Apache-1.0.txt").touch()
 
@@ -215,7 +215,7 @@ def test_generate_project_report_bad_license_in_file(
     fake_repository, multiprocessing
 ):
     """Bad licenses in files are detected."""
-    (fake_repository / "foo.py").write_text("SPDX" "-License-Identifier: bad")
+    (fake_repository / "foo.py").write_text("SPDX-License-Identifier: bad")
 
     project = Project(fake_repository)
     result = ProjectReport.generate(project, multiprocessing=multiprocessing)
@@ -227,7 +227,7 @@ def test_generate_project_report_bad_license_can_also_be_missing(
     fake_repository, multiprocessing
 ):
     """Bad licenses can also be missing licenses."""
-    (fake_repository / "foo.py").write_text("SPDX" "-License-Identifier: bad")
+    (fake_repository / "foo.py").write_text("SPDX-License-Identifier: bad")
 
     project = Project(fake_repository)
     result = ProjectReport.generate(project, multiprocessing=multiprocessing)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -40,6 +40,7 @@ posix = pytest.mark.skipif(not is_posix, reason="Windows not supported")
 
 # REUSE-IgnoreStart
 
+
 def test_extract_expression():
     """Parse various expressions."""
     expressions = ["GPL-3.0+", "GPL-3.0 AND CC0-1.0", "nonsense"]
@@ -336,10 +337,7 @@ def test_copyright_from_dep5(dep5_copyright):
 
 def test_make_copyright_line_simple():
     """Given a simple statement, make it a copyright line."""
-    assert (
-        _util.make_copyright_line("hello")
-        == "SPDX-FileCopyrightText: hello"
-    )
+    assert _util.make_copyright_line("hello") == "SPDX-FileCopyrightText: hello"
 
 
 def test_make_copyright_line_year():
@@ -609,5 +607,6 @@ def test_detect_line_endings_linux():
 def test_detect_line_endings_no_newlines():
     """Given a file without line endings, default to os.linesep."""
     assert _util.detect_line_endings("hello world") == os.linesep
+
 
 # REUSE-IgnoreEnd

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -43,14 +43,14 @@ def test_extract_expression():
     expressions = ["GPL-3.0+", "GPL-3.0 AND CC0-1.0", "nonsense"]
     for expression in expressions:
         result = _util.extract_spdx_info(
-            "SPDX" + f"-License-Identifier: {expression}"
+            f"SPDX-License-Identifier: {expression}"
         )
         assert result.spdx_expressions == {_LICENSING.parse(expression)}
 
 
 def test_extract_erroneous_expression():
     """Parse an incorrect expression."""
-    expression = "SPDX" + "-License-Identifier: GPL-3.0-or-later AND (MIT OR)"
+    expression = "SPDX-License-Identifier: GPL-3.0-or-later AND (MIT OR)"
     with pytest.raises(ParseError):
         _util.extract_spdx_info(expression)
 
@@ -65,7 +65,7 @@ def test_extract_no_info():
 
 def test_extract_tab():
     """A tag followed by a tab is also valid."""
-    result = _util.extract_spdx_info("SPDX" + "-License-Identifier:\tMIT")
+    result = _util.extract_spdx_info("SPDX-License-Identifier:\tMIT")
     assert result.spdx_expressions == {_LICENSING.parse("MIT")}
 
 
@@ -73,13 +73,13 @@ def test_extract_many_whitespace():
     """When a tag is followed by a lot of whitespace, the whitespace should be
     filtered out.
     """
-    result = _util.extract_spdx_info("SPDX" + "-License-Identifier:    MIT")
+    result = _util.extract_spdx_info("SPDX-License-Identifier:    MIT")
     assert result.spdx_expressions == {_LICENSING.parse("MIT")}
 
 
 def test_extract_bibtex_comment():
     """A special case for BibTex comments."""
-    expression = "@Comment{SPDX" + "-License-Identifier: GPL-3.0-or-later}"
+    expression = "@Comment{SPDX-License-Identifier: GPL-3.0-or-later}"
     result = _util.extract_spdx_info(expression)
     assert str(list(result.spdx_expressions)[0]) == "GPL-3.0-or-later"
 
@@ -88,14 +88,14 @@ def test_extract_copyright():
     """Given a file with copyright information, have it return that copyright
     information.
     """
-    copyright_line = "SPDX" + "-FileCopyrightText: 2019 Jane Doe"
+    copyright_line = "SPDX-FileCopyrightText: 2019 Jane Doe"
     result = _util.extract_spdx_info(copyright_line)
     assert result.copyright_lines == {copyright_line}
 
 
 def test_extract_copyright_duplicate():
     """When a copyright line is duplicated, only yield one."""
-    copyright_line = "SPDX" + "-FileCopyrightText: 2019 Jane Doe"
+    copyright_line = "SPDX-FileCopyrightText: 2019 Jane Doe"
     result = _util.extract_spdx_info(
         "\n".join((copyright_line, copyright_line))
     )
@@ -104,7 +104,7 @@ def test_extract_copyright_duplicate():
 
 def test_extract_copyright_tab():
     """A tag followed by a tab is also valid."""
-    copyright_line = "SPDX" + "-FileCopyrightText:\t2019 Jane Doe"
+    copyright_line = "SPDX-FileCopyrightText:\t2019 Jane Doe"
     result = _util.extract_spdx_info(copyright_line)
     assert result.copyright_lines == {copyright_line}
 
@@ -113,7 +113,7 @@ def test_extract_copyright_many_whitespace():
     """When a tag is followed by a lot of whitespace, that is also valid. The
     whitespace is not filtered out.
     """
-    copyright_line = "SPDX" + "-FileCopyrightText:    2019 Jane Doe"
+    copyright_line = "SPDX-FileCopyrightText:    2019 Jane Doe"
     result = _util.extract_spdx_info(copyright_line)
     assert result.copyright_lines == {copyright_line}
 
@@ -336,7 +336,7 @@ def test_make_copyright_line_simple():
     """Given a simple statement, make it a copyright line."""
     assert (
         _util.make_copyright_line("hello")
-        == "SPDX" + "-FileCopyrightText: hello"
+        == "SPDX-FileCopyrightText: hello"
     )
 
 
@@ -344,7 +344,7 @@ def test_make_copyright_line_year():
     """Given a simple statement and a year, make it a copyright line."""
     assert (
         _util.make_copyright_line("hello", year="2019")
-        == "SPDX" + "-FileCopyrightText: 2019 hello"
+        == "SPDX-FileCopyrightText: 2019 hello"
     )
 
 
@@ -404,7 +404,7 @@ def test_make_copyright_line_style_symbol_year():
 
 def test_make_copyright_line_existing_spdx_copyright():
     """Given a copyright line, do nothing."""
-    value = "SPDX" + "-FileCopyrightText: hello"
+    value = "SPDX-FileCopyrightText: hello"
     assert _util.make_copyright_line(value) == value
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -38,6 +38,8 @@ no_root = pytest.mark.xfail(is_root, reason="fails when user is root")
 posix = pytest.mark.skipif(not is_posix, reason="Windows not supported")
 
 
+# REUSE-IgnoreStart
+
 def test_extract_expression():
     """Parse various expressions."""
     expressions = ["GPL-3.0+", "GPL-3.0 AND CC0-1.0", "nonsense"]
@@ -607,3 +609,5 @@ def test_detect_line_endings_linux():
 def test_detect_line_endings_no_newlines():
     """Given a file without line endings, default to os.linesep."""
     assert _util.detect_line_endings("hello world") == os.linesep
+
+# REUSE-IgnoreEnd


### PR DESCRIPTION
In the tool codebase, there are quite some usages of hacks to circumvent SPDX tags and copyright lines to be false-positively detected or to also trigger warnings and errors.

For example, after the first commit in this PR that removed all these hacks, the output was the following:

```
reuse lint
reuse._util - ERROR - Could not parse 'LicenseRef-custom",'
reuse.project - ERROR - 'tests/conftest.py' holds an SPDX expression that cannot be parsed, skipping the file
reuse._util - ERROR - Could not parse 'GPL-3.0-or-later}"'
reuse.project - ERROR - 'tests/test_util.py' holds an SPDX expression that cannot be parsed, skipping the file
reuse._util - ERROR - Could not parse 'Apache-1.0+"'
reuse.project - ERROR - 'tests/test_report.py' holds an SPDX expression that cannot be parsed, skipping the file
reuse._util - ERROR - Could not parse 'MIT AND OR 0BSD'
reuse.project - ERROR - 'tests/test_header.py' holds an SPDX expression that cannot be parsed, skipping the file
reuse._util - ERROR - Could not parse 'bad-license"'
reuse.project - ERROR - 'tests/test_lint.py' holds an SPDX expression that cannot be parsed, skipping the file
# MISSING COPYRIGHT AND LICENSING INFORMATION

The following files have no copyright and licensing information:
* tests/conftest.py
* tests/test_header.py
* tests/test_lint.py
* tests/test_report.py
* tests/test_util.py


# SUMMARY

* Bad licenses:
* Deprecated licenses:
* Licenses without file extension:
* Missing licenses:
* Unused licenses:
* Used licenses: Apache-2.0, CC-BY-SA-4.0, CC0-1.0, GPL-3.0-or-later
* Read errors: 0
* Files with copyright information: 84 / 89
* Files with license information: 84 / 89

Unfortunately, your project is not compliant with version 3.0 of the REUSE Specification :-(
```

Thankfully, we have the tags `REUSE-IgnoreStart` and `REUSE-IgnoreEnd` since the last release that are explained [in the FAQ](https://reuse.software/faq/#exclude-lines). Therefore, the second commit here makes use of them. In the test, I use them very broadly since we don't expect any valid license/copyright information. This *may* change if we ever embedded a snippet, but before that it felt awkward to use countless ignores to just wrap the problematic strings.