### PR TITLE
Apache Velocity template language comment style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ The versions follow [semantic versioning](https://semver.org).
   - Android Interface Definition Language (`.aidl`)
   - Certificate files (`.pem`)
 
+- Added comment style:
+
+  - Apache Velocity Template (Extensions: `.vm`, `.vtl`)
+
 ### Changed
 
 - Updated PyPI development status to 'production/stable' (#381)

--- a/src/reuse/_comment.py
+++ b/src/reuse/_comment.py
@@ -448,6 +448,15 @@ class UncommentableCommentStyle(EmptyCommentStyle):
     """
 
 
+class VelocityCommentStyle(CommentStyle):
+    """Apache Velocity Template Language comment style."""
+
+    _shorthand = "vst"
+
+    # TODO: SINGLE_LINE requires refactor to support trailing `**`.
+    MULTI_LINE = MultiLineSegments("#*", "  ", "*#")
+
+
 class VimCommentStyle(CommentStyle):
     """Vim(Script|Config) style."""
 
@@ -639,7 +648,9 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".v": CCommentStyle,  # V-Lang source code
     ".vala": CCommentStyle,
     ".vim": VimCommentStyle,
+    ".vm": VelocityCommentStyle,
     ".vsh": CCommentStyle,  # V-Lang script
+    ".vtl": VelocityCommentStyle,
     ".vue": HtmlCommentStyle,
     ".xls": UncommentableCommentStyle,
     ".xlsx": UncommentableCommentStyle,


### PR DESCRIPTION
Adds comment style VelocityCommentStyle for the template files of the
Apache Velocity project https://velocity.apache.org/ Most typical file
formats `.vst` and `.vm` for these files are assigned for this comment
style.

This PR relates to issue #553

The single line comments requires a more elaborate code change to
support trailing ` **`, so this change only contains the multi-line
format.

Signed-off-by: Nico Rikken <nico.rikken@alliander.com>
