### PR TITLE
Find license identifiers in comments with ASCII art frames

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -56,6 +56,8 @@ Contributors
 
 - Yaman Qalieh
 
+- Pietro Albini <pietro.albini@ferrous-systems.com>
+
 Translators
 -----------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ The versions follow [semantic versioning](https://semver.org).
 ### Fixed
 
 - Sanitize xargs input in scripts documentation
+- License identifiers in comments with symmetrical ASCII art frames are now
+  properly detected (#560)
 
 ### Security
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: 2022 Nico Rikken <nico.rikken@fsfe.org>
 # SPDX-FileCopyrightText: 2022 Florian Snow <florian@familysnow.net>
 # SPDX-FileCopyrightText: 2022 Carmen Bianca Bakker <carmenbianca@fsfe.org>
+# SPDX-FileCopyrightText: 2022 Pietro Albini <pietro.albini@ferrous-systems.com>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -49,6 +50,20 @@ def test_extract_expression():
             f"SPDX-License-Identifier: {expression}"
         )
         assert result.spdx_expressions == {_LICENSING.parse(expression)}
+
+
+def test_extract_expression_from_ascii_art_frame():
+    """Parse an expression from an ASCII art frame"""
+    result = _util.extract_spdx_info(
+        cleandoc(
+            """
+             /**********************************\\
+             |*  SPDX-License-Identifier: MIT  *|
+             \\**********************************/
+            """
+        )
+    )
+    assert result.spdx_expressions == {_LICENSING.parse("MIT")}
 
 
 def test_extract_erroneous_expression():


### PR DESCRIPTION
The Rust project is working to [adopt REUSE to annotate licenses](https://github.com/rust-lang/compiler-team/issues/519), but when working on the initial implementation I stumbled on #343. The Rust repository has LLVM as one of its submodules, and REUSE currently errors out on some of the LLVM comments:

```
reuse._util - ERROR - Could not parse 'Apache-2.0 WITH LLVM-exception                    *|'
reuse.project - ERROR - 'src/llvm-project/lldb/source/Plugins/Plugins.def.in' holds an SPDX expression that cannot be parsed, skipping the file                                                                      
```

As #343 correctly pointed out, the problem is that LLVM uses ASCII art "frames" for those code comments, like:

```c
/***********************************************************\
|* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception *|
\***********************************************************/
```

The solution I came up with is to implement generic handling for these kinds of ASCII art, even in cases where the multiline delimiter (in this case `*`) is not present. When there are some non-whitespace chars before `SPDX-License-Identifier`, the new code tries to strip the *reverse* of them from the end of the line. That correctly handles LLVM comments, but also any other ASCII art frame that's symmetric.

Fixes #343