### PR TITLE
feat: ansible.cfg comment style support

### DIFF
--- a/src/reuse/_comment.py
+++ b/src/reuse/_comment.py
@@ -661,6 +661,7 @@ FILENAME_COMMENT_STYLE_MAP = {
     ".Rprofile": PythonCommentStyle,
     ".vimrc": VimCommentStyle,
     ".yarnrc": PythonCommentStyle,
+    "ansible.cfg": PythonCommentStyle,
     "archive.sctxar": UncommentableCommentStyle,  # SuperCollider global archive
     "CMakeLists.txt": PythonCommentStyle,
     "CODEOWNERS": PythonCommentStyle,


### PR DESCRIPTION
Support the INI format syntax for `ansible.cfg` files. This file is used
to configure the Ansible software and can reside in multiple locations.
The INI format uses the hash sign (#) for comments that occupy an entire
line. The PythonCommentStyle is chosen to match this comment style.

More documentation about the Ansible Configuration Settings file is
available in the official documentation:
https://docs.ansible.com/ansible/latest/reference_appendices/config.html

Signed-off-by: Nico Rikken <nico.rikken@alliander.com>
