### PR TITLE
Remove unneeded exclude config for black

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,19 +5,6 @@
 
 [tool.black]
 line-length = 80
-exclude = '''
-/(
-    \.git
-  | \.hg
-  | \.mypy_cache
-  | \.tox
-  | \.venv
-  | _build
-  | buck-out
-  | build
-  | dist
-)\
-'''
 
 [tool.isort]
 multi_line_output = 3


### PR DESCRIPTION
For some reason this wasn't working for me, and black started formatting everything in `.tox`. Removing this config fixed it.