### PR TITLE
Rename `addheader` to `annotate`; add `--no-replace`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,8 +67,12 @@ The versions follow [semantic versioning](https://semver.org).
 - Updated PyPI development status to 'production/stable' (#381)
 - Updated versions of pre-commit check packages
 - The pre-commit hook now passes `lint` as an overridable argument
+- `addheader` has been renamed to `annotate`. The functionality remains the
+  same. (#550)
 
 ### Deprecated
+
+- `addheader` has been deprecated. It still works, but is now undocumented.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,9 @@ Congratulations! Your project is compliant with version 3.0 of the REUSE Specifi
 This tool can do various more things, detailed in the documentation. Here a
 short summary:
 
-- `addheader` --- Add copyright and/or licensing information to the header of a
+<!-- TODO: Review this -->
+
+- `annotate` --- Add copyright and/or licensing information to the header of a
   file.
 
 - `download` --- Download the specified license into the `LICENSES/` directory.

--- a/README.md
+++ b/README.md
@@ -178,8 +178,6 @@ Congratulations! Your project is compliant with version 3.0 of the REUSE Specifi
 This tool can do various more things, detailed in the documentation. Here a
 short summary:
 
-<!-- TODO: Review this -->
-
 - `annotate` --- Add copyright and/or licensing information to the header of a
   file.
 

--- a/docs/scripts.rst
+++ b/docs/scripts.rst
@@ -168,11 +168,9 @@ A common use-case is to add headers to existing, modified or newly written code.
 Add headers to staged files based on git settings
 =================================================
 
-.. TODO: Review addheader scripts.
-
 This script helps you add your copyright headers right before committing the code you wrote.
 
-The list of files staged in git can be retrieved using ``git diff --name-only --cached``, which is the basis to apply the ``reuse addheader`` command to.
+The list of files staged in git can be retrieved using ``git diff --name-only --cached``, which is the basis to apply the ``reuse annotate`` command to.
 
 Git user and email address are available through ``git config --get user.name`` and ``git config --get user.email``.
 
@@ -185,7 +183,7 @@ These elements can be combined into a single command:
 
 .. code-block:: console
 
-  $ git diff --name-only --cached | xargs -I {} reuse addheader -c "$(git config --get user.name) <$(git config --get user.email)>" "{}"
+  $ git diff --name-only --cached | xargs -I {} reuse annotate -c "$(git config --get user.name) <$(git config --get user.email)>" "{}"
 
 .. SPDX-SnippetEnd
 

--- a/docs/scripts.rst
+++ b/docs/scripts.rst
@@ -168,6 +168,8 @@ A common use-case is to add headers to existing, modified or newly written code.
 Add headers to staged files based on git settings
 =================================================
 
+.. TODO: Review addheader scripts.
+
 This script helps you add your copyright headers right before committing the code you wrote.
 
 The list of files staged in git can be retrieved using ``git diff --name-only --cached``, which is the basis to apply the ``reuse addheader`` command to.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -38,23 +38,21 @@ passed as optional argument.
 
 Symbolically links and files that are zero-sized are automatically ignored.
 
-.. TODO: Review addheader documentation.
+annotate
+========
 
-addheader
-=========
-
-``addheader`` makes it possible to semi-automatically add copyright and
+``annotate`` makes it possible to semi-automatically add copyright and
 licensing information into the header of a file. This is useful especially in
 scenarios where you want to add a copyright holder or license to a lot of files
 without having to manually edit the header of each file.
 
 .. warning::
-  You should be cautious with using ``addheader`` in automated processes. While
+  You should be cautious with using ``annotate`` in automated processes. While
   nothing is stopping you from using it in your release script, you should make
   sure that the information it adds is actually reflective of reality. This is
   best verified manually.
 
-The basic usage is ``reuse addheader --copyright="Jane Doe" --license=MIT
+The basic usage is ``reuse annotate --copyright="Jane Doe" --license=MIT
 my_file.py``. This will add the following header to the file (assuming that the
 current year is 2019):
 
@@ -83,7 +81,8 @@ With the argument ``--copyright-style`` it is possible to change the default
   string-symbol:  Copyright © <year> <statement>
   symbol:         © <year> <statement>
 
-Shebangs are always preserved at the top of the file.
+Shebangs are always preserved at the top of the file. If you also want to
+preserve the existing header, use the argument ``--no-replace``.
 
 Merging Statements
 ------------------
@@ -106,7 +105,7 @@ The standard tool options would produce the following
 
 .. code-block:: console
 
-   $ reuse addheader --year 2018 --license GPL-2.0 --copyright="Jane Doe" file.py
+   $ reuse annotate --year 2018 --license GPL-2.0 --copyright="Jane Doe" file.py
 
 .. code-block:: python
 
@@ -181,7 +180,7 @@ specified comment style.
 
 You can create your own Jinja2 templates and place them in
 ``.reuse/templates/``. If you create the template ``mytemplate.jinja2``, you can
-use it with ``reuse addheader --copyright="Jane Doe" --template=mytemplate
+use it with ``reuse annotate --copyright="Jane Doe" --template=mytemplate
 foo.py``.
 
 Inside of the template, you have access to the following variables:

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -38,6 +38,8 @@ passed as optional argument.
 
 Symbolically links and files that are zero-sized are automatically ignored.
 
+.. TODO: Review addheader documentation.
+
 addheader
 =========
 

--- a/src/reuse/_comment.py
+++ b/src/reuse/_comment.py
@@ -8,6 +8,7 @@
 # SPDX-FileCopyrightText: 2022 Florian Snow <florian@familysnow.net>
 # SPDX-FileCopyrightText: 2022 Nico Rikken <nico.rikken@fsfe.org>
 # SPDX-FileCopyrightText: 2022 Stefan Hynek <stefan.hynek@uni-goettingen.de>
+# SPDX-FileCopyrightText: 2022 Carmen Bianca Bakker <carmenbianca@fsfe.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -52,6 +53,7 @@ class CommentStyle:
     INDENT_BEFORE_MIDDLE = ""
     INDENT_AFTER_MIDDLE = ""
     INDENT_BEFORE_END = ""
+    SHEBANGS = []
 
     @classmethod
     def can_handle_single(cls) -> bool:
@@ -295,6 +297,10 @@ class CCommentStyle(CommentStyle):
     INDENT_BEFORE_MIDDLE = " "
     INDENT_AFTER_MIDDLE = " "
     INDENT_BEFORE_END = " "
+    SHEBANGS = [
+        "#!",  #  V-Lang
+        "<?php",  # PHP
+    ]
 
 
 class CssCommentStyle(CommentStyle):
@@ -364,6 +370,7 @@ class HtmlCommentStyle(CommentStyle):
     _shorthand = "html"
 
     MULTI_LINE = MultiLineSegments("<!--", "", "-->")
+    SHEBANGS = ["<?xml"]
 
 
 class JinjaCommentStyle(CommentStyle):
@@ -423,6 +430,7 @@ class PythonCommentStyle(CommentStyle):
 
     SINGLE_LINE = "#"
     INDENT_AFTER_SINGLE = " "
+    SHEBANGS = ["#!"]
 
 
 class ReStructedTextCommentStyle(CommentStyle):

--- a/src/reuse/_main.py
+++ b/src/reuse/_main.py
@@ -141,6 +141,15 @@ def parser() -> argparse.ArgumentParser:
         ),
     )
 
+    # TODO: Display a warning when using this deprecated function.
+    add_command(
+        subparsers,
+        "addheader",
+        header.add_arguments,
+        header.run,
+        help=argparse.SUPPRESS,
+    )
+
     add_command(
         subparsers,
         "download",

--- a/src/reuse/_main.py
+++ b/src/reuse/_main.py
@@ -101,9 +101,10 @@ def parser() -> argparse.ArgumentParser:
 
     add_command(
         subparsers,
-        "addheader",
+        "annotate",
         header.add_arguments,
         header.run,
+        # TODO: Review help and description.
         help=_("add copyright and licensing into the header of files"),
         description=fill_all(
             _(

--- a/src/reuse/_main.py
+++ b/src/reuse/_main.py
@@ -141,7 +141,6 @@ def parser() -> argparse.ArgumentParser:
         ),
     )
 
-    # TODO: Display a warning when using this deprecated function.
     add_command(
         subparsers,
         "addheader",

--- a/src/reuse/_main.py
+++ b/src/reuse/_main.py
@@ -104,7 +104,6 @@ def parser() -> argparse.ArgumentParser:
         "annotate",
         header.add_arguments,
         header.run,
-        # TODO: Review help and description.
         help=_("add copyright and licensing into the header of files"),
         description=fill_all(
             _(
@@ -114,6 +113,11 @@ def parser() -> argparse.ArgumentParser:
                 "By using --copyright and --license, you can specify which"
                 " copyright holders and licenses to add to the headers of the"
                 " given files.\n"
+                "\n"
+                "The first comment is replaced with a new header containing"
+                " the new copyright and licensing information and its former"
+                " copyright and licensing. If you want to keep the first"
+                " comment intact, use --no-replace.\n"
                 "\n"
                 "The comment style should be auto-detected for your files. If"
                 " a comment style could not be detected and --skip-unrecognised"
@@ -133,10 +137,7 @@ def parser() -> argparse.ArgumentParser:
                 " how to use this feature.\n"
                 "\n"
                 "If a binary file is detected, or if --explicit-license is"
-                " specified, the header is placed in a .license file.\n"
-                # TODO: Remove this
-                "\n"
-                "IMPORTANT: This is currently EXPERIMENTAL!"
+                " specified, the header is placed in a .license file."
             )
         ),
     )

--- a/src/reuse/header.py
+++ b/src/reuse/header.py
@@ -8,6 +8,7 @@
 # SPDX-FileCopyrightText: 2021 Robin Vobruba <hoijui.quaero@gmail.com>
 # SPDX-FileCopyrightText: 2022 Florian Snow <florian@familysnow.net>
 # SPDX-FileCopyrightText: 2022 Yaman Qalieh
+# SPDX-FileCopyrightText: 2022 Carmen Bianca Bakker <carmenbianca@fsfe.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -37,12 +38,10 @@ from ._comment import (
     EXTENSION_COMMENT_STYLE_MAP_LOWERCASE,
     FILENAME_COMMENT_STYLE_MAP_LOWERCASE,
     NAME_STYLE_MAP,
-    CCommentStyle,
     CommentCreateError,
     CommentParseError,
     CommentStyle,
     EmptyCommentStyle,
-    HtmlCommentStyle,
     PythonCommentStyle,
     UncommentableCommentStyle,
 )
@@ -292,22 +291,17 @@ def find_and_replace_header(
 
     # Keep special first-line-of-file lines as the first line in the file,
     # or say, move our comments after it.
-    for prefix in (
-        prefix
-        for com_style, prefix in (
-            (CCommentStyle, "#!"),  # e.g. V-Lang
-            (CCommentStyle, "<?php"),  # e.g. PHP
-            (HtmlCommentStyle, "<?xml"),  # e.g. XML/XHTML
-            (PythonCommentStyle, "#!"),  # e.g. Shell, Python
-        )
-        if style is com_style
-    ):
-        # Extract shebang from header and put it in before. It's a bit messy,
-        # but it ends up working.
-        if header.startswith(prefix) and not before.strip():
-            before, header = _extract_shebang(prefix, header)
-        elif after.startswith(prefix) and not any((before, header)):
-            before, after = _extract_shebang(prefix, after)
+    if style.SHEBANGS:
+        for shebang in style.SHEBANGS:
+            # Extract shebang from header and put it in before. It's a bit
+            # messy, but it ends up working.
+            if header.startswith(shebang) and not before.strip():
+                before, header = _extract_shebang(shebang, header)
+            elif after.startswith(shebang) and not any((before, header)):
+                before, after = _extract_shebang(shebang, after)
+            else:
+                continue
+            break
 
     header = create_header(
         spdx_info,
@@ -324,6 +318,51 @@ def find_and_replace_header(
         new_text = f"{before.rstrip()}\n\n{new_text}"
     if after.strip():
         new_text = f"{new_text}\n{after.lstrip()}"
+    return new_text
+
+
+# pylint: disable=too-many-arguments
+def add_new_header(
+    text: str,
+    spdx_info: SpdxInfo,
+    template: Template = None,
+    template_is_commented: bool = False,
+    style: CommentStyle = None,
+    force_multi: bool = False,
+    merge_copyrights: bool = False,
+) -> str:
+    """Add a new header at the very top of *text*, similar to
+    find_and_replace_header. But in this function, do not replace any headers or
+    search for any existing SPDX information.
+
+    :raises CommentCreateError: if a comment could not be created.
+    """
+    if style is None:
+        style = PythonCommentStyle
+
+    shebang = ""
+
+    if style.SHEBANGS:
+        for shebang_prefix in style.SHEBANGS:
+            if text.startswith(shebang_prefix):
+                shebang, text = _extract_shebang(shebang_prefix, text)
+                break
+
+    header = create_header(
+        spdx_info,
+        None,
+        template=template,
+        template_is_commented=template_is_commented,
+        style=style,
+        force_multi=force_multi,
+        merge_copyrights=merge_copyrights,
+    )
+
+    new_text = f"{header}\n"
+    if shebang.strip():
+        new_text = f"{shebang.rstrip()}\n\n{new_text}"
+    if text.strip():
+        new_text = f"{new_text}\n{text.lstrip()}"
     return new_text
 
 
@@ -429,6 +468,7 @@ def _add_header_to_file(
     force_multi: bool = False,
     skip_existing: bool = False,
     merge_copyrights: bool = False,
+    replace: bool = True,
     out=sys.stdout,
 ) -> int:
     """Helper function."""
@@ -463,15 +503,26 @@ def _add_header_to_file(
     text = text.replace(line_ending, "\n")
 
     try:
-        output = find_and_replace_header(
-            text,
-            spdx_info,
-            template=template,
-            template_is_commented=template_is_commented,
-            style=style,
-            force_multi=force_multi,
-            merge_copyrights=merge_copyrights,
-        )
+        if replace:
+            output = find_and_replace_header(
+                text,
+                spdx_info,
+                template=template,
+                template_is_commented=template_is_commented,
+                style=style,
+                force_multi=force_multi,
+                merge_copyrights=merge_copyrights,
+            )
+        else:
+            output = add_new_header(
+                text,
+                spdx_info,
+                template=template,
+                template_is_commented=template_is_commented,
+                style=style,
+                force_multi=force_multi,
+                merge_copyrights=merge_copyrights,
+            )
     except CommentCreateError:
         out.write(
             _("Error: Could not create comment for '{path}'").format(path=path)
@@ -588,6 +639,13 @@ def add_arguments(parser) -> None:
         action="store_true",
         help=_(
             "add headers to all files under specified directories recursively"
+        ),
+    )
+    parser.add_argument(
+        "--no-replace",
+        action="store_true",
+        help=_(
+            "do not replace the first header in the file; just add a new one"
         ),
     )
     parser.add_argument(
@@ -728,6 +786,7 @@ def run(args, project: Project, out=sys.stdout) -> int:
             force_multi=args.multi_line,
             skip_existing=args.skip_existing,
             merge_copyrights=args.merge_copyrights,
+            replace=not args.no_replace,
             out=out,
         )
 

--- a/src/reuse/header.py
+++ b/src/reuse/header.py
@@ -664,6 +664,14 @@ def add_arguments(parser) -> None:
 def run(args, project: Project, out=sys.stdout) -> int:
     """Add headers to files."""
     # pylint: disable=too-many-branches,too-many-locals,too-many-statements
+    if "addheader" in args.parser.prog.split():
+        _LOGGER.warning(
+            _(
+                "'reuse addheader' has been deprecated in favour of"
+                " 'reuse annotate'"
+            )
+        )
+
     if not any((args.copyright, args.license)):
         args.parser.error(_("option --copyright or --license is required"))
 

--- a/tests/test_main_annotate.py
+++ b/tests/test_main_annotate.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-"""Tests for reuse._main: addheader"""
+"""Tests for reuse._main: annotate"""
 
 # pylint: disable=too-many-lines,unused-argument
 
@@ -19,7 +19,7 @@ from reuse._main import main
 # REUSE-IgnoreStart
 
 # TODO: Replace this test with a monkeypatched test
-def test_addheader_simple(fake_repository, stringio, mock_date_today):
+def test_annotate_simple(fake_repository, stringio, mock_date_today):
     """Add a header to a file that does not have one."""
     simple_file = fake_repository / "foo.py"
     simple_file.write_text("pass")
@@ -35,7 +35,7 @@ def test_addheader_simple(fake_repository, stringio, mock_date_today):
 
     result = main(
         [
-            "addheader",
+            "annotate",
             "--license",
             "GPL-3.0-or-later",
             "--copyright",
@@ -49,7 +49,7 @@ def test_addheader_simple(fake_repository, stringio, mock_date_today):
     assert simple_file.read_text() == expected
 
 
-def test_addheader_year(fake_repository, stringio):
+def test_annotate_year(fake_repository, stringio):
     """Add a header to a file with a custom year."""
     simple_file = fake_repository / "foo.py"
     simple_file.write_text("pass")
@@ -65,7 +65,7 @@ def test_addheader_year(fake_repository, stringio):
 
     result = main(
         [
-            "addheader",
+            "annotate",
             "--year",
             "2016",
             "--license",
@@ -81,7 +81,7 @@ def test_addheader_year(fake_repository, stringio):
     assert simple_file.read_text() == expected
 
 
-def test_addheader_no_year(fake_repository, stringio):
+def test_annotate_no_year(fake_repository, stringio):
     """Add a header to a file without a year."""
     simple_file = fake_repository / "foo.py"
     simple_file.write_text("pass")
@@ -97,7 +97,7 @@ def test_addheader_no_year(fake_repository, stringio):
 
     result = main(
         [
-            "addheader",
+            "annotate",
             "--exclude-year",
             "--license",
             "GPL-3.0-or-later",
@@ -112,7 +112,7 @@ def test_addheader_no_year(fake_repository, stringio):
     assert simple_file.read_text() == expected
 
 
-def test_addheader_specify_style(fake_repository, stringio, mock_date_today):
+def test_annotate_specify_style(fake_repository, stringio, mock_date_today):
     """Add a header to a file that does not have one, using a custom style."""
     simple_file = fake_repository / "foo.py"
     simple_file.write_text("pass")
@@ -128,7 +128,7 @@ def test_addheader_specify_style(fake_repository, stringio, mock_date_today):
 
     result = main(
         [
-            "addheader",
+            "annotate",
             "--license",
             "GPL-3.0-or-later",
             "--copyright",
@@ -144,7 +144,7 @@ def test_addheader_specify_style(fake_repository, stringio, mock_date_today):
     assert simple_file.read_text() == expected
 
 
-def test_addheader_implicit_style(fake_repository, stringio, mock_date_today):
+def test_annotate_implicit_style(fake_repository, stringio, mock_date_today):
     """Add a header to a file that has a recognised extension."""
     simple_file = fake_repository / "foo.js"
     simple_file.write_text("pass")
@@ -160,7 +160,7 @@ def test_addheader_implicit_style(fake_repository, stringio, mock_date_today):
 
     result = main(
         [
-            "addheader",
+            "annotate",
             "--license",
             "GPL-3.0-or-later",
             "--copyright",
@@ -174,7 +174,7 @@ def test_addheader_implicit_style(fake_repository, stringio, mock_date_today):
     assert simple_file.read_text() == expected
 
 
-def test_addheader_implicit_style_filename(
+def test_annotate_implicit_style_filename(
     fake_repository, stringio, mock_date_today
 ):
     """Add a header to a filename that is recognised."""
@@ -192,7 +192,7 @@ def test_addheader_implicit_style_filename(
 
     result = main(
         [
-            "addheader",
+            "annotate",
             "--license",
             "GPL-3.0-or-later",
             "--copyright",
@@ -206,7 +206,7 @@ def test_addheader_implicit_style_filename(
     assert simple_file.read_text() == expected
 
 
-def test_addheader_unrecognised_style(fake_repository):
+def test_annotate_unrecognised_style(fake_repository):
     """Add a header to a file that has an unrecognised extension."""
     simple_file = fake_repository / "foo.foo"
     simple_file.write_text("pass")
@@ -214,7 +214,7 @@ def test_addheader_unrecognised_style(fake_repository):
     with pytest.raises(SystemExit):
         main(
             [
-                "addheader",
+                "annotate",
                 "--license",
                 "GPL-3.0-or-later",
                 "--copyright",
@@ -224,14 +224,14 @@ def test_addheader_unrecognised_style(fake_repository):
         )
 
 
-def test_addheader_skip_unrecognised(fake_repository, stringio):
+def test_annotate_skip_unrecognised(fake_repository, stringio):
     """Skip file that has an unrecognised extension."""
     simple_file = fake_repository / "foo.foo"
     simple_file.write_text("pass")
 
     result = main(
         [
-            "addheader",
+            "annotate",
             "--license",
             "GPL-3.0-or-later",
             "--copyright",
@@ -246,7 +246,7 @@ def test_addheader_skip_unrecognised(fake_repository, stringio):
     assert "Skipped unrecognised file foo.foo" in stringio.getvalue()
 
 
-def test_addheader_skip_unrecognised_and_style(
+def test_annotate_skip_unrecognised_and_style(
     fake_repository, stringio, caplog
 ):
     """--skip-unrecognised and --style show warning message."""
@@ -255,7 +255,7 @@ def test_addheader_skip_unrecognised_and_style(
 
     result = main(
         [
-            "addheader",
+            "annotate",
             "--license",
             "GPL-3.0-or-later",
             "--copyright",
@@ -271,16 +271,16 @@ def test_addheader_skip_unrecognised_and_style(
     assert "no effect" in caplog.text
 
 
-def test_addheader_no_copyright_or_license(fake_repository):
+def test_annotate_no_copyright_or_license(fake_repository):
     """Add a header, but supply no copyright or license."""
     simple_file = fake_repository / "foo.py"
     simple_file.write_text("pass")
 
     with pytest.raises(SystemExit):
-        main(["addheader", "foo.py"])
+        main(["annotate", "foo.py"])
 
 
-def test_addheader_template_simple(
+def test_annotate_template_simple(
     fake_repository, stringio, mock_date_today, template_simple_source
 ):
     """Add a header with a custom template."""
@@ -303,7 +303,7 @@ def test_addheader_template_simple(
 
     result = main(
         [
-            "addheader",
+            "annotate",
             "--license",
             "GPL-3.0-or-later",
             "--copyright",
@@ -319,7 +319,7 @@ def test_addheader_template_simple(
     assert simple_file.read_text() == expected
 
 
-def test_addheader_template_simple_multiple(
+def test_annotate_template_simple_multiple(
     fake_repository, stringio, mock_date_today, template_simple_source
 ):
     """Add a header with a custom template to multiple files."""
@@ -332,7 +332,7 @@ def test_addheader_template_simple_multiple(
 
     result = main(
         [
-            "addheader",
+            "annotate",
             "--license",
             "GPL-3.0-or-later",
             "--copyright",
@@ -360,7 +360,7 @@ def test_addheader_template_simple_multiple(
         assert simple_file.read_text() == expected
 
 
-def test_addheader_template_no_spdx(
+def test_annotate_template_no_spdx(
     fake_repository, stringio, template_no_spdx_source
 ):
     """Add a header with a template that lacks SPDX info."""
@@ -372,7 +372,7 @@ def test_addheader_template_no_spdx(
 
     result = main(
         [
-            "addheader",
+            "annotate",
             "--license",
             "GPL-3.0-or-later",
             "--copyright",
@@ -387,7 +387,7 @@ def test_addheader_template_no_spdx(
     assert result == 1
 
 
-def test_addheader_template_commented(
+def test_annotate_template_commented(
     fake_repository, stringio, mock_date_today, template_commented_source
 ):
     """Add a header with a custom template that is already commented."""
@@ -412,7 +412,7 @@ def test_addheader_template_commented(
 
     result = main(
         [
-            "addheader",
+            "annotate",
             "--license",
             "GPL-3.0-or-later",
             "--copyright",
@@ -428,7 +428,7 @@ def test_addheader_template_commented(
     assert simple_file.read_text() == expected
 
 
-def test_addheader_template_nonexistant(fake_repository):
+def test_annotate_template_nonexistant(fake_repository):
     """Raise an error when using a header that does not exist."""
 
     simple_file = fake_repository / "foo.py"
@@ -437,7 +437,7 @@ def test_addheader_template_nonexistant(fake_repository):
     with pytest.raises(SystemExit):
         main(
             [
-                "addheader",
+                "annotate",
                 "--license",
                 "GPL-3.0-or-later",
                 "--copyright",
@@ -449,7 +449,7 @@ def test_addheader_template_nonexistant(fake_repository):
         )
 
 
-def test_addheader_template_without_extension(
+def test_annotate_template_without_extension(
     fake_repository, stringio, mock_date_today, template_simple_source
 ):
 
@@ -473,7 +473,7 @@ def test_addheader_template_without_extension(
 
     result = main(
         [
-            "addheader",
+            "annotate",
             "--license",
             "GPL-3.0-or-later",
             "--copyright",
@@ -489,7 +489,7 @@ def test_addheader_template_without_extension(
     assert simple_file.read_text() == expected
 
 
-def test_addheader_binary(
+def test_annotate_binary(
     fake_repository, stringio, mock_date_today, binary_string
 ):
     """Add a header to a .license file if the file is a binary."""
@@ -505,7 +505,7 @@ def test_addheader_binary(
 
     result = main(
         [
-            "addheader",
+            "annotate",
             "--license",
             "GPL-3.0-or-later",
             "--copyright",
@@ -522,7 +522,7 @@ def test_addheader_binary(
     )
 
 
-def test_addheader_uncommentable_json(
+def test_annotate_uncommentable_json(
     fake_repository, stringio, mock_date_today
 ):
     """Add a header to a .license file if the file is uncommentable, e.g.,
@@ -540,7 +540,7 @@ def test_addheader_uncommentable_json(
 
     result = main(
         [
-            "addheader",
+            "annotate",
             "--license",
             "GPL-3.0-or-later",
             "--copyright",
@@ -557,9 +557,7 @@ def test_addheader_uncommentable_json(
     )
 
 
-def test_addheader_force_dot_license(
-    fake_repository, stringio, mock_date_today
-):
+def test_annotate_force_dot_license(fake_repository, stringio, mock_date_today):
     """Add a header to a .license file if --force-dot-license is given."""
     simple_file = fake_repository / "foo.py"
     simple_file.write_text("pass")
@@ -573,7 +571,7 @@ def test_addheader_force_dot_license(
 
     result = main(
         [
-            "addheader",
+            "annotate",
             "--license",
             "GPL-3.0-or-later",
             "--copyright",
@@ -592,7 +590,7 @@ def test_addheader_force_dot_license(
     assert simple_file.read_text() == "pass"
 
 
-def test_addheader_force_dot_license_identical_to_explicit_license(
+def test_annotate_force_dot_license_identical_to_explicit_license(
     fake_repository, stringio, mock_date_today
 ):
     """For backwards compatibility, --force-dot-license should have identical
@@ -615,7 +613,7 @@ def test_addheader_force_dot_license_identical_to_explicit_license(
     for arg, path in zip(("--force-dot-license", "--explicit-license"), files):
         main(
             [
-                "addheader",
+                "annotate",
                 "--license",
                 "GPL-3.0-or-later",
                 "--copyright",
@@ -634,7 +632,7 @@ def test_addheader_force_dot_license_identical_to_explicit_license(
         assert path.read_text() == "pass"
 
 
-def test_addheader_force_dot_license_double(
+def test_annotate_force_dot_license_double(
     fake_repository, stringio, mock_date_today
 ):
     """When path.license already exists, don't create path.license.license."""
@@ -654,7 +652,7 @@ def test_addheader_force_dot_license_double(
 
     result = main(
         [
-            "addheader",
+            "annotate",
             "--license",
             "GPL-3.0-or-later",
             "--copyright",
@@ -670,7 +668,7 @@ def test_addheader_force_dot_license_double(
     assert simple_file_license.read_text().strip() == expected
 
 
-def test_addheader_force_dot_license_unsupported_filetype(
+def test_annotate_force_dot_license_unsupported_filetype(
     fake_repository, stringio, mock_date_today
 ):
     """Add a header to a .license file if --force-dot-license is given, with the
@@ -688,7 +686,7 @@ def test_addheader_force_dot_license_unsupported_filetype(
 
     result = main(
         [
-            "addheader",
+            "annotate",
             "--license",
             "GPL-3.0-or-later",
             "--copyright",
@@ -707,7 +705,7 @@ def test_addheader_force_dot_license_unsupported_filetype(
     assert simple_file.read_text() == "Preserve this"
 
 
-def test_addheader_force_dot_license_doesnt_write_to_file(
+def test_annotate_force_dot_license_doesnt_write_to_file(
     fake_repository, stringio, mock_date_today
 ):
     """Adding a header to a .license file if --force-dot-license is given,
@@ -726,7 +724,7 @@ def test_addheader_force_dot_license_doesnt_write_to_file(
 
     result = main(
         [
-            "addheader",
+            "annotate",
             "--license",
             "GPL-3.0-or-later",
             "--copyright",
@@ -745,7 +743,7 @@ def test_addheader_force_dot_license_doesnt_write_to_file(
     assert simple_file.read_text() == "Preserve this"
 
 
-def test_addheader_to_read_only_file_does_not_traceback(
+def test_annotate_to_read_only_file_does_not_traceback(
     fake_repository, stringio, mock_date_today
 ):
     """Trying to add a header without having write permission, shouldn't result
@@ -756,7 +754,7 @@ def test_addheader_to_read_only_file_does_not_traceback(
     with pytest.raises(SystemExit) as info:
         main(
             [
-                "addheader",
+                "annotate",
                 "--license",
                 "Apache-2.0",
                 "--copyright",
@@ -769,7 +767,7 @@ def test_addheader_to_read_only_file_does_not_traceback(
     assert info.value  # should not exit with 0
 
 
-def test_addheader_license_file(fake_repository, stringio, mock_date_today):
+def test_annotate_license_file(fake_repository, stringio, mock_date_today):
     """Add a header to a .license file if it exists."""
     simple_file = fake_repository / "foo.py"
     simple_file.write_text("foo")
@@ -797,7 +795,7 @@ def test_addheader_license_file(fake_repository, stringio, mock_date_today):
 
     result = main(
         [
-            "addheader",
+            "annotate",
             "--license",
             "GPL-3.0-or-later",
             "--copyright",
@@ -812,7 +810,7 @@ def test_addheader_license_file(fake_repository, stringio, mock_date_today):
     assert simple_file.read_text() == "foo"
 
 
-def test_addheader_license_file_only_one_newline(
+def test_annotate_license_file_only_one_newline(
     fake_repository, stringio, mock_date_today
 ):
     """When a header is added to a .license file that already ends with a
@@ -845,7 +843,7 @@ def test_addheader_license_file_only_one_newline(
 
     result = main(
         [
-            "addheader",
+            "annotate",
             "--license",
             "GPL-3.0-or-later",
             "--copyright",
@@ -860,12 +858,12 @@ def test_addheader_license_file_only_one_newline(
     assert simple_file.read_text() == "foo"
 
 
-def test_addheader_year_mutually_exclusive(fake_repository):
+def test_annotate_year_mutually_exclusive(fake_repository):
     """--exclude-year and --year are mutually exclusive."""
     with pytest.raises(SystemExit):
         main(
             [
-                "addheader",
+                "annotate",
                 "--license",
                 "GPL-3.0-or-later",
                 "--copyright",
@@ -878,12 +876,12 @@ def test_addheader_year_mutually_exclusive(fake_repository):
         )
 
 
-def test_addheader_single_multi_line_mutually_exclusive(fake_repository):
+def test_annotate_single_multi_line_mutually_exclusive(fake_repository):
     """--single-line and --multi-line are mutually exclusive."""
     with pytest.raises(SystemExit):
         main(
             [
-                "addheader",
+                "annotate",
                 "--license",
                 "GPL-3.0-or-later",
                 "--copyright",
@@ -896,12 +894,12 @@ def test_addheader_single_multi_line_mutually_exclusive(fake_repository):
 
 
 @pytest.mark.parametrize("skip_option", [("--skip-unrecognised"), ("")])
-def test_addheader_multi_line_not_supported(fake_repository, skip_option):
+def test_annotate_multi_line_not_supported(fake_repository, skip_option):
     """Expect a fail if --multi-line is not supported for a file type."""
     with pytest.raises(SystemExit):
         main(
             [
-                "addheader",
+                "annotate",
                 "--license",
                 "GPL-3.0-or-later",
                 "--copyright",
@@ -914,12 +912,12 @@ def test_addheader_multi_line_not_supported(fake_repository, skip_option):
 
 
 @pytest.mark.parametrize("skip_option", [("--skip-unrecognised"), ("")])
-def test_addheader_single_line_not_supported(fake_repository, skip_option):
+def test_annotate_single_line_not_supported(fake_repository, skip_option):
     """Expect a fail if --single-line is not supported for a file type."""
     with pytest.raises(SystemExit):
         main(
             [
-                "addheader",
+                "annotate",
                 "--license",
                 "GPL-3.0-or-later",
                 "--copyright",
@@ -931,7 +929,7 @@ def test_addheader_single_line_not_supported(fake_repository, skip_option):
         )
 
 
-def test_addheader_force_multi_line_for_c(
+def test_annotate_force_multi_line_for_c(
     fake_repository, stringio, mock_date_today
 ):
     """--multi-line forces a multi-line comment for C."""
@@ -951,7 +949,7 @@ def test_addheader_force_multi_line_for_c(
 
     result = main(
         [
-            "addheader",
+            "annotate",
             "--license",
             "GPL-3.0-or-later",
             "--copyright",
@@ -967,7 +965,7 @@ def test_addheader_force_multi_line_for_c(
 
 
 @pytest.mark.parametrize("line_ending", ["\r\n", "\r", "\n"])
-def test_addheader_line_endings(
+def test_annotate_line_endings(
     empty_directory, stringio, mock_date_today, line_ending
 ):
     """Given a file with a certain type of line ending, preserve it."""
@@ -988,7 +986,7 @@ def test_addheader_line_endings(
 
     result = main(
         [
-            "addheader",
+            "annotate",
             "--license",
             "GPL-3.0-or-later",
             "--copyright",
@@ -1005,8 +1003,8 @@ def test_addheader_line_endings(
     assert contents == expected
 
 
-def test_addheader_skip_existing(fake_repository, stringio, mock_date_today):
-    """When addheader --skip-existing on a file that already contains SPDX info,
+def test_annotate_skip_existing(fake_repository, stringio, mock_date_today):
+    """When annotate --skip-existing on a file that already contains SPDX info,
     don't write additional information to it.
     """
     for path in ("foo.py", "bar.py"):
@@ -1032,7 +1030,7 @@ def test_addheader_skip_existing(fake_repository, stringio, mock_date_today):
 
     main(
         [
-            "addheader",
+            "annotate",
             "--license",
             "GPL-3.0-or-later",
             "--copyright",
@@ -1044,7 +1042,7 @@ def test_addheader_skip_existing(fake_repository, stringio, mock_date_today):
 
     result = main(
         [
-            "addheader",
+            "annotate",
             "--license",
             "MIT",
             "--copyright",
@@ -1060,7 +1058,7 @@ def test_addheader_skip_existing(fake_repository, stringio, mock_date_today):
     assert (fake_repository / "bar.py").read_text() == expected_bar
 
 
-def test_addheader_recursive(fake_repository, stringio, mock_date_today):
+def test_annotate_recursive(fake_repository, stringio, mock_date_today):
     """Add a header to a directory recursively."""
     (fake_repository / "src/one/two").mkdir(parents=True)
     (fake_repository / "src/one/two/foo.py").write_text(
@@ -1077,7 +1075,7 @@ def test_addheader_recursive(fake_repository, stringio, mock_date_today):
 
     result = main(
         [
-            "addheader",
+            "annotate",
             "--copyright",
             "Joe Somebody",
             "--recursive",
@@ -1094,13 +1092,11 @@ def test_addheader_recursive(fake_repository, stringio, mock_date_today):
     assert result == 0
 
 
-def test_addheader_recursive_on_file(
-    fake_repository, stringio, mock_date_today
-):
-    """Don't expect errors when addheader is run 'recursively' on a file."""
+def test_annotate_recursive_on_file(fake_repository, stringio, mock_date_today):
+    """Don't expect errors when annotate is run 'recursively' on a file."""
     result = main(
         [
-            "addheader",
+            "annotate",
             "--copyright",
             "Joe Somebody",
             "--recursive",
@@ -1115,7 +1111,7 @@ def test_addheader_recursive_on_file(
     assert result == 0
 
 
-def test_addheader_recursive_contains_unrecognised(
+def test_annotate_recursive_contains_unrecognised(
     fake_repository, stringio, mock_date_today
 ):
     """Expect error and no edited files if at least one file has not been
@@ -1128,7 +1124,7 @@ def test_addheader_recursive_contains_unrecognised(
     with pytest.raises(SystemExit):
         main(
             [
-                "addheader",
+                "annotate",
                 "--license",
                 "Apache-2.0",
                 "--copyright",

--- a/tests/test_main_annotate.py
+++ b/tests/test_main_annotate.py
@@ -49,6 +49,36 @@ def test_annotate_simple(fake_repository, stringio, mock_date_today):
     assert simple_file.read_text() == expected
 
 
+def test_addheader_simple(fake_repository, stringio, mock_date_today):
+    """Add a header to a file that does not have one."""
+    simple_file = fake_repository / "foo.py"
+    simple_file.write_text("pass")
+    expected = cleandoc(
+        """
+        # SPDX-FileCopyrightText: 2018 Jane Doe
+        #
+        # SPDX-License-Identifier: GPL-3.0-or-later
+
+        pass
+        """
+    )
+
+    result = main(
+        [
+            "addheader",
+            "--license",
+            "GPL-3.0-or-later",
+            "--copyright",
+            "Jane Doe",
+            "foo.py",
+        ],
+        out=stringio,
+    )
+
+    assert result == 0
+    assert simple_file.read_text() == expected
+
+
 def test_annotate_year(fake_repository, stringio):
     """Add a header to a file with a custom year."""
     simple_file = fake_repository / "foo.py"

--- a/tests/test_main_annotate.py
+++ b/tests/test_main_annotate.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2019 Stefan Bakker <s.bakker777@gmail.com>
 # SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 # SPDX-FileCopyrightText: 2022 Florian Snow <florian@familysnow.net>
+# SPDX-FileCopyrightText: 2022 Carmen Bianca Bakker <carmenbianca@fsfe.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -66,6 +67,51 @@ def test_addheader_simple(fake_repository, stringio, mock_date_today):
     result = main(
         [
             "addheader",
+            "--license",
+            "GPL-3.0-or-later",
+            "--copyright",
+            "Jane Doe",
+            "foo.py",
+        ],
+        out=stringio,
+    )
+
+    assert result == 0
+    assert simple_file.read_text() == expected
+
+
+def test_annotate_simple_no_replace(fake_repository, stringio, mock_date_today):
+    """Add a header to a file without replacing the existing header."""
+    simple_file = fake_repository / "foo.py"
+    simple_file.write_text(
+        cleandoc(
+            """
+            # SPDX-FileCopyrightText: 2017 John Doe
+            #
+            # SPDX-License-Identifier: MIT
+
+            pass
+            """
+        )
+    )
+    expected = cleandoc(
+        """
+        # SPDX-FileCopyrightText: 2018 Jane Doe
+        #
+        # SPDX-License-Identifier: GPL-3.0-or-later
+
+        # SPDX-FileCopyrightText: 2017 John Doe
+        #
+        # SPDX-License-Identifier: MIT
+
+        pass
+        """
+    )
+
+    result = main(
+        [
+            "annotate",
+            "--no-replace",
             "--license",
             "GPL-3.0-or-later",
             "--copyright",

--- a/tests/test_main_annotate_merge.py
+++ b/tests/test_main_annotate_merge.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-"""Tests for reuse._main: addheader merge-copyrights option"""
+"""Tests for reuse._main: annotate merge-copyrights option"""
 
 
 from inspect import cleandoc
@@ -12,14 +12,14 @@ from reuse._main import main
 # REUSE-IgnoreStart
 
 
-def test_addheader_merge_copyrights_simple(fake_repository, stringio):
+def test_annotate_merge_copyrights_simple(fake_repository, stringio):
     """Add multiple headers to a file with merge copyrights."""
     simple_file = fake_repository / "foo.py"
     simple_file.write_text("pass")
 
     result = main(
         [
-            "addheader",
+            "annotate",
             "--year",
             "2016",
             "--license",
@@ -45,7 +45,7 @@ def test_addheader_merge_copyrights_simple(fake_repository, stringio):
 
     result = main(
         [
-            "addheader",
+            "annotate",
             "--year",
             "2018",
             "--license",
@@ -70,7 +70,7 @@ def test_addheader_merge_copyrights_simple(fake_repository, stringio):
     )
 
 
-def test_addheader_merge_copyrights_multi_prefix(fake_repository, stringio):
+def test_annotate_merge_copyrights_multi_prefix(fake_repository, stringio):
     """Add multiple headers to a file with merge copyrights."""
     simple_file = fake_repository / "foo.py"
     simple_file.write_text("pass")
@@ -78,7 +78,7 @@ def test_addheader_merge_copyrights_multi_prefix(fake_repository, stringio):
     for i in range(0, 3):
         result = main(
             [
-                "addheader",
+                "annotate",
                 "--year",
                 str(2010 + i),
                 "--license",
@@ -95,7 +95,7 @@ def test_addheader_merge_copyrights_multi_prefix(fake_repository, stringio):
     for i in range(0, 5):
         result = main(
             [
-                "addheader",
+                "annotate",
                 "--year",
                 str(2015 + i),
                 "--license",
@@ -130,7 +130,7 @@ def test_addheader_merge_copyrights_multi_prefix(fake_repository, stringio):
 
     result = main(
         [
-            "addheader",
+            "annotate",
             "--year",
             "2018",
             "--license",


### PR DESCRIPTION
Fixes #338 

# reuse annotate

Plan: Rename `addheader` to `annotate` to reduce confusion.

`annotate` keeps current behaviour: New header if none exists; replace header if exists.

Add `--no-replace` flag to not replace the header.

## Desired behaviour of `--no-replace`

Instead of replacing the first header, add a new header before it. Do NOT pull
SPDX info from the 'old' first header.


```bash
$ reuse annotate --no-replace --license GPL-3.0
```

```python
# This file must be sourced in sh:
#
#   . `which env_parallel.sh`
#
# after which 'env_parallel' works
#
#
# Copyright (C) 2016-2021 Ole Tange, http://ole.tange.dk and Free Software Foundation, Inc.
#
# This program is free software; you can redistribute it and/or modify
# it under the terms of the GNU General Public License as published by
# the Free Software Foundation; either version 3 of the License, or
# (at your option) any later version.
#
# This program is distributed in the hope that it will be useful, but
# WITHOUT ANY WARRANTY; without even the implied warranty of
# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
# General Public License for more details.
#
# You should have received a copy of the GNU General Public License
# along with this program; if not, see <http://www.gnu.org/licenses/>
# or write to the Free Software Foundation, Inc., 51 Franklin St,
# Fifth Floor, Boston, MA 02110-1301 USA
```

->


```python
# SPDX-License-Identifier: GPL-3.0

# This file must be sourced in sh:
#
#   . `which env_parallel.sh`
#
# after which 'env_parallel' works
#
#
# Copyright (C) 2016-2021 Ole Tange, http://ole.tange.dk and Free Software Foundation, Inc.
#
# This program is free software; you can redistribute it and/or modify
# it under the terms of the GNU General Public License as published by
# the Free Software Foundation; either version 3 of the License, or
# (at your option) any later version.
#
# This program is distributed in the hope that it will be useful, but
# WITHOUT ANY WARRANTY; without even the implied warranty of
# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
# General Public License for more details.
#
# You should have received a copy of the GNU General Public License
# along with this program; if not, see <http://www.gnu.org/licenses/>
# or write to the Free Software Foundation, Inc., 51 Franklin St,
# Fifth Floor, Boston, MA 02110-1301 USA
```
