### PR TITLE
add c and c-lower copyright-style

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -74,6 +74,8 @@ With the argument ``--copyright-style`` it is possible to change the default
 
 .. code-block::
 
+  c:              (C) <year> <statement>
+  c-lower:        (c) <year> <statement>
   spdx:           SPDX-FileCopyrightText: <year> <statement>
   spdx-symbol:    SPDX-FileCopyrightText: © <year> <statement>
   string:         Copyright <year> <statement>

--- a/src/reuse/_util.py
+++ b/src/reuse/_util.py
@@ -71,10 +71,17 @@ _COPYRIGHT_PATTERNS = [
         r"((?P<year>\d{4} - \d{4}|\d{4}),?\s+)?"
         r"(?P<statement>.*)?)" + _END_PATTERN
     ),
+    re.compile(
+        r"(?P<copyright>(?P<prefix>\([cC]\))\s+"
+        r"((?P<year>\d{4} - \d{4}|\d{4}),?\s+)?"
+        r"(?P<statement>.*)?)" + _END_PATTERN
+    ),
 ]
 
 _COPYRIGHT_STYLES = {
     # REUSE-IgnoreStart
+    "c": "(C)",
+    "c-lower": "(c)",
     "spdx": "SPDX-FileCopyrightText:",
     "spdx-symbol": "SPDX-FileCopyrightText: ©",
     "string": "Copyright",
@@ -331,8 +338,8 @@ def make_copyright_line(
     copyright_prefix = _COPYRIGHT_STYLES.get(copyright_style)
     if copyright_prefix is None:
         raise RuntimeError(
-            "Unexpected copyright style: Need 'spdx', 'spdx-symbol', 'string', "
-            "'string-c', 'string-symbol' or 'symbol'"
+            "Unexpected copyright style: Need 'c', 'c-lower', 'spdx', "
+            "'spdx-symbol', 'string', 'string-c', 'string-symbol' or 'symbol'"
         )
 
     for pattern in _COPYRIGHT_PATTERNS:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -378,6 +378,22 @@ def test_make_copyright_line_style_string_year():
     assert statement == "Copyright 2019 hello"
 
 
+def test_make_copyright_line_style_c():
+    """Given a simple statement, style and a year, make it a copyright line."""
+    statement = _util.make_copyright_line(
+        "hello", year=2019, copyright_style="c"
+    )
+    assert statement == "(C) 2019 hello"
+
+
+def test_make_copyright_line_style_c_lower():
+    """Given a simple statement, style and a year, make it a copyright line."""
+    statement = _util.make_copyright_line(
+        "hello", year=2019, copyright_style="c-lower"
+    )
+    assert statement == "(c) 2019 hello"
+
+
 def test_make_copyright_line_style_string_c_year():
     """Given a simple statement, style and a year, make it a copyright line."""
     statement = _util.make_copyright_line(


### PR DESCRIPTION
"Copyright" is English-specific, while the copyright symbol can be difficult to type. These are good reasons to use `(C)` or `(c)`, and I've seen many projects use these. This pull request adds support for `(C)` as style `c` and `(c)` as style `c-lower`.