### PR TITLE
CODEOWNERS file comment support

### DIFF
--- a/src/reuse/_comment.py
+++ b/src/reuse/_comment.py
@@ -663,6 +663,7 @@ FILENAME_COMMENT_STYLE_MAP = {
     ".yarnrc": PythonCommentStyle,
     "archive.sctxar": UncommentableCommentStyle,  # SuperCollider global archive
     "CMakeLists.txt": PythonCommentStyle,
+    "CODEOWNERS": PythonCommentStyle,
     "configure.ac": M4CommentStyle,
     "Containerfile": PythonCommentStyle,
     "Dockerfile": PythonCommentStyle,


### PR DESCRIPTION
Add comment style support for CODEOWNERS files used to define
permissions in code repositories. The syntax is mainly based on the
syntax from the .gitignore files. More on this is available in the
documentation by GitHub:
https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax

Signed-off-by: Nico Rikken <nico.rikken@fsfe.org>
