### PR TITLE
Update SPDX license/exception list to 3.18

### DIFF
--- a/src/reuse/resources/exceptions.json
+++ b/src/reuse/resources/exceptions.json
@@ -1,22 +1,55 @@
 {
-  "licenseListVersion": "3.17",
+  "licenseListVersion": "3.18",
   "exceptions": [
     {
-      "reference": "./FLTK-exception.json",
+      "reference": "./Qt-GPL-exception-1.0.json",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./FLTK-exception.html",
+      "detailsUrl": "./Qt-GPL-exception-1.0.html",
       "referenceNumber": 1,
-      "name": "FLTK exception",
-      "licenseExceptionId": "FLTK-exception",
+      "name": "Qt GPL exception 1.0",
+      "licenseExceptionId": "Qt-GPL-exception-1.0",
       "seeAlso": [
-        "http://www.fltk.org/COPYING.php"
+        "http://code.qt.io/cgit/qt/qtbase.git/tree/LICENSE.GPL3-EXCEPT"
+      ]
+    },
+    {
+      "reference": "./Fawkes-Runtime-exception.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Fawkes-Runtime-exception.html",
+      "referenceNumber": 2,
+      "name": "Fawkes Runtime Exception",
+      "licenseExceptionId": "Fawkes-Runtime-exception",
+      "seeAlso": [
+        "http://www.fawkesrobotics.org/about/license/"
+      ]
+    },
+    {
+      "reference": "./openvpn-openssl-exception.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./openvpn-openssl-exception.html",
+      "referenceNumber": 3,
+      "name": "OpenVPN OpenSSL Exception",
+      "licenseExceptionId": "openvpn-openssl-exception",
+      "seeAlso": [
+        "http://openvpn.net/index.php/license.html"
+      ]
+    },
+    {
+      "reference": "./DigiRule-FOSS-exception.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./DigiRule-FOSS-exception.html",
+      "referenceNumber": 4,
+      "name": "DigiRule FOSS License Exception",
+      "licenseExceptionId": "DigiRule-FOSS-exception",
+      "seeAlso": [
+        "http://www.digirulesolutions.com/drupal/foss"
       ]
     },
     {
       "reference": "./Bootloader-exception.json",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "./Bootloader-exception.html",
-      "referenceNumber": 2,
+      "referenceNumber": 5,
       "name": "Bootloader Distribution Exception",
       "licenseExceptionId": "Bootloader-exception",
       "seeAlso": [
@@ -24,87 +57,21 @@
       ]
     },
     {
-      "reference": "./WxWindows-exception-3.1.json",
+      "reference": "./OpenJDK-assembly-exception-1.0.json",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./WxWindows-exception-3.1.html",
-      "referenceNumber": 3,
-      "name": "WxWindows Library Exception 3.1",
-      "licenseExceptionId": "WxWindows-exception-3.1",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/WXwindows"
-      ]
-    },
-    {
-      "reference": "./Linux-syscall-note.json",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "./Linux-syscall-note.html",
-      "referenceNumber": 4,
-      "name": "Linux Syscall Note",
-      "licenseExceptionId": "Linux-syscall-note",
-      "seeAlso": [
-        "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/COPYING"
-      ]
-    },
-    {
-      "reference": "./Qt-LGPL-exception-1.1.json",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "./Qt-LGPL-exception-1.1.html",
-      "referenceNumber": 5,
-      "name": "Qt LGPL exception 1.1",
-      "licenseExceptionId": "Qt-LGPL-exception-1.1",
-      "seeAlso": [
-        "http://code.qt.io/cgit/qt/qtbase.git/tree/LGPL_EXCEPTION.txt"
-      ]
-    },
-    {
-      "reference": "./LLVM-exception.json",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "./LLVM-exception.html",
+      "detailsUrl": "./OpenJDK-assembly-exception-1.0.html",
       "referenceNumber": 6,
-      "name": "LLVM Exception",
-      "licenseExceptionId": "LLVM-exception",
+      "name": "OpenJDK Assembly exception 1.0",
+      "licenseExceptionId": "OpenJDK-assembly-exception-1.0",
       "seeAlso": [
-        "http://llvm.org/foundation/relicensing/LICENSE.txt"
-      ]
-    },
-    {
-      "reference": "./PS-or-PDF-font-exception-20170817.json",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "./PS-or-PDF-font-exception-20170817.html",
-      "referenceNumber": 7,
-      "name": "PS/PDF font exception (2017-08-17)",
-      "licenseExceptionId": "PS-or-PDF-font-exception-20170817",
-      "seeAlso": [
-        "https://github.com/ArtifexSoftware/urw-base35-fonts/blob/65962e27febc3883a17e651cdb23e783668c996f/LICENSE"
-      ]
-    },
-    {
-      "reference": "./GCC-exception-3.1.json",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "./GCC-exception-3.1.html",
-      "referenceNumber": 8,
-      "name": "GCC Runtime Library exception 3.1",
-      "licenseExceptionId": "GCC-exception-3.1",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/gcc-exception-3.1.html"
-      ]
-    },
-    {
-      "reference": "./Autoconf-exception-3.0.json",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "./Autoconf-exception-3.0.html",
-      "referenceNumber": 9,
-      "name": "Autoconf exception 3.0",
-      "licenseExceptionId": "Autoconf-exception-3.0",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/autoconf-exception-3.0.html"
+        "http://openjdk.java.net/legal/assembly-exception.html"
       ]
     },
     {
       "reference": "./LGPL-3.0-linking-exception.json",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "./LGPL-3.0-linking-exception.html",
-      "referenceNumber": 10,
+      "referenceNumber": 7,
       "name": "LGPL-3.0 Linking Exception",
       "licenseExceptionId": "LGPL-3.0-linking-exception",
       "seeAlso": [
@@ -114,21 +81,21 @@
       ]
     },
     {
-      "reference": "./GCC-exception-2.0.json",
+      "reference": "./u-boot-exception-2.0.json",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./GCC-exception-2.0.html",
-      "referenceNumber": 11,
-      "name": "GCC Runtime Library exception 2.0",
-      "licenseExceptionId": "GCC-exception-2.0",
+      "detailsUrl": "./u-boot-exception-2.0.html",
+      "referenceNumber": 8,
+      "name": "U-Boot exception 2.0",
+      "licenseExceptionId": "u-boot-exception-2.0",
       "seeAlso": [
-        "https://gcc.gnu.org/git/?p\u003dgcc.git;a\u003dblob;f\u003dgcc/libgcc1.c;h\u003d762f5143fc6eed57b6797c82710f3538aa52b40b;hb\u003dcb143a3ce4fb417c68f5fa2691a1b1b1053dfba9#l10"
+        "http://git.denx.de/?p\u003du-boot.git;a\u003dblob;f\u003dLicenses/Exceptions"
       ]
     },
     {
       "reference": "./Bison-exception-2.2.json",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "./Bison-exception-2.2.html",
-      "referenceNumber": 12,
+      "referenceNumber": 9,
       "name": "Bison exception 2.2",
       "licenseExceptionId": "Bison-exception-2.2",
       "seeAlso": [
@@ -136,37 +103,70 @@
       ]
     },
     {
-      "reference": "./openvpn-openssl-exception.json",
+      "reference": "./OCaml-LGPL-linking-exception.json",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./openvpn-openssl-exception.html",
+      "detailsUrl": "./OCaml-LGPL-linking-exception.html",
+      "referenceNumber": 10,
+      "name": "OCaml LGPL Linking Exception",
+      "licenseExceptionId": "OCaml-LGPL-linking-exception",
+      "seeAlso": [
+        "https://caml.inria.fr/ocaml/license.en.html"
+      ]
+    },
+    {
+      "reference": "./Swift-exception.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Swift-exception.html",
+      "referenceNumber": 11,
+      "name": "Swift Exception",
+      "licenseExceptionId": "Swift-exception",
+      "seeAlso": [
+        "https://swift.org/LICENSE.txt",
+        "https://github.com/apple/swift-package-manager/blob/7ab2275f447a5eb37497ed63a9340f8a6d1e488b/LICENSE.txt#L205"
+      ]
+    },
+    {
+      "reference": "./CLISP-exception-2.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./CLISP-exception-2.0.html",
+      "referenceNumber": 12,
+      "name": "CLISP exception 2.0",
+      "licenseExceptionId": "CLISP-exception-2.0",
+      "seeAlso": [
+        "http://sourceforge.net/p/clisp/clisp/ci/default/tree/COPYRIGHT"
+      ]
+    },
+    {
+      "reference": "./Qwt-exception-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Qwt-exception-1.0.html",
       "referenceNumber": 13,
-      "name": "OpenVPN OpenSSL Exception",
-      "licenseExceptionId": "openvpn-openssl-exception",
+      "name": "Qwt exception 1.0",
+      "licenseExceptionId": "Qwt-exception-1.0",
       "seeAlso": [
-        "http://openvpn.net/index.php/license.html"
+        "http://qwt.sourceforge.net/qwtlicense.html"
       ]
     },
     {
-      "reference": "./Libtool-exception.json",
+      "reference": "./Universal-FOSS-exception-1.0.json",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./Libtool-exception.html",
+      "detailsUrl": "./Universal-FOSS-exception-1.0.html",
       "referenceNumber": 14,
-      "name": "Libtool Exception",
-      "licenseExceptionId": "Libtool-exception",
+      "name": "Universal FOSS Exception, Version 1.0",
+      "licenseExceptionId": "Universal-FOSS-exception-1.0",
       "seeAlso": [
-        "http://git.savannah.gnu.org/cgit/libtool.git/tree/m4/libtool.m4"
+        "https://oss.oracle.com/licenses/universal-foss-exception/"
       ]
     },
     {
-      "reference": "./Autoconf-exception-2.0.json",
+      "reference": "./LLVM-exception.json",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./Autoconf-exception-2.0.html",
+      "detailsUrl": "./LLVM-exception.html",
       "referenceNumber": 15,
-      "name": "Autoconf exception 2.0",
-      "licenseExceptionId": "Autoconf-exception-2.0",
+      "name": "LLVM Exception",
+      "licenseExceptionId": "LLVM-exception",
       "seeAlso": [
-        "http://ac-archive.sourceforge.net/doc/copyright.html",
-        "http://ftp.gnu.org/gnu/autoconf/autoconf-2.59.tar.gz"
+        "http://llvm.org/foundation/relicensing/LICENSE.txt"
       ]
     },
     {
@@ -182,10 +182,266 @@
       ]
     },
     {
+      "reference": "./GStreamer-exception-2008.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./GStreamer-exception-2008.html",
+      "referenceNumber": 17,
+      "name": "GStreamer Exception (2008)",
+      "licenseExceptionId": "GStreamer-exception-2008",
+      "seeAlso": [
+        "https://gstreamer.freedesktop.org/documentation/frequently-asked-questions/licensing.html?gi-language\u003dc#licensing-of-applications-using-gstreamer"
+      ]
+    },
+    {
+      "reference": "./FLTK-exception.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./FLTK-exception.html",
+      "referenceNumber": 18,
+      "name": "FLTK exception",
+      "licenseExceptionId": "FLTK-exception",
+      "seeAlso": [
+        "http://www.fltk.org/COPYING.php"
+      ]
+    },
+    {
+      "reference": "./GPL-3.0-linking-exception.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./GPL-3.0-linking-exception.html",
+      "referenceNumber": 19,
+      "name": "GPL-3.0 Linking Exception",
+      "licenseExceptionId": "GPL-3.0-linking-exception",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/gpl-faq.en.html#GPLIncompatibleLibs"
+      ]
+    },
+    {
+      "reference": "./Qt-LGPL-exception-1.1.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Qt-LGPL-exception-1.1.html",
+      "referenceNumber": 20,
+      "name": "Qt LGPL exception 1.1",
+      "licenseExceptionId": "Qt-LGPL-exception-1.1",
+      "seeAlso": [
+        "http://code.qt.io/cgit/qt/qtbase.git/tree/LGPL_EXCEPTION.txt"
+      ]
+    },
+    {
+      "reference": "./Classpath-exception-2.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Classpath-exception-2.0.html",
+      "referenceNumber": 21,
+      "name": "Classpath exception 2.0",
+      "licenseExceptionId": "Classpath-exception-2.0",
+      "seeAlso": [
+        "http://www.gnu.org/software/classpath/license.html",
+        "https://fedoraproject.org/wiki/Licensing/GPL_Classpath_Exception"
+      ]
+    },
+    {
+      "reference": "./Nokia-Qt-exception-1.1.json",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "./Nokia-Qt-exception-1.1.html",
+      "referenceNumber": 22,
+      "name": "Nokia Qt LGPL exception 1.1",
+      "licenseExceptionId": "Nokia-Qt-exception-1.1",
+      "seeAlso": [
+        "https://www.keepassx.org/dev/projects/keepassx/repository/revisions/b8dfb9cc4d5133e0f09cd7533d15a4f1c19a40f2/entry/LICENSE.NOKIA-LGPL-EXCEPTION"
+      ]
+    },
+    {
+      "reference": "./389-exception.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./389-exception.html",
+      "referenceNumber": 23,
+      "name": "389 Directory Server Exception",
+      "licenseExceptionId": "389-exception",
+      "seeAlso": [
+        "http://directory.fedoraproject.org/wiki/GPL_Exception_License_Text",
+        "https://web.archive.org/web/20080828121337/http://directory.fedoraproject.org/wiki/GPL_Exception_License_Text"
+      ]
+    },
+    {
+      "reference": "./Font-exception-2.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Font-exception-2.0.html",
+      "referenceNumber": 24,
+      "name": "Font exception 2.0",
+      "licenseExceptionId": "Font-exception-2.0",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/gpl-faq.html#FontException"
+      ]
+    },
+    {
+      "reference": "./GStreamer-exception-2005.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./GStreamer-exception-2005.html",
+      "referenceNumber": 25,
+      "name": "GStreamer Exception (2005)",
+      "licenseExceptionId": "GStreamer-exception-2005",
+      "seeAlso": [
+        "https://gstreamer.freedesktop.org/documentation/frequently-asked-questions/licensing.html?gi-language\u003dc#licensing-of-applications-using-gstreamer"
+      ]
+    },
+    {
+      "reference": "./SHL-2.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./SHL-2.0.html",
+      "referenceNumber": 26,
+      "name": "Solderpad Hardware License v2.0",
+      "licenseExceptionId": "SHL-2.0",
+      "seeAlso": [
+        "https://solderpad.org/licenses/SHL-2.0/"
+      ]
+    },
+    {
+      "reference": "./WxWindows-exception-3.1.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./WxWindows-exception-3.1.html",
+      "referenceNumber": 27,
+      "name": "WxWindows Library Exception 3.1",
+      "licenseExceptionId": "WxWindows-exception-3.1",
+      "seeAlso": [
+        "http://www.opensource.org/licenses/WXwindows"
+      ]
+    },
+    {
+      "reference": "./Autoconf-exception-3.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Autoconf-exception-3.0.html",
+      "referenceNumber": 28,
+      "name": "Autoconf exception 3.0",
+      "licenseExceptionId": "Autoconf-exception-3.0",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/autoconf-exception-3.0.html"
+      ]
+    },
+    {
+      "reference": "./PS-or-PDF-font-exception-20170817.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./PS-or-PDF-font-exception-20170817.html",
+      "referenceNumber": 29,
+      "name": "PS/PDF font exception (2017-08-17)",
+      "licenseExceptionId": "PS-or-PDF-font-exception-20170817",
+      "seeAlso": [
+        "https://github.com/ArtifexSoftware/urw-base35-fonts/blob/65962e27febc3883a17e651cdb23e783668c996f/LICENSE"
+      ]
+    },
+    {
+      "reference": "./Autoconf-exception-2.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./Autoconf-exception-2.0.html",
+      "referenceNumber": 30,
+      "name": "Autoconf exception 2.0",
+      "licenseExceptionId": "Autoconf-exception-2.0",
+      "seeAlso": [
+        "http://ac-archive.sourceforge.net/doc/copyright.html",
+        "http://ftp.gnu.org/gnu/autoconf/autoconf-2.59.tar.gz"
+      ]
+    },
+    {
+      "reference": "./SHL-2.1.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./SHL-2.1.html",
+      "referenceNumber": 31,
+      "name": "Solderpad Hardware License v2.1",
+      "licenseExceptionId": "SHL-2.1",
+      "seeAlso": [
+        "https://solderpad.org/licenses/SHL-2.1/"
+      ]
+    },
+    {
+      "reference": "./LZMA-exception.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./LZMA-exception.html",
+      "referenceNumber": 32,
+      "name": "LZMA exception",
+      "licenseExceptionId": "LZMA-exception",
+      "seeAlso": [
+        "http://nsis.sourceforge.net/Docs/AppendixI.html#I.6"
+      ]
+    },
+    {
+      "reference": "./GCC-exception-2.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./GCC-exception-2.0.html",
+      "referenceNumber": 33,
+      "name": "GCC Runtime Library exception 2.0",
+      "licenseExceptionId": "GCC-exception-2.0",
+      "seeAlso": [
+        "https://gcc.gnu.org/git/?p\u003dgcc.git;a\u003dblob;f\u003dgcc/libgcc1.c;h\u003d762f5143fc6eed57b6797c82710f3538aa52b40b;hb\u003dcb143a3ce4fb417c68f5fa2691a1b1b1053dfba9#l10"
+      ]
+    },
+    {
+      "reference": "./eCos-exception-2.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./eCos-exception-2.0.html",
+      "referenceNumber": 34,
+      "name": "eCos exception 2.0",
+      "licenseExceptionId": "eCos-exception-2.0",
+      "seeAlso": [
+        "http://ecos.sourceware.org/license-overview.html"
+      ]
+    },
+    {
+      "reference": "./gnu-javamail-exception.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./gnu-javamail-exception.html",
+      "referenceNumber": 35,
+      "name": "GNU JavaMail exception",
+      "licenseExceptionId": "gnu-javamail-exception",
+      "seeAlso": [
+        "http://www.gnu.org/software/classpathx/javamail/javamail.html"
+      ]
+    },
+    {
+      "reference": "./OCCT-exception-1.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./OCCT-exception-1.0.html",
+      "referenceNumber": 36,
+      "name": "Open CASCADE Exception 1.0",
+      "licenseExceptionId": "OCCT-exception-1.0",
+      "seeAlso": [
+        "http://www.opencascade.com/content/licensing"
+      ]
+    },
+    {
+      "reference": "./KiCad-libraries-exception.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./KiCad-libraries-exception.html",
+      "referenceNumber": 37,
+      "name": "KiCad Libraries Exception",
+      "licenseExceptionId": "KiCad-libraries-exception",
+      "seeAlso": [
+        "https://www.kicad.org/libraries/license/"
+      ]
+    },
+    {
+      "reference": "./GCC-exception-3.1.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./GCC-exception-3.1.html",
+      "referenceNumber": 38,
+      "name": "GCC Runtime Library exception 3.1",
+      "licenseExceptionId": "GCC-exception-3.1",
+      "seeAlso": [
+        "http://www.gnu.org/licenses/gcc-exception-3.1.html"
+      ]
+    },
+    {
+      "reference": "./freertos-exception-2.0.json",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "./freertos-exception-2.0.html",
+      "referenceNumber": 39,
+      "name": "FreeRTOS Exception 2.0",
+      "licenseExceptionId": "freertos-exception-2.0",
+      "seeAlso": [
+        "https://web.archive.org/web/20060809182744/http://www.freertos.org/a00114.html"
+      ]
+    },
+    {
       "reference": "./GPL-CC-1.0.json",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "./GPL-CC-1.0.html",
-      "referenceNumber": 17,
+      "referenceNumber": 40,
       "name": "GPL Cooperation Commitment 1.0",
       "licenseExceptionId": "GPL-CC-1.0",
       "seeAlso": [
@@ -194,142 +450,10 @@
       ]
     },
     {
-      "reference": "./OCaml-LGPL-linking-exception.json",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "./OCaml-LGPL-linking-exception.html",
-      "referenceNumber": 18,
-      "name": "OCaml LGPL Linking Exception",
-      "licenseExceptionId": "OCaml-LGPL-linking-exception",
-      "seeAlso": [
-        "https://caml.inria.fr/ocaml/license.en.html"
-      ]
-    },
-    {
-      "reference": "./Universal-FOSS-exception-1.0.json",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "./Universal-FOSS-exception-1.0.html",
-      "referenceNumber": 19,
-      "name": "Universal FOSS Exception, Version 1.0",
-      "licenseExceptionId": "Universal-FOSS-exception-1.0",
-      "seeAlso": [
-        "https://oss.oracle.com/licenses/universal-foss-exception/"
-      ]
-    },
-    {
-      "reference": "./i2p-gpl-java-exception.json",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "./i2p-gpl-java-exception.html",
-      "referenceNumber": 20,
-      "name": "i2p GPL+Java Exception",
-      "licenseExceptionId": "i2p-gpl-java-exception",
-      "seeAlso": [
-        "http://geti2p.net/en/get-involved/develop/licenses#java_exception"
-      ]
-    },
-    {
-      "reference": "./CLISP-exception-2.0.json",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "./CLISP-exception-2.0.html",
-      "referenceNumber": 21,
-      "name": "CLISP exception 2.0",
-      "licenseExceptionId": "CLISP-exception-2.0",
-      "seeAlso": [
-        "http://sourceforge.net/p/clisp/clisp/ci/default/tree/COPYRIGHT"
-      ]
-    },
-    {
-      "reference": "./OCCT-exception-1.0.json",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "./OCCT-exception-1.0.html",
-      "referenceNumber": 22,
-      "name": "Open CASCADE Exception 1.0",
-      "licenseExceptionId": "OCCT-exception-1.0",
-      "seeAlso": [
-        "http://www.opencascade.com/content/licensing"
-      ]
-    },
-    {
-      "reference": "./Qwt-exception-1.0.json",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "./Qwt-exception-1.0.html",
-      "referenceNumber": 23,
-      "name": "Qwt exception 1.0",
-      "licenseExceptionId": "Qwt-exception-1.0",
-      "seeAlso": [
-        "http://qwt.sourceforge.net/qwtlicense.html"
-      ]
-    },
-    {
-      "reference": "./gnu-javamail-exception.json",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "./gnu-javamail-exception.html",
-      "referenceNumber": 24,
-      "name": "GNU JavaMail exception",
-      "licenseExceptionId": "gnu-javamail-exception",
-      "seeAlso": [
-        "http://www.gnu.org/software/classpathx/javamail/javamail.html"
-      ]
-    },
-    {
-      "reference": "./u-boot-exception-2.0.json",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "./u-boot-exception-2.0.html",
-      "referenceNumber": 25,
-      "name": "U-Boot exception 2.0",
-      "licenseExceptionId": "u-boot-exception-2.0",
-      "seeAlso": [
-        "http://git.denx.de/?p\u003du-boot.git;a\u003dblob;f\u003dLicenses/Exceptions"
-      ]
-    },
-    {
-      "reference": "./freertos-exception-2.0.json",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "./freertos-exception-2.0.html",
-      "referenceNumber": 26,
-      "name": "FreeRTOS Exception 2.0",
-      "licenseExceptionId": "freertos-exception-2.0",
-      "seeAlso": [
-        "https://web.archive.org/web/20060809182744/http://www.freertos.org/a00114.html"
-      ]
-    },
-    {
-      "reference": "./Qt-GPL-exception-1.0.json",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "./Qt-GPL-exception-1.0.html",
-      "referenceNumber": 27,
-      "name": "Qt GPL exception 1.0",
-      "licenseExceptionId": "Qt-GPL-exception-1.0",
-      "seeAlso": [
-        "http://code.qt.io/cgit/qt/qtbase.git/tree/LICENSE.GPL3-EXCEPT"
-      ]
-    },
-    {
-      "reference": "./OpenJDK-assembly-exception-1.0.json",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "./OpenJDK-assembly-exception-1.0.html",
-      "referenceNumber": 28,
-      "name": "OpenJDK Assembly exception 1.0",
-      "licenseExceptionId": "OpenJDK-assembly-exception-1.0",
-      "seeAlso": [
-        "http://openjdk.java.net/legal/assembly-exception.html"
-      ]
-    },
-    {
-      "reference": "./SHL-2.1.json",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "./SHL-2.1.html",
-      "referenceNumber": 29,
-      "name": "Solderpad Hardware License v2.1",
-      "licenseExceptionId": "SHL-2.1",
-      "seeAlso": [
-        "https://solderpad.org/licenses/SHL-2.1/"
-      ]
-    },
-    {
       "reference": "./mif-exception.json",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "./mif-exception.html",
-      "referenceNumber": 30,
+      "referenceNumber": 41,
       "name": "Macros and Inline Functions Exception",
       "licenseExceptionId": "mif-exception",
       "seeAlso": [
@@ -339,128 +463,38 @@
       ]
     },
     {
-      "reference": "./Fawkes-Runtime-exception.json",
+      "reference": "./Linux-syscall-note.json",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./Fawkes-Runtime-exception.html",
-      "referenceNumber": 31,
-      "name": "Fawkes Runtime Exception",
-      "licenseExceptionId": "Fawkes-Runtime-exception",
+      "detailsUrl": "./Linux-syscall-note.html",
+      "referenceNumber": 42,
+      "name": "Linux Syscall Note",
+      "licenseExceptionId": "Linux-syscall-note",
       "seeAlso": [
-        "http://www.fawkesrobotics.org/about/license/"
+        "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/COPYING"
       ]
     },
     {
-      "reference": "./Swift-exception.json",
+      "reference": "./i2p-gpl-java-exception.json",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./Swift-exception.html",
-      "referenceNumber": 32,
-      "name": "Swift Exception",
-      "licenseExceptionId": "Swift-exception",
+      "detailsUrl": "./i2p-gpl-java-exception.html",
+      "referenceNumber": 43,
+      "name": "i2p GPL+Java Exception",
+      "licenseExceptionId": "i2p-gpl-java-exception",
       "seeAlso": [
-        "https://swift.org/LICENSE.txt",
-        "https://github.com/apple/swift-package-manager/blob/7ab2275f447a5eb37497ed63a9340f8a6d1e488b/LICENSE.txt#L205"
+        "http://geti2p.net/en/get-involved/develop/licenses#java_exception"
       ]
     },
     {
-      "reference": "./GPL-3.0-linking-exception.json",
+      "reference": "./Libtool-exception.json",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./GPL-3.0-linking-exception.html",
-      "referenceNumber": 33,
-      "name": "GPL-3.0 Linking Exception",
-      "licenseExceptionId": "GPL-3.0-linking-exception",
+      "detailsUrl": "./Libtool-exception.html",
+      "referenceNumber": 44,
+      "name": "Libtool Exception",
+      "licenseExceptionId": "Libtool-exception",
       "seeAlso": [
-        "https://www.gnu.org/licenses/gpl-faq.en.html#GPLIncompatibleLibs"
-      ]
-    },
-    {
-      "reference": "./SHL-2.0.json",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "./SHL-2.0.html",
-      "referenceNumber": 34,
-      "name": "Solderpad Hardware License v2.0",
-      "licenseExceptionId": "SHL-2.0",
-      "seeAlso": [
-        "https://solderpad.org/licenses/SHL-2.0/"
-      ]
-    },
-    {
-      "reference": "./Classpath-exception-2.0.json",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "./Classpath-exception-2.0.html",
-      "referenceNumber": 35,
-      "name": "Classpath exception 2.0",
-      "licenseExceptionId": "Classpath-exception-2.0",
-      "seeAlso": [
-        "http://www.gnu.org/software/classpath/license.html",
-        "https://fedoraproject.org/wiki/Licensing/GPL_Classpath_Exception"
-      ]
-    },
-    {
-      "reference": "./LZMA-exception.json",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "./LZMA-exception.html",
-      "referenceNumber": 36,
-      "name": "LZMA exception",
-      "licenseExceptionId": "LZMA-exception",
-      "seeAlso": [
-        "http://nsis.sourceforge.net/Docs/AppendixI.html#I.6"
-      ]
-    },
-    {
-      "reference": "./Font-exception-2.0.json",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "./Font-exception-2.0.html",
-      "referenceNumber": 37,
-      "name": "Font exception 2.0",
-      "licenseExceptionId": "Font-exception-2.0",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/gpl-faq.html#FontException"
-      ]
-    },
-    {
-      "reference": "./Nokia-Qt-exception-1.1.json",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "./Nokia-Qt-exception-1.1.html",
-      "referenceNumber": 38,
-      "name": "Nokia Qt LGPL exception 1.1",
-      "licenseExceptionId": "Nokia-Qt-exception-1.1",
-      "seeAlso": [
-        "https://www.keepassx.org/dev/projects/keepassx/repository/revisions/b8dfb9cc4d5133e0f09cd7533d15a4f1c19a40f2/entry/LICENSE.NOKIA-LGPL-EXCEPTION"
-      ]
-    },
-    {
-      "reference": "./DigiRule-FOSS-exception.json",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "./DigiRule-FOSS-exception.html",
-      "referenceNumber": 39,
-      "name": "DigiRule FOSS License Exception",
-      "licenseExceptionId": "DigiRule-FOSS-exception",
-      "seeAlso": [
-        "http://www.digirulesolutions.com/drupal/foss"
-      ]
-    },
-    {
-      "reference": "./eCos-exception-2.0.json",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "./eCos-exception-2.0.html",
-      "referenceNumber": 40,
-      "name": "eCos exception 2.0",
-      "licenseExceptionId": "eCos-exception-2.0",
-      "seeAlso": [
-        "http://ecos.sourceware.org/license-overview.html"
-      ]
-    },
-    {
-      "reference": "./389-exception.json",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "./389-exception.html",
-      "referenceNumber": 41,
-      "name": "389 Directory Server Exception",
-      "licenseExceptionId": "389-exception",
-      "seeAlso": [
-        "http://directory.fedoraproject.org/wiki/GPL_Exception_License_Text"
+        "http://git.savannah.gnu.org/cgit/libtool.git/tree/m4/libtool.m4"
       ]
     }
   ],
-  "releaseDate": "2022-05-08"
+  "releaseDate": "2022-08-12"
 }

--- a/src/reuse/resources/licenses.json
+++ b/src/reuse/resources/licenses.json
@@ -1,187 +1,90 @@
 {
-  "licenseListVersion": "3.17",
+  "licenseListVersion": "3.18",
   "licenses": [
     {
-      "reference": "https://spdx.org/licenses/CC-BY-NC-ND-2.0.html",
+      "reference": "https://spdx.org/licenses/VSL-1.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-2.0.json",
+      "detailsUrl": "https://spdx.org/licenses/VSL-1.0.json",
       "referenceNumber": 0,
-      "name": "Creative Commons Attribution Non Commercial No Derivatives 2.0 Generic",
-      "licenseId": "CC-BY-NC-ND-2.0",
+      "name": "Vovida Software License v1.0",
+      "licenseId": "VSL-1.0",
       "seeAlso": [
-        "https://creativecommons.org/licenses/by-nc-nd/2.0/legalcode"
+        "https://opensource.org/licenses/VSL-1.0"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": true
     },
     {
-      "reference": "https://spdx.org/licenses/SGI-B-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/SGI-B-2.0.json",
+      "reference": "https://spdx.org/licenses/GPL-2.0.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/GPL-2.0.json",
       "referenceNumber": 1,
-      "name": "SGI Free Software License B v2.0",
-      "licenseId": "SGI-B-2.0",
+      "name": "GNU General Public License v2.0 only",
+      "licenseId": "GPL-2.0",
       "seeAlso": [
-        "http://oss.sgi.com/projects/FreeB/SGIFreeSWLicB.2.0.pdf"
+        "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
+        "https://opensource.org/licenses/GPL-2.0"
       ],
-      "isOsiApproved": false,
+      "isOsiApproved": true,
       "isFsfLibre": true
     },
     {
-      "reference": "https://spdx.org/licenses/LPPL-1.3c.html",
+      "reference": "https://spdx.org/licenses/blessing.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/LPPL-1.3c.json",
+      "detailsUrl": "https://spdx.org/licenses/blessing.json",
       "referenceNumber": 2,
-      "name": "LaTeX Project Public License v1.3c",
-      "licenseId": "LPPL-1.3c",
+      "name": "SQLite Blessing",
+      "licenseId": "blessing",
       "seeAlso": [
-        "http://www.latex-project.org/lppl/lppl-1-3c.txt",
-        "https://opensource.org/licenses/LPPL-1.3c"
+        "https://www.sqlite.org/src/artifact/e33a4df7e32d742a?ln\u003d4-9",
+        "https://sqlite.org/src/artifact/df5091916dbb40e6"
       ],
-      "isOsiApproved": true
+      "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/NIST-PD-fallback.html",
+      "reference": "https://spdx.org/licenses/BSD-4-Clause-Shortened.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/NIST-PD-fallback.json",
+      "detailsUrl": "https://spdx.org/licenses/BSD-4-Clause-Shortened.json",
       "referenceNumber": 3,
-      "name": "NIST Public Domain Notice with license fallback",
-      "licenseId": "NIST-PD-fallback",
+      "name": "BSD 4 Clause Shortened",
+      "licenseId": "BSD-4-Clause-Shortened",
       "seeAlso": [
-        "https://github.com/usnistgov/jsip/blob/59700e6926cbe96c5cdae897d9a7d2656b42abe3/LICENSE",
-        "https://github.com/usnistgov/fipy/blob/86aaa5c2ba2c6f1be19593c5986071cf6568cc34/LICENSE.rst"
+        "https://metadata.ftp-master.debian.org/changelogs//main/a/arpwatch/arpwatch_2.1a15-7_copyright"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/libtiff.html",
+      "reference": "https://spdx.org/licenses/Libpng.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/libtiff.json",
+      "detailsUrl": "https://spdx.org/licenses/Libpng.json",
       "referenceNumber": 4,
-      "name": "libtiff License",
-      "licenseId": "libtiff",
+      "name": "libpng License",
+      "licenseId": "Libpng",
       "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/libtiff"
+        "http://www.libpng.org/pub/png/src/libpng-LICENSE.txt"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/XSkat.html",
+      "reference": "https://spdx.org/licenses/OFL-1.0-no-RFN.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/XSkat.json",
+      "detailsUrl": "https://spdx.org/licenses/OFL-1.0-no-RFN.json",
       "referenceNumber": 5,
-      "name": "XSkat License",
-      "licenseId": "XSkat",
+      "name": "SIL Open Font License 1.0 with no Reserved Font Name",
+      "licenseId": "OFL-1.0-no-RFN",
       "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/XSkat_License"
+        "http://scripts.sil.org/cms/scripts/page.php?item_id\u003dOFL10_web"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/PDDL-1.0.html",
+      "reference": "https://spdx.org/licenses/MakeIndex.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/PDDL-1.0.json",
+      "detailsUrl": "https://spdx.org/licenses/MakeIndex.json",
       "referenceNumber": 6,
-      "name": "Open Data Commons Public Domain Dedication \u0026 License 1.0",
-      "licenseId": "PDDL-1.0",
+      "name": "MakeIndex License",
+      "licenseId": "MakeIndex",
       "seeAlso": [
-        "http://opendatacommons.org/licenses/pddl/1.0/",
-        "https://opendatacommons.org/licenses/pddl/"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/KiCad-libraries-exception.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/KiCad-libraries-exception.json",
-      "referenceNumber": 7,
-      "name": "KiCad Libraries Exception",
-      "licenseId": "KiCad-libraries-exception",
-      "seeAlso": [
-        "https://www.kicad.org/libraries/license/"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/CC-BY-NC-SA-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-1.0.json",
-      "referenceNumber": 8,
-      "name": "Creative Commons Attribution Non Commercial Share Alike 1.0 Generic",
-      "licenseId": "CC-BY-NC-SA-1.0",
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nc-sa/1.0/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/GFDL-1.1-no-invariants-only.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-no-invariants-only.json",
-      "referenceNumber": 9,
-      "name": "GNU Free Documentation License v1.1 only - no invariants",
-      "licenseId": "GFDL-1.1-no-invariants-only",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/Xerox.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Xerox.json",
-      "referenceNumber": 10,
-      "name": "Xerox License",
-      "licenseId": "Xerox",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Xerox"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/LPPL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/LPPL-1.1.json",
-      "referenceNumber": 11,
-      "name": "LaTeX Project Public License v1.1",
-      "licenseId": "LPPL-1.1",
-      "seeAlso": [
-        "http://www.latex-project.org/lppl/lppl-1-1.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/VOSTROM.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/VOSTROM.json",
-      "referenceNumber": 12,
-      "name": "VOSTROM Public License for Open Source",
-      "licenseId": "VOSTROM",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/VOSTROM"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/UCL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/UCL-1.0.json",
-      "referenceNumber": 13,
-      "name": "Upstream Compatibility License v1.0",
-      "licenseId": "UCL-1.0",
-      "seeAlso": [
-        "https://opensource.org/licenses/UCL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/ADSL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/ADSL.json",
-      "referenceNumber": 14,
-      "name": "Amazon Digital Services License",
-      "licenseId": "ADSL",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/AmazonDigitalServicesLicense"
+        "https://fedoraproject.org/wiki/Licensing/MakeIndex"
       ],
       "isOsiApproved": false
     },
@@ -189,7 +92,7 @@
       "reference": "https://spdx.org/licenses/OSL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OSL-2.0.json",
-      "referenceNumber": 15,
+      "referenceNumber": 7,
       "name": "Open Software License 2.0",
       "licenseId": "OSL-2.0",
       "seeAlso": [
@@ -199,625 +102,36 @@
       "isFsfLibre": true
     },
     {
-      "reference": "https://spdx.org/licenses/AAL.html",
+      "reference": "https://spdx.org/licenses/Artistic-1.0-cl8.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/AAL.json",
-      "referenceNumber": 16,
-      "name": "Attribution Assurance License",
-      "licenseId": "AAL",
+      "detailsUrl": "https://spdx.org/licenses/Artistic-1.0-cl8.json",
+      "referenceNumber": 8,
+      "name": "Artistic License 1.0 w/clause 8",
+      "licenseId": "Artistic-1.0-cl8",
       "seeAlso": [
-        "https://opensource.org/licenses/attribution"
+        "https://opensource.org/licenses/Artistic-1.0"
       ],
       "isOsiApproved": true
     },
     {
-      "reference": "https://spdx.org/licenses/FDK-AAC.html",
+      "reference": "https://spdx.org/licenses/ZPL-2.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/FDK-AAC.json",
-      "referenceNumber": 17,
-      "name": "Fraunhofer FDK AAC Codec Library",
-      "licenseId": "FDK-AAC",
+      "detailsUrl": "https://spdx.org/licenses/ZPL-2.0.json",
+      "referenceNumber": 9,
+      "name": "Zope Public License 2.0",
+      "licenseId": "ZPL-2.0",
       "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/FDK-AAC",
-        "https://directory.fsf.org/wiki/License:Fdk"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/W3C-20150513.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/W3C-20150513.json",
-      "referenceNumber": 18,
-      "name": "W3C Software Notice and Document License (2015-05-13)",
-      "licenseId": "W3C-20150513",
-      "seeAlso": [
-        "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/AFL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/AFL-1.1.json",
-      "referenceNumber": 19,
-      "name": "Academic Free License v1.1",
-      "licenseId": "AFL-1.1",
-      "seeAlso": [
-        "http://opensource.linux-mirror.org/licenses/afl-1.1.txt",
-        "http://wayback.archive.org/web/20021004124254/http://www.opensource.org/licenses/academic.php"
+        "http://old.zope.org/Resources/License/ZPL-2.0",
+        "https://opensource.org/licenses/ZPL-2.0"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/W3C.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/W3C.json",
-      "referenceNumber": 20,
-      "name": "W3C Software Notice and License (2002-12-31)",
-      "licenseId": "W3C",
-      "seeAlso": [
-        "http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231.html",
-        "https://opensource.org/licenses/W3C"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/Sleepycat.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Sleepycat.json",
-      "referenceNumber": 21,
-      "name": "Sleepycat License",
-      "licenseId": "Sleepycat",
-      "seeAlso": [
-        "https://opensource.org/licenses/Sleepycat"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/CECILL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CECILL-1.1.json",
-      "referenceNumber": 22,
-      "name": "CeCILL Free Software License Agreement v1.1",
-      "licenseId": "CECILL-1.1",
-      "seeAlso": [
-        "http://www.cecill.info/licences/Licence_CeCILL_V1.1-US.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/mpich2.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/mpich2.json",
-      "referenceNumber": 23,
-      "name": "mpich2 License",
-      "licenseId": "mpich2",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/MIT"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/SISSL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/SISSL.json",
-      "referenceNumber": 24,
-      "name": "Sun Industry Standards Source License v1.1",
-      "licenseId": "SISSL",
-      "seeAlso": [
-        "http://www.openoffice.org/licenses/sissl_license.html",
-        "https://opensource.org/licenses/SISSL"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/NLOD-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/NLOD-1.0.json",
-      "referenceNumber": 25,
-      "name": "Norwegian Licence for Open Government Data (NLOD) 1.0",
-      "licenseId": "NLOD-1.0",
-      "seeAlso": [
-        "http://data.norge.no/nlod/en/1.0"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/ANTLR-PD.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/ANTLR-PD.json",
-      "referenceNumber": 26,
-      "name": "ANTLR Software Rights Notice",
-      "licenseId": "ANTLR-PD",
-      "seeAlso": [
-        "http://www.antlr2.org/license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/GPL-3.0-only.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/GPL-3.0-only.json",
-      "referenceNumber": 27,
-      "name": "GNU General Public License v3.0 only",
-      "licenseId": "GPL-3.0-only",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
-        "https://opensource.org/licenses/GPL-3.0"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/gnuplot.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/gnuplot.json",
-      "referenceNumber": 28,
-      "name": "gnuplot License",
-      "licenseId": "gnuplot",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Gnuplot"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/NLOD-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/NLOD-2.0.json",
-      "referenceNumber": 29,
-      "name": "Norwegian Licence for Open Government Data (NLOD) 2.0",
-      "licenseId": "NLOD-2.0",
-      "seeAlso": [
-        "http://data.norge.no/nlod/en/2.0"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/BSD-3-Clause-Open-MPI.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Open-MPI.json",
-      "referenceNumber": 30,
-      "name": "BSD 3-Clause Open MPI variant",
-      "licenseId": "BSD-3-Clause-Open-MPI",
-      "seeAlso": [
-        "https://www.open-mpi.org/community/license.php",
-        "http://www.netlib.org/lapack/LICENSE.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/LiLiQ-P-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/LiLiQ-P-1.1.json",
-      "referenceNumber": 31,
-      "name": "Licence Libre du Québec – Permissive version 1.1",
-      "licenseId": "LiLiQ-P-1.1",
-      "seeAlso": [
-        "https://forge.gouv.qc.ca/licence/fr/liliq-v1-1/",
-        "http://opensource.org/licenses/LiLiQ-P-1.1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/BSD-3-Clause-Clear.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Clear.json",
-      "referenceNumber": 32,
-      "name": "BSD 3-Clause Clear License",
-      "licenseId": "BSD-3-Clause-Clear",
-      "seeAlso": [
-        "http://labs.metacarta.com/license-explanation.html#license"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/FSFUL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/FSFUL.json",
-      "referenceNumber": 33,
-      "name": "FSF Unlimited License",
-      "licenseId": "FSFUL",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/FSF_Unlimited_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-UK.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-UK.json",
-      "referenceNumber": 34,
-      "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 England and Wales",
-      "licenseId": "CC-BY-NC-SA-2.0-UK",
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nc-sa/2.0/uk/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/CERN-OHL-S-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CERN-OHL-S-2.0.json",
-      "referenceNumber": 35,
-      "name": "CERN Open Hardware Licence Version 2 - Strongly Reciprocal",
-      "licenseId": "CERN-OHL-S-2.0",
-      "seeAlso": [
-        "https://www.ohwr.org/project/cernohl/wikis/Documents/CERN-OHL-version-2"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/Spencer-94.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Spencer-94.json",
-      "referenceNumber": 36,
-      "name": "Spencer License 94",
-      "licenseId": "Spencer-94",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Henry_Spencer_Reg-Ex_Library_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/CERN-OHL-1.2.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CERN-OHL-1.2.json",
-      "referenceNumber": 37,
-      "name": "CERN Open Hardware Licence v1.2",
-      "licenseId": "CERN-OHL-1.2",
-      "seeAlso": [
-        "https://www.ohwr.org/project/licenses/wikis/cern-ohl-v1.2"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/GFDL-1.1-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-or-later.json",
-      "referenceNumber": 38,
-      "name": "GNU Free Documentation License v1.1 or later",
-      "licenseId": "GFDL-1.1-or-later",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/AGPL-1.0-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/AGPL-1.0-or-later.json",
-      "referenceNumber": 39,
-      "name": "Affero General Public License v1.0 or later",
-      "licenseId": "AGPL-1.0-or-later",
-      "seeAlso": [
-        "http://www.affero.org/oagpl.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/Wsuipa.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Wsuipa.json",
-      "referenceNumber": 40,
-      "name": "Wsuipa License",
-      "licenseId": "Wsuipa",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Wsuipa"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/AML.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/AML.json",
-      "referenceNumber": 41,
-      "name": "Apple MIT License",
-      "licenseId": "AML",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Apple_MIT_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/BSD-2-Clause.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause.json",
-      "referenceNumber": 42,
-      "name": "BSD 2-Clause \"Simplified\" License",
-      "licenseId": "BSD-2-Clause",
-      "seeAlso": [
-        "https://opensource.org/licenses/BSD-2-Clause"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/DSDP.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/DSDP.json",
-      "referenceNumber": 43,
-      "name": "DSDP License",
-      "licenseId": "DSDP",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/DSDP"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/CC-BY-2.5.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-2.5.json",
-      "referenceNumber": 44,
-      "name": "Creative Commons Attribution 2.5 Generic",
-      "licenseId": "CC-BY-2.5",
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by/2.5/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/MIT-CMU.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/MIT-CMU.json",
-      "referenceNumber": 45,
-      "name": "CMU License",
-      "licenseId": "MIT-CMU",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing:MIT?rd\u003dLicensing/MIT#CMU_Style",
-        "https://github.com/python-pillow/Pillow/blob/fffb426092c8db24a5f4b6df243a8a3c01fb63cd/LICENSE"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/Beerware.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Beerware.json",
-      "referenceNumber": 46,
-      "name": "Beerware License",
-      "licenseId": "Beerware",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Beerware",
-        "https://people.freebsd.org/~phk/"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/Sendmail.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Sendmail.json",
-      "referenceNumber": 47,
-      "name": "Sendmail License",
-      "licenseId": "Sendmail",
-      "seeAlso": [
-        "http://www.sendmail.com/pdfs/open_source/sendmail_license.pdf",
-        "https://web.archive.org/web/20160322142305/https://www.sendmail.com/pdfs/open_source/sendmail_license.pdf"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/TU-Berlin-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/TU-Berlin-1.0.json",
-      "referenceNumber": 48,
-      "name": "Technische Universitaet Berlin License 1.0",
-      "licenseId": "TU-Berlin-1.0",
-      "seeAlso": [
-        "https://github.com/swh/ladspa/blob/7bf6f3799fdba70fda297c2d8fd9f526803d9680/gsm/COPYRIGHT"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/CNRI-Jython.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CNRI-Jython.json",
-      "referenceNumber": 49,
-      "name": "CNRI Jython License",
-      "licenseId": "CNRI-Jython",
-      "seeAlso": [
-        "http://www.jython.org/license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/mplus.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/mplus.json",
-      "referenceNumber": 50,
-      "name": "mplus Font License",
-      "licenseId": "mplus",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing:Mplus?rd\u003dLicensing/mplus"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/CPOL-1.02.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CPOL-1.02.json",
-      "referenceNumber": 51,
-      "name": "Code Project Open License 1.02",
-      "licenseId": "CPOL-1.02",
-      "seeAlso": [
-        "http://www.codeproject.com/info/cpol10.aspx"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License-2014.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License-2014.json",
-      "referenceNumber": 52,
-      "name": "BSD 3-Clause No Nuclear License 2014",
-      "licenseId": "BSD-3-Clause-No-Nuclear-License-2014",
-      "seeAlso": [
-        "https://java.net/projects/javaeetutorial/pages/BerkeleyLicense"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/ISC.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/ISC.json",
-      "referenceNumber": 53,
-      "name": "ISC License",
-      "licenseId": "ISC",
-      "seeAlso": [
-        "https://www.isc.org/licenses/",
-        "https://www.isc.org/downloads/software-support-policy/isc-license/",
-        "https://opensource.org/licenses/ISC"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/CC-BY-SA-4.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-4.0.json",
-      "referenceNumber": 54,
-      "name": "Creative Commons Attribution Share Alike 4.0 International",
-      "licenseId": "CC-BY-SA-4.0",
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-sa/4.0/legalcode"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/Eurosym.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Eurosym.json",
-      "referenceNumber": 55,
-      "name": "Eurosym License",
-      "licenseId": "Eurosym",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Eurosym"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/LGPL-3.0-only.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/LGPL-3.0-only.json",
-      "referenceNumber": 56,
-      "name": "GNU Lesser General Public License v3.0 only",
-      "licenseId": "LGPL-3.0-only",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
-        "https://www.gnu.org/licenses/lgpl+gpl-3.0.txt",
-        "https://opensource.org/licenses/LGPL-3.0"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/OLDAP-1.3.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/OLDAP-1.3.json",
-      "referenceNumber": 57,
-      "name": "Open LDAP Public License v1.3",
-      "licenseId": "OLDAP-1.3",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003de5f8117f0ce088d0bd7a8e18ddf37eaa40eb09b1"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/GFDL-1.1-invariants-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-invariants-or-later.json",
-      "referenceNumber": 58,
-      "name": "GNU Free Documentation License v1.1 or later - invariants",
-      "licenseId": "GFDL-1.1-invariants-or-later",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/Glulxe.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Glulxe.json",
-      "referenceNumber": 59,
-      "name": "Glulxe License",
-      "licenseId": "Glulxe",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Glulxe"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/SimPL-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/SimPL-2.0.json",
-      "referenceNumber": 60,
-      "name": "Simple Public License 2.0",
-      "licenseId": "SimPL-2.0",
-      "seeAlso": [
-        "https://opensource.org/licenses/SimPL-2.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/CDLA-Permissive-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CDLA-Permissive-2.0.json",
-      "referenceNumber": 61,
-      "name": "Community Data License Agreement Permissive 2.0",
-      "licenseId": "CDLA-Permissive-2.0",
-      "seeAlso": [
-        "https://cdla.dev/permissive-2-0"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/GPL-2.0-with-font-exception.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-font-exception.json",
-      "referenceNumber": 62,
-      "name": "GNU General Public License v2.0 w/Font exception",
-      "licenseId": "GPL-2.0-with-font-exception",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/gpl-faq.html#FontException"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/OGL-UK-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/OGL-UK-2.0.json",
-      "referenceNumber": 63,
-      "name": "Open Government Licence v2.0",
-      "licenseId": "OGL-UK-2.0",
-      "seeAlso": [
-        "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/2/"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/CC-BY-SA-3.0-DE.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-3.0-DE.json",
-      "referenceNumber": 64,
-      "name": "Creative Commons Attribution Share Alike 3.0 Germany",
-      "licenseId": "CC-BY-SA-3.0-DE",
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-sa/3.0/de/legalcode"
-      ],
-      "isOsiApproved": false
     },
     {
       "reference": "https://spdx.org/licenses/CC-BY-ND-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-1.0.json",
-      "referenceNumber": 65,
+      "referenceNumber": 10,
       "name": "Creative Commons Attribution No Derivatives 1.0 Generic",
       "licenseId": "CC-BY-ND-1.0",
       "seeAlso": [
@@ -827,36 +141,318 @@
       "isFsfLibre": false
     },
     {
-      "reference": "https://spdx.org/licenses/GFDL-1.1.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "https://spdx.org/licenses/GFDL-1.1.json",
-      "referenceNumber": 66,
-      "name": "GNU Free Documentation License v1.1",
-      "licenseId": "GFDL-1.1",
+      "reference": "https://spdx.org/licenses/CC-BY-ND-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-2.0.json",
+      "referenceNumber": 11,
+      "name": "Creative Commons Attribution No Derivatives 2.0 Generic",
+      "licenseId": "CC-BY-ND-2.0",
       "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
+        "https://creativecommons.org/licenses/by-nd/2.0/legalcode"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Xerox.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Xerox.json",
+      "referenceNumber": 12,
+      "name": "Xerox License",
+      "licenseId": "Xerox",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Xerox"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Arphic-1999.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Arphic-1999.json",
+      "referenceNumber": 13,
+      "name": "Arphic Public License",
+      "licenseId": "Arphic-1999",
+      "seeAlso": [
+        "http://ftp.gnu.org/gnu/non-gnu/chinese-fonts-truetype/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Unicode-TOU.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Unicode-TOU.json",
+      "referenceNumber": 14,
+      "name": "Unicode Terms of Use",
+      "licenseId": "Unicode-TOU",
+      "seeAlso": [
+        "http://www.unicode.org/copyright.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-UK.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-UK.json",
+      "referenceNumber": 15,
+      "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 England and Wales",
+      "licenseId": "CC-BY-NC-SA-2.0-UK",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-sa/2.0/uk/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MIT-advertising.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MIT-advertising.json",
+      "referenceNumber": 16,
+      "name": "Enlightenment License (e16)",
+      "licenseId": "MIT-advertising",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/MIT_With_Advertising"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/YPL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/YPL-1.1.json",
+      "referenceNumber": 17,
+      "name": "Yahoo! Public License v1.1",
+      "licenseId": "YPL-1.1",
+      "seeAlso": [
+        "http://www.zimbra.com/license/yahoo_public_license_1.1.html"
       ],
       "isOsiApproved": false,
       "isFsfLibre": true
     },
     {
-      "reference": "https://spdx.org/licenses/CC-BY-4.0.html",
+      "reference": "https://spdx.org/licenses/copyleft-next-0.3.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-4.0.json",
-      "referenceNumber": 67,
-      "name": "Creative Commons Attribution 4.0 International",
-      "licenseId": "CC-BY-4.0",
+      "detailsUrl": "https://spdx.org/licenses/copyleft-next-0.3.0.json",
+      "referenceNumber": 18,
+      "name": "copyleft-next 0.3.0",
+      "licenseId": "copyleft-next-0.3.0",
       "seeAlso": [
-        "https://creativecommons.org/licenses/by/4.0/legalcode"
+        "https://github.com/copyleft-next/copyleft-next/blob/master/Releases/copyleft-next-0.3.0"
       ],
-      "isOsiApproved": false,
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/EUPL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/EUPL-1.1.json",
+      "referenceNumber": 19,
+      "name": "European Union Public License 1.1",
+      "licenseId": "EUPL-1.1",
+      "seeAlso": [
+        "https://joinup.ec.europa.eu/software/page/eupl/licence-eupl",
+        "https://joinup.ec.europa.eu/sites/default/files/custom-page/attachment/eupl1.1.-licence-en_0.pdf",
+        "https://opensource.org/licenses/EUPL-1.1"
+      ],
+      "isOsiApproved": true,
       "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/AGPL-1.0-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/AGPL-1.0-or-later.json",
+      "referenceNumber": 20,
+      "name": "Affero General Public License v1.0 or later",
+      "licenseId": "AGPL-1.0-or-later",
+      "seeAlso": [
+        "http://www.affero.org/oagpl.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OML.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OML.json",
+      "referenceNumber": 21,
+      "name": "Open Market License",
+      "licenseId": "OML",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Open_Market_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OLDAP-1.3.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-1.3.json",
+      "referenceNumber": 22,
+      "name": "Open LDAP Public License v1.3",
+      "licenseId": "OLDAP-1.3",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003de5f8117f0ce088d0bd7a8e18ddf37eaa40eb09b1"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SHL-0.5.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SHL-0.5.json",
+      "referenceNumber": 23,
+      "name": "Solderpad Hardware License v0.5",
+      "licenseId": "SHL-0.5",
+      "seeAlso": [
+        "https://solderpad.org/licenses/SHL-0.5/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-SA-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-3.0.json",
+      "referenceNumber": 24,
+      "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 Unported",
+      "licenseId": "CC-BY-NC-SA-3.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-sa/3.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.3-invariants-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-invariants-or-later.json",
+      "referenceNumber": 25,
+      "name": "GNU Free Documentation License v1.3 or later - invariants",
+      "licenseId": "GFDL-1.3-invariants-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/fdl-1.3.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-2.5.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-2.5.json",
+      "referenceNumber": 26,
+      "name": "Creative Commons Attribution 2.5 Generic",
+      "licenseId": "CC-BY-2.5",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by/2.5/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/YPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/YPL-1.0.json",
+      "referenceNumber": 27,
+      "name": "Yahoo! Public License v1.0",
+      "licenseId": "YPL-1.0",
+      "seeAlso": [
+        "http://www.zimbra.com/license/yahoo_public_license_1.0.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-3.0-DE.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-3.0-DE.json",
+      "referenceNumber": 28,
+      "name": "Creative Commons Attribution Non Commercial 3.0 Germany",
+      "licenseId": "CC-BY-NC-3.0-DE",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc/3.0/de/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/FreeImage.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/FreeImage.json",
+      "referenceNumber": 29,
+      "name": "FreeImage Public License v1.0",
+      "licenseId": "FreeImage",
+      "seeAlso": [
+        "http://freeimage.sourceforge.net/freeimage-license.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OFL-1.1-no-RFN.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OFL-1.1-no-RFN.json",
+      "referenceNumber": 30,
+      "name": "SIL Open Font License 1.1 with no Reserved Font Name",
+      "licenseId": "OFL-1.1-no-RFN",
+      "seeAlso": [
+        "http://scripts.sil.org/cms/scripts/page.php?item_id\u003dOFL_web",
+        "https://opensource.org/licenses/OFL-1.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/LGPL-2.1-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LGPL-2.1-or-later.json",
+      "referenceNumber": 31,
+      "name": "GNU Lesser General Public License v2.1 or later",
+      "licenseId": "LGPL-2.1-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+        "https://opensource.org/licenses/LGPL-2.1"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Intel-ACPI.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Intel-ACPI.json",
+      "referenceNumber": 32,
+      "name": "Intel ACPI Software License Agreement",
+      "licenseId": "Intel-ACPI",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Intel_ACPI_Software_License_Agreement"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OCCT-PL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OCCT-PL.json",
+      "referenceNumber": 33,
+      "name": "Open CASCADE Technology Public License",
+      "licenseId": "OCCT-PL",
+      "seeAlso": [
+        "http://www.opencascade.com/content/occt-public-license"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.2-no-invariants-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-no-invariants-or-later.json",
+      "referenceNumber": 34,
+      "name": "GNU Free Documentation License v1.2 or later - no invariants",
+      "licenseId": "GFDL-1.2-no-invariants-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GL2PS.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GL2PS.json",
+      "referenceNumber": 35,
+      "name": "GL2PS License",
+      "licenseId": "GL2PS",
+      "seeAlso": [
+        "http://www.geuz.org/gl2ps/COPYING.GL2PS"
+      ],
+      "isOsiApproved": false
     },
     {
       "reference": "https://spdx.org/licenses/OpenSSL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OpenSSL.json",
-      "referenceNumber": 68,
+      "referenceNumber": 36,
       "name": "OpenSSL License",
       "licenseId": "OpenSSL",
       "seeAlso": [
@@ -866,328 +462,238 @@
       "isFsfLibre": true
     },
     {
-      "reference": "https://spdx.org/licenses/TU-Berlin-2.0.html",
+      "reference": "https://spdx.org/licenses/Ruby.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/TU-Berlin-2.0.json",
-      "referenceNumber": 69,
-      "name": "Technische Universitaet Berlin License 2.0",
-      "licenseId": "TU-Berlin-2.0",
+      "detailsUrl": "https://spdx.org/licenses/Ruby.json",
+      "referenceNumber": 37,
+      "name": "Ruby License",
+      "licenseId": "Ruby",
       "seeAlso": [
-        "https://github.com/CorsixTH/deps/blob/fd339a9f526d1d9c9f01ccf39e438a015da50035/licences/libgsm.txt"
+        "http://www.ruby-lang.org/en/LICENSE.txt"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-SA-4.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-4.0.json",
+      "referenceNumber": 38,
+      "name": "Creative Commons Attribution Share Alike 4.0 International",
+      "licenseId": "CC-BY-SA-4.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-sa/4.0/legalcode"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Naumen.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Naumen.json",
+      "referenceNumber": 39,
+      "name": "Naumen Public License",
+      "licenseId": "Naumen",
+      "seeAlso": [
+        "https://opensource.org/licenses/Naumen"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/zlib-acknowledgement.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/zlib-acknowledgement.json",
+      "referenceNumber": 40,
+      "name": "zlib/libpng License with Acknowledgement",
+      "licenseId": "zlib-acknowledgement",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/ZlibWithAcknowledgement"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/DOC.html",
+      "reference": "https://spdx.org/licenses/Adobe-Glyph.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/DOC.json",
-      "referenceNumber": 70,
-      "name": "DOC License",
-      "licenseId": "DOC",
+      "detailsUrl": "https://spdx.org/licenses/Adobe-Glyph.json",
+      "referenceNumber": 41,
+      "name": "Adobe Glyph List License",
+      "licenseId": "Adobe-Glyph",
       "seeAlso": [
-        "http://www.cs.wustl.edu/~schmidt/ACE-copying.html",
-        "https://www.dre.vanderbilt.edu/~schmidt/ACE-copying.html"
+        "https://fedoraproject.org/wiki/Licensing/MIT#AdobeGlyph"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/GFDL-1.2-no-invariants-or-later.html",
+      "reference": "https://spdx.org/licenses/NOSL.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-no-invariants-or-later.json",
-      "referenceNumber": 71,
-      "name": "GNU Free Documentation License v1.2 or later - no invariants",
-      "licenseId": "GFDL-1.2-no-invariants-or-later",
+      "detailsUrl": "https://spdx.org/licenses/NOSL.json",
+      "referenceNumber": 42,
+      "name": "Netizen Open Source License",
+      "licenseId": "NOSL",
       "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
+        "http://bits.netizen.com.au/licenses/NOSL/nosl.txt"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Artistic-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Artistic-1.0.json",
+      "referenceNumber": 43,
+      "name": "Artistic License 1.0",
+      "licenseId": "Artistic-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/Artistic-1.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/dvipdfm.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/dvipdfm.json",
+      "referenceNumber": 44,
+      "name": "dvipdfm License",
+      "licenseId": "dvipdfm",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/dvipdfm"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/QPL-1.0.html",
+      "reference": "https://spdx.org/licenses/Spencer-86.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/QPL-1.0.json",
-      "referenceNumber": 72,
-      "name": "Q Public License 1.0",
-      "licenseId": "QPL-1.0",
+      "detailsUrl": "https://spdx.org/licenses/Spencer-86.json",
+      "referenceNumber": 45,
+      "name": "Spencer License 86",
+      "licenseId": "Spencer-86",
       "seeAlso": [
-        "http://doc.qt.nokia.com/3.3/license.html",
-        "https://opensource.org/licenses/QPL-1.0",
-        "https://doc.qt.io/archives/3.3/license.html"
+        "https://fedoraproject.org/wiki/Licensing/Henry_Spencer_Reg-Ex_Library_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/LPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LPL-1.0.json",
+      "referenceNumber": 46,
+      "name": "Lucent Public License Version 1.0",
+      "licenseId": "LPL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/LPL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-4.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-4.0.json",
+      "referenceNumber": 47,
+      "name": "Creative Commons Attribution 4.0 International",
+      "licenseId": "CC-BY-4.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by/4.0/legalcode"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/BUSL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BUSL-1.1.json",
+      "referenceNumber": 48,
+      "name": "Business Source License 1.1",
+      "licenseId": "BUSL-1.1",
+      "seeAlso": [
+        "https://mariadb.com/bsl11/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CNRI-Python.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CNRI-Python.json",
+      "referenceNumber": 49,
+      "name": "CNRI Python License",
+      "licenseId": "CNRI-Python",
+      "seeAlso": [
+        "https://opensource.org/licenses/CNRI-Python"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Saxpath.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Saxpath.json",
+      "referenceNumber": 50,
+      "name": "Saxpath License",
+      "licenseId": "Saxpath",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Saxpath_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Apache-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Apache-1.0.json",
+      "referenceNumber": 51,
+      "name": "Apache License 1.0",
+      "licenseId": "Apache-1.0",
+      "seeAlso": [
+        "http://www.apache.org/licenses/LICENSE-1.0"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSL-1.0.json",
+      "referenceNumber": 52,
+      "name": "Boost Software License 1.0",
+      "licenseId": "BSL-1.0",
+      "seeAlso": [
+        "http://www.boost.org/LICENSE_1_0.txt",
+        "https://opensource.org/licenses/BSL-1.0"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
     },
     {
-      "reference": "https://spdx.org/licenses/OLDAP-2.8.html",
+      "reference": "https://spdx.org/licenses/LPPL-1.1.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.8.json",
-      "referenceNumber": 73,
-      "name": "Open LDAP Public License v2.8",
-      "licenseId": "OLDAP-2.8",
+      "detailsUrl": "https://spdx.org/licenses/LPPL-1.1.json",
+      "referenceNumber": 53,
+      "name": "LaTeX Project Public License v1.1",
+      "licenseId": "LPPL-1.1",
       "seeAlso": [
-        "http://www.openldap.org/software/release/license.html"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/OML.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/OML.json",
-      "referenceNumber": 74,
-      "name": "Open Market License",
-      "licenseId": "OML",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Open_Market_License"
+        "http://www.latex-project.org/lppl/lppl-1-1.txt"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/OLDAP-2.7.html",
+      "reference": "https://spdx.org/licenses/GFDL-1.1-invariants-or-later.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.7.json",
-      "referenceNumber": 75,
-      "name": "Open LDAP Public License v2.7",
-      "licenseId": "OLDAP-2.7",
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-invariants-or-later.json",
+      "referenceNumber": 54,
+      "name": "GNU Free Documentation License v1.1 or later - invariants",
+      "licenseId": "GFDL-1.1-invariants-or-later",
       "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d47c2415c1df81556eeb39be6cad458ef87c534a2"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/NIST-PD.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/NIST-PD.json",
-      "referenceNumber": 76,
-      "name": "NIST Public Domain Notice",
-      "licenseId": "NIST-PD",
-      "seeAlso": [
-        "https://github.com/tcheneau/simpleRPL/blob/e645e69e38dd4e3ccfeceb2db8cba05b7c2e0cd3/LICENSE.txt",
-        "https://github.com/tcheneau/Routing/blob/f09f46fcfe636107f22f2c98348188a65a135d98/README.md"
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/Bitstream-Vera.html",
+      "reference": "https://spdx.org/licenses/Afmparse.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Bitstream-Vera.json",
-      "referenceNumber": 77,
-      "name": "Bitstream Vera Font License",
-      "licenseId": "Bitstream-Vera",
+      "detailsUrl": "https://spdx.org/licenses/Afmparse.json",
+      "referenceNumber": 55,
+      "name": "Afmparse License",
+      "licenseId": "Afmparse",
       "seeAlso": [
-        "https://web.archive.org/web/20080207013128/http://www.gnome.org/fonts/",
-        "https://docubrain.com/sites/default/files/licenses/bitstream-vera.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/GFDL-1.2-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-or-later.json",
-      "referenceNumber": 78,
-      "name": "GNU Free Documentation License v1.2 or later",
-      "licenseId": "GFDL-1.2-or-later",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/OFL-1.1-RFN.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/OFL-1.1-RFN.json",
-      "referenceNumber": 79,
-      "name": "SIL Open Font License 1.1 with Reserved Font Name",
-      "licenseId": "OFL-1.1-RFN",
-      "seeAlso": [
-        "http://scripts.sil.org/cms/scripts/page.php?item_id\u003dOFL_web",
-        "https://opensource.org/licenses/OFL-1.1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/Bahyph.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Bahyph.json",
-      "referenceNumber": 80,
-      "name": "Bahyph License",
-      "licenseId": "Bahyph",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Bahyph"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/Barr.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Barr.json",
-      "referenceNumber": 81,
-      "name": "Barr License",
-      "licenseId": "Barr",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Barr"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/COIL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/COIL-1.0.json",
-      "referenceNumber": 82,
-      "name": "Copyfree Open Innovation License",
-      "licenseId": "COIL-1.0",
-      "seeAlso": [
-        "https://coil.apotheon.org/plaintext/01.0.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/GFDL-1.3.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "https://spdx.org/licenses/GFDL-1.3.json",
-      "referenceNumber": 83,
-      "name": "GNU Free Documentation License v1.3",
-      "licenseId": "GFDL-1.3",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/fdl-1.3.txt"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/CECILL-B.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CECILL-B.json",
-      "referenceNumber": 84,
-      "name": "CeCILL-B Free Software License Agreement",
-      "licenseId": "CECILL-B",
-      "seeAlso": [
-        "http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.html"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/JPNIC.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/JPNIC.json",
-      "referenceNumber": 85,
-      "name": "Japan Network Information Center License",
-      "licenseId": "JPNIC",
-      "seeAlso": [
-        "https://gitlab.isc.org/isc-projects/bind9/blob/master/COPYRIGHT#L366"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/Zed.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Zed.json",
-      "referenceNumber": 86,
-      "name": "Zed License",
-      "licenseId": "Zed",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Zed"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/ICU.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/ICU.json",
-      "referenceNumber": 87,
-      "name": "ICU License",
-      "licenseId": "ICU",
-      "seeAlso": [
-        "http://source.icu-project.org/repos/icu/icu/trunk/license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/CC-BY-NC-SA-2.5.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-2.5.json",
-      "referenceNumber": 88,
-      "name": "Creative Commons Attribution Non Commercial Share Alike 2.5 Generic",
-      "licenseId": "CC-BY-NC-SA-2.5",
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nc-sa/2.5/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/CC-BY-ND-3.0-DE.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-3.0-DE.json",
-      "referenceNumber": 89,
-      "name": "Creative Commons Attribution No Derivatives 3.0 Germany",
-      "licenseId": "CC-BY-ND-3.0-DE",
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nd/3.0/de/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/bzip2-1.0.5.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "https://spdx.org/licenses/bzip2-1.0.5.json",
-      "referenceNumber": 90,
-      "name": "bzip2 and libbzip2 License v1.0.5",
-      "licenseId": "bzip2-1.0.5",
-      "seeAlso": [
-        "https://sourceware.org/bzip2/1.0.5/bzip2-manual-1.0.5.html",
-        "http://bzip.org/1.0.5/bzip2-manual-1.0.5.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/SPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/SPL-1.0.json",
-      "referenceNumber": 91,
-      "name": "Sun Public License v1.0",
-      "licenseId": "SPL-1.0",
-      "seeAlso": [
-        "https://opensource.org/licenses/SPL-1.0"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/YPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/YPL-1.0.json",
-      "referenceNumber": 92,
-      "name": "Yahoo! Public License v1.0",
-      "licenseId": "YPL-1.0",
-      "seeAlso": [
-        "http://www.zimbra.com/license/yahoo_public_license_1.0.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/OSET-PL-2.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/OSET-PL-2.1.json",
-      "referenceNumber": 93,
-      "name": "OSET Public License version 2.1",
-      "licenseId": "OSET-PL-2.1",
-      "seeAlso": [
-        "http://www.osetfoundation.org/public-license",
-        "https://opensource.org/licenses/OPL-2.1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/Noweb.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Noweb.json",
-      "referenceNumber": 94,
-      "name": "Noweb License",
-      "licenseId": "Noweb",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Noweb"
+        "https://fedoraproject.org/wiki/Licensing/Afmparse"
       ],
       "isOsiApproved": false
     },
@@ -1195,7 +701,7 @@
       "reference": "https://spdx.org/licenses/RPSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/RPSL-1.0.json",
-      "referenceNumber": 95,
+      "referenceNumber": 56,
       "name": "RealNetworks Public Source License v1.0",
       "licenseId": "RPSL-1.0",
       "seeAlso": [
@@ -1206,83 +712,952 @@
       "isFsfLibre": true
     },
     {
-      "reference": "https://spdx.org/licenses/BSD-3-Clause-LBNL.html",
+      "reference": "https://spdx.org/licenses/EPL-2.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-LBNL.json",
-      "referenceNumber": 96,
-      "name": "Lawrence Berkeley National Labs BSD variant license",
-      "licenseId": "BSD-3-Clause-LBNL",
+      "detailsUrl": "https://spdx.org/licenses/EPL-2.0.json",
+      "referenceNumber": 57,
+      "name": "Eclipse Public License 2.0",
+      "licenseId": "EPL-2.0",
       "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/LBNLBSD"
+        "https://www.eclipse.org/legal/epl-2.0",
+        "https://www.opensource.org/licenses/EPL-2.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CDLA-Permissive-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CDLA-Permissive-1.0.json",
+      "referenceNumber": 58,
+      "name": "Community Data License Agreement Permissive 1.0",
+      "licenseId": "CDLA-Permissive-1.0",
+      "seeAlso": [
+        "https://cdla.io/permissive-1-0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/ANTLR-PD.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ANTLR-PD.json",
+      "referenceNumber": 59,
+      "name": "ANTLR Software Rights Notice",
+      "licenseId": "ANTLR-PD",
+      "seeAlso": [
+        "http://www.antlr2.org/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/AFL-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/AFL-2.0.json",
+      "referenceNumber": 60,
+      "name": "Academic Free License v2.0",
+      "licenseId": "AFL-2.0",
+      "seeAlso": [
+        "http://wayback.archive.org/web/20060924134533/http://www.opensource.org/licenses/afl-2.0.txt"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/LiLiQ-P-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LiLiQ-P-1.1.json",
+      "referenceNumber": 61,
+      "name": "Licence Libre du Québec – Permissive version 1.1",
+      "licenseId": "LiLiQ-P-1.1",
+      "seeAlso": [
+        "https://forge.gouv.qc.ca/licence/fr/liliq-v1-1/",
+        "http://opensource.org/licenses/LiLiQ-P-1.1"
       ],
       "isOsiApproved": true
     },
     {
-      "reference": "https://spdx.org/licenses/CDLA-Sharing-1.0.html",
+      "reference": "https://spdx.org/licenses/CECILL-C.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CDLA-Sharing-1.0.json",
-      "referenceNumber": 97,
-      "name": "Community Data License Agreement Sharing 1.0",
-      "licenseId": "CDLA-Sharing-1.0",
+      "detailsUrl": "https://spdx.org/licenses/CECILL-C.json",
+      "referenceNumber": 62,
+      "name": "CeCILL-C Free Software License Agreement",
+      "licenseId": "CECILL-C",
       "seeAlso": [
-        "https://cdla.io/sharing-1-0"
+        "http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.html"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/RPL-1.5.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/RPL-1.5.json",
+      "referenceNumber": 63,
+      "name": "Reciprocal Public License 1.5",
+      "licenseId": "RPL-1.5",
+      "seeAlso": [
+        "https://opensource.org/licenses/RPL-1.5"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/libselinux-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/libselinux-1.0.json",
+      "referenceNumber": 64,
+      "name": "libselinux public domain notice",
+      "licenseId": "libselinux-1.0",
+      "seeAlso": [
+        "https://github.com/SELinuxProject/selinux/blob/master/libselinux/LICENSE"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/CECILL-1.0.html",
+      "reference": "https://spdx.org/licenses/Zimbra-1.4.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CECILL-1.0.json",
-      "referenceNumber": 98,
-      "name": "CeCILL Free Software License Agreement v1.0",
-      "licenseId": "CECILL-1.0",
+      "detailsUrl": "https://spdx.org/licenses/Zimbra-1.4.json",
+      "referenceNumber": 65,
+      "name": "Zimbra Public License v1.4",
+      "licenseId": "Zimbra-1.4",
       "seeAlso": [
-        "http://www.cecill.info/licences/Licence_CeCILL_V1-fr.html"
+        "http://www.zimbra.com/legal/zimbra-public-license-1-4"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/AMPAS.html",
+      "reference": "https://spdx.org/licenses/LGPL-2.1-only.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/AMPAS.json",
-      "referenceNumber": 99,
-      "name": "Academy of Motion Picture Arts and Sciences BSD",
-      "licenseId": "AMPAS",
+      "detailsUrl": "https://spdx.org/licenses/LGPL-2.1-only.json",
+      "referenceNumber": 66,
+      "name": "GNU Lesser General Public License v2.1 only",
+      "licenseId": "LGPL-2.1-only",
       "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/BSD#AMPASBSD"
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+        "https://opensource.org/licenses/LGPL-2.1"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-2-Clause-FreeBSD.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-FreeBSD.json",
+      "referenceNumber": 67,
+      "name": "BSD 2-Clause FreeBSD License",
+      "licenseId": "BSD-2-Clause-FreeBSD",
+      "seeAlso": [
+        "http://www.freebsd.org/copyright/freebsd-license.html"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-PDDC.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-PDDC.json",
+      "referenceNumber": 68,
+      "name": "Creative Commons Public Domain Dedication and Certification",
+      "licenseId": "CC-PDDC",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/publicdomain/"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/APAFML.html",
+      "reference": "https://spdx.org/licenses/OLDAP-2.8.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/APAFML.json",
-      "referenceNumber": 100,
-      "name": "Adobe Postscript AFM License",
-      "licenseId": "APAFML",
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.8.json",
+      "referenceNumber": 69,
+      "name": "Open LDAP Public License v2.8",
+      "licenseId": "OLDAP-2.8",
       "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/AdobePostscriptAFM"
+        "http://www.openldap.org/software/release/license.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/AGPL-3.0.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/AGPL-3.0.json",
+      "referenceNumber": 70,
+      "name": "GNU Affero General Public License v3.0",
+      "licenseId": "AGPL-3.0",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/agpl.txt",
+        "https://opensource.org/licenses/AGPL-3.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/LGPL-3.0.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/LGPL-3.0.json",
+      "referenceNumber": 71,
+      "name": "GNU Lesser General Public License v3.0 only",
+      "licenseId": "LGPL-3.0",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
+        "https://www.gnu.org/licenses/lgpl+gpl-3.0.txt",
+        "https://opensource.org/licenses/LGPL-3.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Leptonica.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Leptonica.json",
+      "referenceNumber": 72,
+      "name": "Leptonica License",
+      "licenseId": "Leptonica",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Leptonica"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/CC-BY-ND-3.0.html",
+      "reference": "https://spdx.org/licenses/Python-2.0.1.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-3.0.json",
-      "referenceNumber": 101,
-      "name": "Creative Commons Attribution No Derivatives 3.0 Unported",
-      "licenseId": "CC-BY-ND-3.0",
+      "detailsUrl": "https://spdx.org/licenses/Python-2.0.1.json",
+      "referenceNumber": 73,
+      "name": "Python License 2.0.1",
+      "licenseId": "Python-2.0.1",
       "seeAlso": [
-        "https://creativecommons.org/licenses/by-nd/3.0/legalcode"
+        "https://www.python.org/download/releases/2.0.1/license/",
+        "https://docs.python.org/3/license.html",
+        "https://github.com/python/cpython/blob/main/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.3.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.3.json",
+      "referenceNumber": 74,
+      "name": "GNU Free Documentation License v1.3",
+      "licenseId": "GFDL-1.3",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/fdl-1.3.txt"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/LPPL-1.3a.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LPPL-1.3a.json",
+      "referenceNumber": 75,
+      "name": "LaTeX Project Public License v1.3a",
+      "licenseId": "LPPL-1.3a",
+      "seeAlso": [
+        "http://www.latex-project.org/lppl/lppl-1-3a.txt"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/SimPL-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SimPL-2.0.json",
+      "referenceNumber": 76,
+      "name": "Simple Public License 2.0",
+      "licenseId": "SimPL-2.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/SimPL-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/W3C-20150513.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/W3C-20150513.json",
+      "referenceNumber": 77,
+      "name": "W3C Software Notice and Document License (2015-05-13)",
+      "licenseId": "W3C-20150513",
+      "seeAlso": [
+        "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-3-Clause-Open-MPI.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Open-MPI.json",
+      "referenceNumber": 78,
+      "name": "BSD 3-Clause Open MPI variant",
+      "licenseId": "BSD-3-Clause-Open-MPI",
+      "seeAlso": [
+        "https://www.open-mpi.org/community/license.php",
+        "http://www.netlib.org/lapack/LICENSE.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-Protection.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-Protection.json",
+      "referenceNumber": 79,
+      "name": "BSD Protection License",
+      "licenseId": "BSD-Protection",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/BSD_Protection_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OGTSL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OGTSL.json",
+      "referenceNumber": 80,
+      "name": "Open Group Test Suite License",
+      "licenseId": "OGTSL",
+      "seeAlso": [
+        "http://www.opengroup.org/testing/downloads/The_Open_Group_TSL.txt",
+        "https://opensource.org/licenses/OGTSL"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/FSFULLR.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/FSFULLR.json",
+      "referenceNumber": 81,
+      "name": "FSF Unlimited License (with License Retention)",
+      "licenseId": "FSFULLR",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/FSF_Unlimited_License#License_Retention_Variant"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/AFL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/AFL-1.1.json",
+      "referenceNumber": 82,
+      "name": "Academic Free License v1.1",
+      "licenseId": "AFL-1.1",
+      "seeAlso": [
+        "http://opensource.linux-mirror.org/licenses/afl-1.1.txt",
+        "http://wayback.archive.org/web/20021004124254/http://www.opensource.org/licenses/academic.php"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License-2014.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License-2014.json",
+      "referenceNumber": 83,
+      "name": "BSD 3-Clause No Nuclear License 2014",
+      "licenseId": "BSD-3-Clause-No-Nuclear-License-2014",
+      "seeAlso": [
+        "https://java.net/projects/javaeetutorial/pages/BerkeleyLicense"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/IPA.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/IPA.json",
+      "referenceNumber": 84,
+      "name": "IPA Font License",
+      "licenseId": "IPA",
+      "seeAlso": [
+        "https://opensource.org/licenses/IPA"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-2.0.json",
+      "referenceNumber": 85,
+      "name": "Creative Commons Attribution Non Commercial 2.0 Generic",
+      "licenseId": "CC-BY-NC-2.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc/2.0/legalcode"
       ],
       "isOsiApproved": false,
       "isFsfLibre": false
     },
     {
+      "reference": "https://spdx.org/licenses/CECILL-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CECILL-2.0.json",
+      "referenceNumber": 86,
+      "name": "CeCILL Free Software License Agreement v2.0",
+      "licenseId": "CECILL-2.0",
+      "seeAlso": [
+        "http://www.cecill.info/licences/Licence_CeCILL_V2-en.html"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/NLOD-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NLOD-1.0.json",
+      "referenceNumber": 87,
+      "name": "Norwegian Licence for Open Government Data (NLOD) 1.0",
+      "licenseId": "NLOD-1.0",
+      "seeAlso": [
+        "http://data.norge.no/nlod/en/1.0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/PSF-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/PSF-2.0.json",
+      "referenceNumber": 88,
+      "name": "Python Software Foundation License 2.0",
+      "licenseId": "PSF-2.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/Python-2.0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-3.0.json",
+      "referenceNumber": 89,
+      "name": "Creative Commons Attribution Non Commercial 3.0 Unported",
+      "licenseId": "CC-BY-NC-3.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc/3.0/legalcode"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Borceux.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Borceux.json",
+      "referenceNumber": 90,
+      "name": "Borceux license",
+      "licenseId": "Borceux",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Borceux"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/TAPR-OHL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/TAPR-OHL-1.0.json",
+      "referenceNumber": 91,
+      "name": "TAPR Open Hardware License v1.0",
+      "licenseId": "TAPR-OHL-1.0",
+      "seeAlso": [
+        "https://www.tapr.org/OHL"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-Warranty.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-Warranty.json",
+      "referenceNumber": 92,
+      "name": "BSD 3-Clause No Nuclear Warranty",
+      "licenseId": "BSD-3-Clause-No-Nuclear-Warranty",
+      "seeAlso": [
+        "https://jogamp.org/git/?p\u003dgluegen.git;a\u003dblob_plain;f\u003dLICENSE.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Parity-6.0.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Parity-6.0.0.json",
+      "referenceNumber": 93,
+      "name": "The Parity Public License 6.0.0",
+      "licenseId": "Parity-6.0.0",
+      "seeAlso": [
+        "https://paritylicense.com/versions/6.0.0.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-1.0.json",
+      "referenceNumber": 94,
+      "name": "Creative Commons Attribution Non Commercial 1.0 Generic",
+      "licenseId": "CC-BY-NC-1.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc/1.0/legalcode"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-3-Clause-Modification.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Modification.json",
+      "referenceNumber": 95,
+      "name": "BSD 3-Clause Modification",
+      "licenseId": "BSD-3-Clause-Modification",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing:BSD#Modification_Variant"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.3-invariants-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-invariants-only.json",
+      "referenceNumber": 96,
+      "name": "GNU Free Documentation License v1.3 only - invariants",
+      "licenseId": "GFDL-1.3-invariants-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/fdl-1.3.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Spencer-94.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Spencer-94.json",
+      "referenceNumber": 97,
+      "name": "Spencer License 94",
+      "licenseId": "Spencer-94",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Henry_Spencer_Reg-Ex_Library_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Unlicense.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Unlicense.json",
+      "referenceNumber": 98,
+      "name": "The Unlicense",
+      "licenseId": "Unlicense",
+      "seeAlso": [
+        "https://unlicense.org/"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/EUPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/EUPL-1.0.json",
+      "referenceNumber": 99,
+      "name": "European Union Public License 1.0",
+      "licenseId": "EUPL-1.0",
+      "seeAlso": [
+        "http://ec.europa.eu/idabc/en/document/7330.html",
+        "http://ec.europa.eu/idabc/servlets/Doc027f.pdf?id\u003d31096"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/DSDP.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/DSDP.json",
+      "referenceNumber": 100,
+      "name": "DSDP License",
+      "licenseId": "DSDP",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/DSDP"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-ND-3.0-IGO.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-3.0-IGO.json",
+      "referenceNumber": 101,
+      "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 IGO",
+      "licenseId": "CC-BY-NC-ND-3.0-IGO",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-nd/3.0/igo/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HTMLTIDY.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HTMLTIDY.json",
+      "referenceNumber": 102,
+      "name": "HTML Tidy License",
+      "licenseId": "HTMLTIDY",
+      "seeAlso": [
+        "https://github.com/htacg/tidy-html5/blob/next/README/LICENSE.md"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/LAL-1.2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LAL-1.2.json",
+      "referenceNumber": 103,
+      "name": "Licence Art Libre 1.2",
+      "licenseId": "LAL-1.2",
+      "seeAlso": [
+        "http://artlibre.org/licence/lal/licence-art-libre-12/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/APSL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/APSL-1.0.json",
+      "referenceNumber": 104,
+      "name": "Apple Public Source License 1.0",
+      "licenseId": "APSL-1.0",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Apple_Public_Source_License_1.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/LPPL-1.2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LPPL-1.2.json",
+      "referenceNumber": 105,
+      "name": "LaTeX Project Public License v1.2",
+      "licenseId": "LPPL-1.2",
+      "seeAlso": [
+        "http://www.latex-project.org/lppl/lppl-1-2.txt"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/OFL-1.0-RFN.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OFL-1.0-RFN.json",
+      "referenceNumber": 106,
+      "name": "SIL Open Font License 1.0 with Reserved Font Name",
+      "licenseId": "OFL-1.0-RFN",
+      "seeAlso": [
+        "http://scripts.sil.org/cms/scripts/page.php?item_id\u003dOFL10_web"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Zed.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Zed.json",
+      "referenceNumber": 107,
+      "name": "Zed License",
+      "licenseId": "Zed",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Zed"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/NGPL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NGPL.json",
+      "referenceNumber": 108,
+      "name": "Nethack General Public License",
+      "licenseId": "NGPL",
+      "seeAlso": [
+        "https://opensource.org/licenses/NGPL"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-SA-2.5.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-2.5.json",
+      "referenceNumber": 109,
+      "name": "Creative Commons Attribution Share Alike 2.5 Generic",
+      "licenseId": "CC-BY-SA-2.5",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-sa/2.5/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/IJG.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/IJG.json",
+      "referenceNumber": 110,
+      "name": "Independent JPEG Group License",
+      "licenseId": "IJG",
+      "seeAlso": [
+        "http://dev.w3.org/cvsweb/Amaya/libjpeg/Attic/README?rev\u003d1.2"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/LPPL-1.3c.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LPPL-1.3c.json",
+      "referenceNumber": 111,
+      "name": "LaTeX Project Public License v1.3c",
+      "licenseId": "LPPL-1.3c",
+      "seeAlso": [
+        "http://www.latex-project.org/lppl/lppl-1-3c.txt",
+        "https://opensource.org/licenses/LPPL-1.3c"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/OLDAP-2.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.1.json",
+      "referenceNumber": 112,
+      "name": "Open LDAP Public License v2.1",
+      "licenseId": "OLDAP-2.1",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003db0d176738e96a0d3b9f85cb51e140a86f21be715"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MIT-CMU.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MIT-CMU.json",
+      "referenceNumber": 113,
+      "name": "CMU License",
+      "licenseId": "MIT-CMU",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing:MIT?rd\u003dLicensing/MIT#CMU_Style",
+        "https://github.com/python-pillow/Pillow/blob/fffb426092c8db24a5f4b6df243a8a3c01fb63cd/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-2.0+.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/GPL-2.0+.json",
+      "referenceNumber": 114,
+      "name": "GNU General Public License v2.0 or later",
+      "licenseId": "GPL-2.0+",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
+        "https://opensource.org/licenses/GPL-2.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CNRI-Jython.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CNRI-Jython.json",
+      "referenceNumber": 115,
+      "name": "CNRI Jython License",
+      "licenseId": "CNRI-Jython",
+      "seeAlso": [
+        "http://www.jython.org/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-3.0-DE.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-DE.json",
+      "referenceNumber": 116,
+      "name": "Creative Commons Attribution 3.0 Germany",
+      "licenseId": "CC-BY-3.0-DE",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by/3.0/de/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.1-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-or-later.json",
+      "referenceNumber": 117,
+      "name": "GNU Free Documentation License v1.1 or later",
+      "licenseId": "GFDL-1.1-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/TCP-wrappers.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/TCP-wrappers.json",
+      "referenceNumber": 118,
+      "name": "TCP Wrappers License",
+      "licenseId": "TCP-wrappers",
+      "seeAlso": [
+        "http://rc.quest.com/topics/openssh/license.php#tcpwrappers"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-ND-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-3.0.json",
+      "referenceNumber": 119,
+      "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 Unported",
+      "licenseId": "CC-BY-NC-ND-3.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-nd/3.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-1.0+.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/GPL-1.0+.json",
+      "referenceNumber": 120,
+      "name": "GNU General Public License v1.0 or later",
+      "licenseId": "GPL-1.0+",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Imlib2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Imlib2.json",
+      "referenceNumber": 121,
+      "name": "Imlib2 License",
+      "licenseId": "Imlib2",
+      "seeAlso": [
+        "http://trac.enlightenment.org/e/browser/trunk/imlib2/COPYING",
+        "https://git.enlightenment.org/legacy/imlib2.git/tree/COPYING"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/App-s2p.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/App-s2p.json",
+      "referenceNumber": 122,
+      "name": "App::s2p License",
+      "licenseId": "App-s2p",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/App-s2p"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OGL-UK-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OGL-UK-2.0.json",
+      "referenceNumber": 123,
+      "name": "Open Government Licence v2.0",
+      "licenseId": "OGL-UK-2.0",
+      "seeAlso": [
+        "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/2/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/NTP.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NTP.json",
+      "referenceNumber": 124,
+      "name": "NTP License",
+      "licenseId": "NTP",
+      "seeAlso": [
+        "https://opensource.org/licenses/NTP"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/OLDAP-2.2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.2.json",
+      "referenceNumber": 125,
+      "name": "Open LDAP Public License v2.2",
+      "licenseId": "OLDAP-2.2",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d470b0c18ec67621c85881b2733057fecf4a1acc3"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OPL-1.0.json",
+      "referenceNumber": 126,
+      "name": "Open Public License v1.0",
+      "licenseId": "OPL-1.0",
+      "seeAlso": [
+        "http://old.koalateam.com/jackaroo/OPL_1_0.TXT",
+        "https://fedoraproject.org/wiki/Licensing/Open_Public_License"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OSET-PL-2.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OSET-PL-2.1.json",
+      "referenceNumber": 127,
+      "name": "OSET Public License version 2.1",
+      "licenseId": "OSET-PL-2.1",
+      "seeAlso": [
+        "http://www.osetfoundation.org/public-license",
+        "https://opensource.org/licenses/OPL-2.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/SISSL-1.2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SISSL-1.2.json",
+      "referenceNumber": 128,
+      "name": "Sun Industry Standards Source License v1.2",
+      "licenseId": "SISSL-1.2",
+      "seeAlso": [
+        "http://gridscheduler.sourceforge.net/Gridengine_SISSL_license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-3.0-with-GCC-exception.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/GPL-3.0-with-GCC-exception.json",
+      "referenceNumber": 129,
+      "name": "GNU General Public License v3.0 w/GCC Runtime Library exception",
+      "licenseId": "GPL-3.0-with-GCC-exception",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/gcc-exception-3.1.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/BitTorrent-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BitTorrent-1.1.json",
+      "referenceNumber": 130,
+      "name": "BitTorrent Open Source License v1.1",
+      "licenseId": "BitTorrent-1.1",
+      "seeAlso": [
+        "http://directory.fsf.org/wiki/License:BitTorrentOSL1.1"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/DRL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/DRL-1.0.json",
+      "referenceNumber": 131,
+      "name": "Detection Rule License 1.0",
+      "licenseId": "DRL-1.0",
+      "seeAlso": [
+        "https://github.com/Neo23x0/sigma/blob/master/LICENSE.Detection.Rules.md"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/D-FSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/D-FSL-1.0.json",
-      "referenceNumber": 102,
+      "referenceNumber": 132,
       "name": "Deutsche Freie Software Lizenz",
       "licenseId": "D-FSL-1.0",
       "seeAlso": [
@@ -1298,77 +1673,88 @@
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/CC-BY-NC-3.0.html",
+      "reference": "https://spdx.org/licenses/BSD-3-Clause.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-3.0.json",
-      "referenceNumber": 103,
-      "name": "Creative Commons Attribution Non Commercial 3.0 Unported",
-      "licenseId": "CC-BY-NC-3.0",
+      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause.json",
+      "referenceNumber": 133,
+      "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+      "licenseId": "BSD-3-Clause",
       "seeAlso": [
-        "https://creativecommons.org/licenses/by-nc/3.0/legalcode"
+        "https://opensource.org/licenses/BSD-3-Clause"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/BitTorrent-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BitTorrent-1.0.json",
+      "referenceNumber": 134,
+      "name": "BitTorrent Open Source License v1.0",
+      "licenseId": "BitTorrent-1.0",
+      "seeAlso": [
+        "http://sources.gentoo.org/cgi-bin/viewvc.cgi/gentoo-x86/licenses/BitTorrent?r1\u003d1.1\u0026r2\u003d1.1.1.1\u0026diff_format\u003ds"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Linux-OpenIB.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Linux-OpenIB.json",
+      "referenceNumber": 135,
+      "name": "Linux Kernel Variant of OpenIB.org license",
+      "licenseId": "Linux-OpenIB",
+      "seeAlso": [
+        "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/infiniband/core/sa.h"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CPOL-1.02.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CPOL-1.02.json",
+      "referenceNumber": 136,
+      "name": "Code Project Open License 1.02",
+      "licenseId": "CPOL-1.02",
+      "seeAlso": [
+        "http://www.codeproject.com/info/cpol10.aspx"
       ],
       "isOsiApproved": false,
       "isFsfLibre": false
     },
     {
-      "reference": "https://spdx.org/licenses/libpng-2.0.html",
+      "reference": "https://spdx.org/licenses/NICTA-1.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/libpng-2.0.json",
-      "referenceNumber": 104,
-      "name": "PNG Reference Library version 2",
-      "licenseId": "libpng-2.0",
+      "detailsUrl": "https://spdx.org/licenses/NICTA-1.0.json",
+      "referenceNumber": 137,
+      "name": "NICTA Public Software License, Version 1.0",
+      "licenseId": "NICTA-1.0",
       "seeAlso": [
-        "http://www.libpng.org/pub/png/src/libpng-LICENSE.txt"
+        "https://opensource.apple.com/source/mDNSResponder/mDNSResponder-320.10/mDNSPosix/nss_ReadMe.txt"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/PolyForm-Noncommercial-1.0.0.html",
+      "reference": "https://spdx.org/licenses/GPL-1.0-or-later.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/PolyForm-Noncommercial-1.0.0.json",
-      "referenceNumber": 105,
-      "name": "PolyForm Noncommercial License 1.0.0",
-      "licenseId": "PolyForm-Noncommercial-1.0.0",
+      "detailsUrl": "https://spdx.org/licenses/GPL-1.0-or-later.json",
+      "referenceNumber": 138,
+      "name": "GNU General Public License v1.0 or later",
+      "licenseId": "GPL-1.0-or-later",
       "seeAlso": [
-        "https://polyformproject.org/licenses/noncommercial/1.0.0"
+        "https://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/dvipdfm.html",
+      "reference": "https://spdx.org/licenses/Xnet.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/dvipdfm.json",
-      "referenceNumber": 106,
-      "name": "dvipdfm License",
-      "licenseId": "dvipdfm",
+      "detailsUrl": "https://spdx.org/licenses/Xnet.json",
+      "referenceNumber": 139,
+      "name": "X.Net License",
+      "licenseId": "Xnet",
       "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/dvipdfm"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/GFDL-1.3-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-or-later.json",
-      "referenceNumber": 107,
-      "name": "GNU Free Documentation License v1.3 or later",
-      "licenseId": "GFDL-1.3-or-later",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/fdl-1.3.txt"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/OGTSL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/OGTSL.json",
-      "referenceNumber": 108,
-      "name": "Open Group Test Suite License",
-      "licenseId": "OGTSL",
-      "seeAlso": [
-        "http://www.opengroup.org/testing/downloads/The_Open_Group_TSL.txt",
-        "https://opensource.org/licenses/OGTSL"
+        "https://opensource.org/licenses/Xnet"
       ],
       "isOsiApproved": true
     },
@@ -1376,7 +1762,7 @@
       "reference": "https://spdx.org/licenses/NPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NPL-1.1.json",
-      "referenceNumber": 109,
+      "referenceNumber": 140,
       "name": "Netscape Public License v1.1",
       "licenseId": "NPL-1.1",
       "seeAlso": [
@@ -1386,1520 +1772,52 @@
       "isFsfLibre": true
     },
     {
-      "reference": "https://spdx.org/licenses/GPL-3.0.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "https://spdx.org/licenses/GPL-3.0.json",
-      "referenceNumber": 110,
-      "name": "GNU General Public License v3.0 only",
-      "licenseId": "GPL-3.0",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
-        "https://opensource.org/licenses/GPL-3.0"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/CERN-OHL-P-2.0.html",
+      "reference": "https://spdx.org/licenses/Parity-7.0.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CERN-OHL-P-2.0.json",
-      "referenceNumber": 111,
-      "name": "CERN Open Hardware Licence Version 2 - Permissive",
-      "licenseId": "CERN-OHL-P-2.0",
-      "seeAlso": [
-        "https://www.ohwr.org/project/cernohl/wikis/Documents/CERN-OHL-version-2"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/BlueOak-1.0.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/BlueOak-1.0.0.json",
-      "referenceNumber": 112,
-      "name": "Blue Oak Model License 1.0.0",
-      "licenseId": "BlueOak-1.0.0",
-      "seeAlso": [
-        "https://blueoakcouncil.org/license/1.0.0"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/AGPL-3.0-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/AGPL-3.0-or-later.json",
-      "referenceNumber": 113,
-      "name": "GNU Affero General Public License v3.0 or later",
-      "licenseId": "AGPL-3.0-or-later",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/agpl.txt",
-        "https://opensource.org/licenses/AGPL-3.0"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/blessing.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/blessing.json",
-      "referenceNumber": 114,
-      "name": "SQLite Blessing",
-      "licenseId": "blessing",
-      "seeAlso": [
-        "https://www.sqlite.org/src/artifact/e33a4df7e32d742a?ln\u003d4-9",
-        "https://sqlite.org/src/artifact/df5091916dbb40e6"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/ImageMagick.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/ImageMagick.json",
-      "referenceNumber": 115,
-      "name": "ImageMagick License",
-      "licenseId": "ImageMagick",
-      "seeAlso": [
-        "http://www.imagemagick.org/script/license.php"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/APSL-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/APSL-2.0.json",
-      "referenceNumber": 116,
-      "name": "Apple Public Source License 2.0",
-      "licenseId": "APSL-2.0",
-      "seeAlso": [
-        "http://www.opensource.apple.com/license/apsl/"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/MIT-advertising.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/MIT-advertising.json",
-      "referenceNumber": 117,
-      "name": "Enlightenment License (e16)",
-      "licenseId": "MIT-advertising",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/MIT_With_Advertising"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/curl.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/curl.json",
-      "referenceNumber": 118,
-      "name": "curl License",
-      "licenseId": "curl",
-      "seeAlso": [
-        "https://github.com/bagder/curl/blob/master/COPYING"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/CC0-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC0-1.0.json",
-      "referenceNumber": 119,
-      "name": "Creative Commons Zero v1.0 Universal",
-      "licenseId": "CC0-1.0",
-      "seeAlso": [
-        "https://creativecommons.org/publicdomain/zero/1.0/legalcode"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/Zimbra-1.4.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Zimbra-1.4.json",
-      "referenceNumber": 120,
-      "name": "Zimbra Public License v1.4",
-      "licenseId": "Zimbra-1.4",
-      "seeAlso": [
-        "http://www.zimbra.com/legal/zimbra-public-license-1-4"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/SSPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/SSPL-1.0.json",
-      "referenceNumber": 121,
-      "name": "Server Side Public License, v 1",
-      "licenseId": "SSPL-1.0",
-      "seeAlso": [
-        "https://www.mongodb.com/licensing/server-side-public-license"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/psutils.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/psutils.json",
-      "referenceNumber": 122,
-      "name": "psutils License",
-      "licenseId": "psutils",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/psutils"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/CC-BY-SA-2.0-UK.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-2.0-UK.json",
-      "referenceNumber": 123,
-      "name": "Creative Commons Attribution Share Alike 2.0 England and Wales",
-      "licenseId": "CC-BY-SA-2.0-UK",
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-sa/2.0/uk/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/PSF-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/PSF-2.0.json",
-      "referenceNumber": 124,
-      "name": "Python Software Foundation License 2.0",
-      "licenseId": "PSF-2.0",
-      "seeAlso": [
-        "https://opensource.org/licenses/Python-2.0"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/Net-SNMP.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Net-SNMP.json",
-      "referenceNumber": 125,
-      "name": "Net-SNMP License",
-      "licenseId": "Net-SNMP",
-      "seeAlso": [
-        "http://net-snmp.sourceforge.net/about/license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/NAIST-2003.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/NAIST-2003.json",
-      "referenceNumber": 126,
-      "name": "Nara Institute of Science and Technology License (2003)",
-      "licenseId": "NAIST-2003",
-      "seeAlso": [
-        "https://enterprise.dejacode.com/licenses/public/naist-2003/#license-text",
-        "https://github.com/nodejs/node/blob/4a19cc8947b1bba2b2d27816ec3d0edf9b28e503/LICENSE#L343"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/GFDL-1.2-invariants-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-invariants-or-later.json",
-      "referenceNumber": 127,
-      "name": "GNU Free Documentation License v1.2 or later - invariants",
-      "licenseId": "GFDL-1.2-invariants-or-later",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/SGI-B-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/SGI-B-1.0.json",
-      "referenceNumber": 128,
-      "name": "SGI Free Software License B v1.0",
-      "licenseId": "SGI-B-1.0",
-      "seeAlso": [
-        "http://oss.sgi.com/projects/FreeB/SGIFreeSWLicB.1.0.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/NBPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/NBPL-1.0.json",
-      "referenceNumber": 129,
-      "name": "Net Boolean Public License v1",
-      "licenseId": "NBPL-1.0",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d37b4b3f6cc4bf34e1d3dec61e69914b9819d8894"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/GFDL-1.2-invariants-only.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-invariants-only.json",
-      "referenceNumber": 130,
-      "name": "GNU Free Documentation License v1.2 only - invariants",
-      "licenseId": "GFDL-1.2-invariants-only",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/W3C-19980720.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/W3C-19980720.json",
-      "referenceNumber": 131,
-      "name": "W3C Software Notice and License (1998-07-20)",
-      "licenseId": "W3C-19980720",
-      "seeAlso": [
-        "http://www.w3.org/Consortium/Legal/copyright-software-19980720.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/OFL-1.0-no-RFN.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/OFL-1.0-no-RFN.json",
-      "referenceNumber": 132,
-      "name": "SIL Open Font License 1.0 with no Reserved Font Name",
-      "licenseId": "OFL-1.0-no-RFN",
-      "seeAlso": [
-        "http://scripts.sil.org/cms/scripts/page.php?item_id\u003dOFL10_web"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/NetCDF.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/NetCDF.json",
-      "referenceNumber": 133,
-      "name": "NetCDF license",
-      "licenseId": "NetCDF",
-      "seeAlso": [
-        "http://www.unidata.ucar.edu/software/netcdf/copyright.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/TMate.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/TMate.json",
-      "referenceNumber": 134,
-      "name": "TMate Open Source License",
-      "licenseId": "TMate",
-      "seeAlso": [
-        "http://svnkit.com/license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/NOSL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/NOSL.json",
-      "referenceNumber": 135,
-      "name": "Netizen Open Source License",
-      "licenseId": "NOSL",
-      "seeAlso": [
-        "http://bits.netizen.com.au/licenses/NOSL/nosl.txt"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/CNRI-Python-GPL-Compatible.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CNRI-Python-GPL-Compatible.json",
-      "referenceNumber": 136,
-      "name": "CNRI Python Open Source GPL Compatible License Agreement",
-      "licenseId": "CNRI-Python-GPL-Compatible",
-      "seeAlso": [
-        "http://www.python.org/download/releases/1.6.1/download_win/"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/BSD-1-Clause.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/BSD-1-Clause.json",
-      "referenceNumber": 137,
-      "name": "BSD 1-Clause License",
-      "licenseId": "BSD-1-Clause",
-      "seeAlso": [
-        "https://svnweb.freebsd.org/base/head/include/ifaddrs.h?revision\u003d326823"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/CC-BY-NC-SA-3.0-DE.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-3.0-DE.json",
-      "referenceNumber": 138,
-      "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 Germany",
-      "licenseId": "CC-BY-NC-SA-3.0-DE",
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nc-sa/3.0/de/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/BSD-3-Clause-Modification.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Modification.json",
-      "referenceNumber": 139,
-      "name": "BSD 3-Clause Modification",
-      "licenseId": "BSD-3-Clause-Modification",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing:BSD#Modification_Variant"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/GLWTPL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/GLWTPL.json",
-      "referenceNumber": 140,
-      "name": "Good Luck With That Public License",
-      "licenseId": "GLWTPL",
-      "seeAlso": [
-        "https://github.com/me-shaon/GLWTPL/commit/da5f6bc734095efbacb442c0b31e33a65b9d6e85"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/GFDL-1.3-only.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-only.json",
+      "detailsUrl": "https://spdx.org/licenses/Parity-7.0.0.json",
       "referenceNumber": 141,
-      "name": "GNU Free Documentation License v1.3 only",
-      "licenseId": "GFDL-1.3-only",
+      "name": "The Parity Public License 7.0.0",
+      "licenseId": "Parity-7.0.0",
       "seeAlso": [
-        "https://www.gnu.org/licenses/fdl-1.3.txt"
+        "https://paritylicense.com/versions/7.0.0.html"
       ],
-      "isOsiApproved": false,
-      "isFsfLibre": true
+      "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/OLDAP-2.2.html",
+      "reference": "https://spdx.org/licenses/XFree86-1.1.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.2.json",
+      "detailsUrl": "https://spdx.org/licenses/XFree86-1.1.json",
       "referenceNumber": 142,
-      "name": "Open LDAP Public License v2.2",
-      "licenseId": "OLDAP-2.2",
+      "name": "XFree86 License 1.1",
+      "licenseId": "XFree86-1.1",
       "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d470b0c18ec67621c85881b2733057fecf4a1acc3"
+        "http://www.xfree86.org/current/LICENSE4.html"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": false,
+      "isFsfLibre": true
     },
     {
-      "reference": "https://spdx.org/licenses/CC-BY-ND-4.0.html",
+      "reference": "https://spdx.org/licenses/Watcom-1.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-4.0.json",
+      "detailsUrl": "https://spdx.org/licenses/Watcom-1.0.json",
       "referenceNumber": 143,
-      "name": "Creative Commons Attribution No Derivatives 4.0 International",
-      "licenseId": "CC-BY-ND-4.0",
+      "name": "Sybase Open Watcom Public License 1.0",
+      "licenseId": "Watcom-1.0",
       "seeAlso": [
-        "https://creativecommons.org/licenses/by-nd/4.0/legalcode"
+        "https://opensource.org/licenses/Watcom-1.0"
       ],
-      "isOsiApproved": false,
+      "isOsiApproved": true,
       "isFsfLibre": false
     },
     {
-      "reference": "https://spdx.org/licenses/CC-BY-NC-ND-3.0-DE.html",
+      "reference": "https://spdx.org/licenses/HaskellReport.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-3.0-DE.json",
+      "detailsUrl": "https://spdx.org/licenses/HaskellReport.json",
       "referenceNumber": 144,
-      "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 Germany",
-      "licenseId": "CC-BY-NC-ND-3.0-DE",
+      "name": "Haskell Language Report License",
+      "licenseId": "HaskellReport",
       "seeAlso": [
-        "https://creativecommons.org/licenses/by-nc-nd/3.0/de/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/EUPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/EUPL-1.0.json",
-      "referenceNumber": 145,
-      "name": "European Union Public License 1.0",
-      "licenseId": "EUPL-1.0",
-      "seeAlso": [
-        "http://ec.europa.eu/idabc/en/document/7330.html",
-        "http://ec.europa.eu/idabc/servlets/Doc027f.pdf?id\u003d31096"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/Linux-OpenIB.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Linux-OpenIB.json",
-      "referenceNumber": 146,
-      "name": "Linux Kernel Variant of OpenIB.org license",
-      "licenseId": "Linux-OpenIB",
-      "seeAlso": [
-        "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/infiniband/core/sa.h"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/LGPL-2.0-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/LGPL-2.0-or-later.json",
-      "referenceNumber": 147,
-      "name": "GNU Library General Public License v2 or later",
-      "licenseId": "LGPL-2.0-or-later",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/OSL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/OSL-1.1.json",
-      "referenceNumber": 148,
-      "name": "Open Software License 1.1",
-      "licenseId": "OSL-1.1",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/OSL1.1"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/Spencer-86.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Spencer-86.json",
-      "referenceNumber": 149,
-      "name": "Spencer License 86",
-      "licenseId": "Spencer-86",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Henry_Spencer_Reg-Ex_Library_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/LGPL-2.0.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "https://spdx.org/licenses/LGPL-2.0.json",
-      "referenceNumber": 150,
-      "name": "GNU Library General Public License v2 only",
-      "licenseId": "LGPL-2.0",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/CC-PDDC.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-PDDC.json",
-      "referenceNumber": 151,
-      "name": "Creative Commons Public Domain Dedication and Certification",
-      "licenseId": "CC-PDDC",
-      "seeAlso": [
-        "https://creativecommons.org/licenses/publicdomain/"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/CC-BY-NC-ND-3.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-3.0.json",
-      "referenceNumber": 152,
-      "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 Unported",
-      "licenseId": "CC-BY-NC-ND-3.0",
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nc-nd/3.0/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/CDL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CDL-1.0.json",
-      "referenceNumber": 153,
-      "name": "Common Documentation License 1.0",
-      "licenseId": "CDL-1.0",
-      "seeAlso": [
-        "http://www.opensource.apple.com/cdl/",
-        "https://fedoraproject.org/wiki/Licensing/Common_Documentation_License",
-        "https://www.gnu.org/licenses/license-list.html#ACDL"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/Elastic-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Elastic-2.0.json",
-      "referenceNumber": 154,
-      "name": "Elastic License 2.0",
-      "licenseId": "Elastic-2.0",
-      "seeAlso": [
-        "https://www.elastic.co/licensing/elastic-license",
-        "https://github.com/elastic/elasticsearch/blob/master/licenses/ELASTIC-LICENSE-2.0.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/CC-BY-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-2.0.json",
-      "referenceNumber": 155,
-      "name": "Creative Commons Attribution 2.0 Generic",
-      "licenseId": "CC-BY-2.0",
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by/2.0/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/BSD-3-Clause-No-Military-License.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-No-Military-License.json",
-      "referenceNumber": 156,
-      "name": "BSD 3-Clause No Military License",
-      "licenseId": "BSD-3-Clause-No-Military-License",
-      "seeAlso": [
-        "https://gitlab.syncad.com/hive/dhive/-/blob/master/LICENSE",
-        "https://github.com/greymass/swift-eosio/blob/master/LICENSE"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/IJG.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/IJG.json",
-      "referenceNumber": 157,
-      "name": "Independent JPEG Group License",
-      "licenseId": "IJG",
-      "seeAlso": [
-        "http://dev.w3.org/cvsweb/Amaya/libjpeg/Attic/README?rev\u003d1.2"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/LPPL-1.3a.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/LPPL-1.3a.json",
-      "referenceNumber": 158,
-      "name": "LaTeX Project Public License v1.3a",
-      "licenseId": "LPPL-1.3a",
-      "seeAlso": [
-        "http://www.latex-project.org/lppl/lppl-1-3a.txt"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/SAX-PD.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/SAX-PD.json",
-      "referenceNumber": 159,
-      "name": "Sax Public Domain Notice",
-      "licenseId": "SAX-PD",
-      "seeAlso": [
-        "http://www.saxproject.org/copying.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/BitTorrent-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/BitTorrent-1.0.json",
-      "referenceNumber": 160,
-      "name": "BitTorrent Open Source License v1.0",
-      "licenseId": "BitTorrent-1.0",
-      "seeAlso": [
-        "http://sources.gentoo.org/cgi-bin/viewvc.cgi/gentoo-x86/licenses/BitTorrent?r1\u003d1.1\u0026r2\u003d1.1.1.1\u0026diff_format\u003ds"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/OLDAP-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.0.json",
-      "referenceNumber": 161,
-      "name": "Open LDAP Public License v2.0 (or possibly 2.0A and 2.0B)",
-      "licenseId": "OLDAP-2.0",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003dcbf50f4e1185a21abd4c0a54d3f4341fe28f36ea"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/Giftware.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Giftware.json",
-      "referenceNumber": 162,
-      "name": "Giftware License",
-      "licenseId": "Giftware",
-      "seeAlso": [
-        "http://liballeg.org/license.html#allegro-4-the-giftware-license"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/C-UDA-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/C-UDA-1.0.json",
-      "referenceNumber": 163,
-      "name": "Computational Use of Data Agreement v1.0",
-      "licenseId": "C-UDA-1.0",
-      "seeAlso": [
-        "https://github.com/microsoft/Computational-Use-of-Data-Agreement/blob/master/C-UDA-1.0.md",
-        "https://cdla.dev/computational-use-of-data-agreement-v1-0/"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/LGPL-2.0+.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "https://spdx.org/licenses/LGPL-2.0+.json",
-      "referenceNumber": 164,
-      "name": "GNU Library General Public License v2 or later",
-      "licenseId": "LGPL-2.0+",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/Rdisc.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Rdisc.json",
-      "referenceNumber": 165,
-      "name": "Rdisc License",
-      "licenseId": "Rdisc",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Rdisc_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/GPL-2.0-with-classpath-exception.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-classpath-exception.json",
-      "referenceNumber": 166,
-      "name": "GNU General Public License v2.0 w/Classpath exception",
-      "licenseId": "GPL-2.0-with-classpath-exception",
-      "seeAlso": [
-        "https://www.gnu.org/software/classpath/license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/CC-BY-3.0-US.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-US.json",
-      "referenceNumber": 167,
-      "name": "Creative Commons Attribution 3.0 United States",
-      "licenseId": "CC-BY-3.0-US",
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by/3.0/us/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/CDDL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CDDL-1.0.json",
-      "referenceNumber": 168,
-      "name": "Common Development and Distribution License 1.0",
-      "licenseId": "CDDL-1.0",
-      "seeAlso": [
-        "https://opensource.org/licenses/cddl1"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/Xnet.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Xnet.json",
-      "referenceNumber": 169,
-      "name": "X.Net License",
-      "licenseId": "Xnet",
-      "seeAlso": [
-        "https://opensource.org/licenses/Xnet"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/CPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CPL-1.0.json",
-      "referenceNumber": 170,
-      "name": "Common Public License 1.0",
-      "licenseId": "CPL-1.0",
-      "seeAlso": [
-        "https://opensource.org/licenses/CPL-1.0"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/LGPL-3.0-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/LGPL-3.0-or-later.json",
-      "referenceNumber": 171,
-      "name": "GNU Lesser General Public License v3.0 or later",
-      "licenseId": "LGPL-3.0-or-later",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
-        "https://www.gnu.org/licenses/lgpl+gpl-3.0.txt",
-        "https://opensource.org/licenses/LGPL-3.0"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/NASA-1.3.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/NASA-1.3.json",
-      "referenceNumber": 172,
-      "name": "NASA Open Source Agreement 1.3",
-      "licenseId": "NASA-1.3",
-      "seeAlso": [
-        "http://ti.arc.nasa.gov/opensource/nosa/",
-        "https://opensource.org/licenses/NASA-1.3"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/BUSL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/BUSL-1.1.json",
-      "referenceNumber": 173,
-      "name": "Business Source License 1.1",
-      "licenseId": "BUSL-1.1",
-      "seeAlso": [
-        "https://mariadb.com/bsl11/"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/etalab-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/etalab-2.0.json",
-      "referenceNumber": 174,
-      "name": "Etalab Open License 2.0",
-      "licenseId": "etalab-2.0",
-      "seeAlso": [
-        "https://github.com/DISIC/politique-de-contribution-open-source/blob/master/LICENSE.pdf",
-        "https://raw.githubusercontent.com/DISIC/politique-de-contribution-open-source/master/LICENSE"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/MIT-open-group.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/MIT-open-group.json",
-      "referenceNumber": 175,
-      "name": "MIT Open Group variant",
-      "licenseId": "MIT-open-group",
-      "seeAlso": [
-        "https://gitlab.freedesktop.org/xorg/app/iceauth/-/blob/master/COPYING",
-        "https://gitlab.freedesktop.org/xorg/app/xvinfo/-/blob/master/COPYING",
-        "https://gitlab.freedesktop.org/xorg/app/xsetroot/-/blob/master/COPYING",
-        "https://gitlab.freedesktop.org/xorg/app/xauth/-/blob/master/COPYING"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/OLDAP-1.4.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/OLDAP-1.4.json",
-      "referenceNumber": 176,
-      "name": "Open LDAP Public License v1.4",
-      "licenseId": "OLDAP-1.4",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003dc9f95c2f3f2ffb5e0ae55fe7388af75547660941"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/GFDL-1.1-invariants-only.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-invariants-only.json",
-      "referenceNumber": 177,
-      "name": "GNU Free Documentation License v1.1 only - invariants",
-      "licenseId": "GFDL-1.1-invariants-only",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/RPL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/RPL-1.1.json",
-      "referenceNumber": 178,
-      "name": "Reciprocal Public License 1.1",
-      "licenseId": "RPL-1.1",
-      "seeAlso": [
-        "https://opensource.org/licenses/RPL-1.1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/CC-BY-NC-ND-2.5.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-2.5.json",
-      "referenceNumber": 179,
-      "name": "Creative Commons Attribution Non Commercial No Derivatives 2.5 Generic",
-      "licenseId": "CC-BY-NC-ND-2.5",
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nc-nd/2.5/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/FSFULLR.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/FSFULLR.json",
-      "referenceNumber": 180,
-      "name": "FSF Unlimited License (with License Retention)",
-      "licenseId": "FSFULLR",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/FSF_Unlimited_License#License_Retention_Variant"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/Saxpath.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Saxpath.json",
-      "referenceNumber": 181,
-      "name": "Saxpath License",
-      "licenseId": "Saxpath",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Saxpath_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/NTP-0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/NTP-0.json",
-      "referenceNumber": 182,
-      "name": "NTP No Attribution",
-      "licenseId": "NTP-0",
-      "seeAlso": [
-        "https://github.com/tytso/e2fsprogs/blob/master/lib/et/et_name.c"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/SISSL-1.2.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/SISSL-1.2.json",
-      "referenceNumber": 183,
-      "name": "Sun Industry Standards Source License v1.2",
-      "licenseId": "SISSL-1.2",
-      "seeAlso": [
-        "http://gridscheduler.sourceforge.net/Gridengine_SISSL_license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/GPL-3.0-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/GPL-3.0-or-later.json",
-      "referenceNumber": 184,
-      "name": "GNU General Public License v3.0 or later",
-      "licenseId": "GPL-3.0-or-later",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
-        "https://opensource.org/licenses/GPL-3.0"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/Apache-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Apache-1.1.json",
-      "referenceNumber": 185,
-      "name": "Apache License 1.1",
-      "licenseId": "Apache-1.1",
-      "seeAlso": [
-        "http://apache.org/licenses/LICENSE-1.1",
-        "https://opensource.org/licenses/Apache-1.1"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/CC-BY-SA-2.1-JP.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-2.1-JP.json",
-      "referenceNumber": 186,
-      "name": "Creative Commons Attribution Share Alike 2.1 Japan",
-      "licenseId": "CC-BY-SA-2.1-JP",
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-sa/2.1/jp/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/AGPL-3.0-only.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/AGPL-3.0-only.json",
-      "referenceNumber": 187,
-      "name": "GNU Affero General Public License v3.0 only",
-      "licenseId": "AGPL-3.0-only",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/agpl.txt",
-        "https://opensource.org/licenses/AGPL-3.0"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/GPL-2.0-with-autoconf-exception.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-autoconf-exception.json",
-      "referenceNumber": 188,
-      "name": "GNU General Public License v2.0 w/Autoconf exception",
-      "licenseId": "GPL-2.0-with-autoconf-exception",
-      "seeAlso": [
-        "http://ac-archive.sourceforge.net/doc/copyright.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/Artistic-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Artistic-2.0.json",
-      "referenceNumber": 189,
-      "name": "Artistic License 2.0",
-      "licenseId": "Artistic-2.0",
-      "seeAlso": [
-        "http://www.perlfoundation.org/artistic_license_2_0",
-        "https://www.perlfoundation.org/artistic-license-20.html",
-        "https://opensource.org/licenses/artistic-license-2.0"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/App-s2p.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/App-s2p.json",
-      "referenceNumber": 190,
-      "name": "App::s2p License",
-      "licenseId": "App-s2p",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/App-s2p"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/Unicode-DFS-2015.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Unicode-DFS-2015.json",
-      "referenceNumber": 191,
-      "name": "Unicode License Agreement - Data Files and Software (2015)",
-      "licenseId": "Unicode-DFS-2015",
-      "seeAlso": [
-        "https://web.archive.org/web/20151224134844/http://unicode.org/copyright.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/diffmark.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/diffmark.json",
-      "referenceNumber": 192,
-      "name": "diffmark license",
-      "licenseId": "diffmark",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/diffmark"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/SNIA.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/SNIA.json",
-      "referenceNumber": 193,
-      "name": "SNIA Public License 1.1",
-      "licenseId": "SNIA",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/SNIA_Public_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/CC-BY-SA-2.5.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-2.5.json",
-      "referenceNumber": 194,
-      "name": "Creative Commons Attribution Share Alike 2.5 Generic",
-      "licenseId": "CC-BY-SA-2.5",
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-sa/2.5/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/Linux-man-pages-copyleft.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Linux-man-pages-copyleft.json",
-      "referenceNumber": 195,
-      "name": "Linux man-pages Copyleft",
-      "licenseId": "Linux-man-pages-copyleft",
-      "seeAlso": [
-        "https://www.kernel.org/doc/man-pages/licenses.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/HPND-sell-variant.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/HPND-sell-variant.json",
-      "referenceNumber": 196,
-      "name": "Historical Permission Notice and Disclaimer - sell variant",
-      "licenseId": "HPND-sell-variant",
-      "seeAlso": [
-        "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/net/sunrpc/auth_gss/gss_generic_token.c?h\u003dv4.19"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/ZPL-2.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/ZPL-2.1.json",
-      "referenceNumber": 197,
-      "name": "Zope Public License 2.1",
-      "licenseId": "ZPL-2.1",
-      "seeAlso": [
-        "http://old.zope.org/Resources/ZPL/"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/BSD-4-Clause-UC.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/BSD-4-Clause-UC.json",
-      "referenceNumber": 198,
-      "name": "BSD-4-Clause (University of California-Specific)",
-      "licenseId": "BSD-4-Clause-UC",
-      "seeAlso": [
-        "http://www.freebsd.org/copyright/license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/LAL-1.2.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/LAL-1.2.json",
-      "referenceNumber": 199,
-      "name": "Licence Art Libre 1.2",
-      "licenseId": "LAL-1.2",
-      "seeAlso": [
-        "http://artlibre.org/licence/lal/licence-art-libre-12/"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/AGPL-1.0-only.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/AGPL-1.0-only.json",
-      "referenceNumber": 200,
-      "name": "Affero General Public License v1.0 only",
-      "licenseId": "AGPL-1.0-only",
-      "seeAlso": [
-        "http://www.affero.org/oagpl.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/MIT-enna.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/MIT-enna.json",
-      "referenceNumber": 201,
-      "name": "enna License",
-      "licenseId": "MIT-enna",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/MIT#enna"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/Condor-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Condor-1.1.json",
-      "referenceNumber": 202,
-      "name": "Condor Public License v1.1",
-      "licenseId": "Condor-1.1",
-      "seeAlso": [
-        "http://research.cs.wisc.edu/condor/license.html#condor",
-        "http://web.archive.org/web/20111123062036/http://research.cs.wisc.edu/condor/license.html#condor"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/Naumen.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Naumen.json",
-      "referenceNumber": 203,
-      "name": "Naumen Public License",
-      "licenseId": "Naumen",
-      "seeAlso": [
-        "https://opensource.org/licenses/Naumen"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/GFDL-1.3-no-invariants-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-no-invariants-or-later.json",
-      "referenceNumber": 204,
-      "name": "GNU Free Documentation License v1.3 or later - no invariants",
-      "licenseId": "GFDL-1.3-no-invariants-or-later",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/fdl-1.3.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/RPL-1.5.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/RPL-1.5.json",
-      "referenceNumber": 205,
-      "name": "Reciprocal Public License 1.5",
-      "licenseId": "RPL-1.5",
-      "seeAlso": [
-        "https://opensource.org/licenses/RPL-1.5"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/PolyForm-Small-Business-1.0.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/PolyForm-Small-Business-1.0.0.json",
-      "referenceNumber": 206,
-      "name": "PolyForm Small Business License 1.0.0",
-      "licenseId": "PolyForm-Small-Business-1.0.0",
-      "seeAlso": [
-        "https://polyformproject.org/licenses/small-business/1.0.0"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/EFL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/EFL-1.0.json",
-      "referenceNumber": 207,
-      "name": "Eiffel Forum License v1.0",
-      "licenseId": "EFL-1.0",
-      "seeAlso": [
-        "http://www.eiffel-nice.org/license/forum.txt",
-        "https://opensource.org/licenses/EFL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/MirOS.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/MirOS.json",
-      "referenceNumber": 208,
-      "name": "The MirOS Licence",
-      "licenseId": "MirOS",
-      "seeAlso": [
-        "https://opensource.org/licenses/MirOS"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/CC-BY-2.5-AU.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-2.5-AU.json",
-      "referenceNumber": 209,
-      "name": "Creative Commons Attribution 2.5 Australia",
-      "licenseId": "CC-BY-2.5-AU",
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by/2.5/au/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/Afmparse.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Afmparse.json",
-      "referenceNumber": 210,
-      "name": "Afmparse License",
-      "licenseId": "Afmparse",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Afmparse"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/MPL-2.0-no-copyleft-exception.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/MPL-2.0-no-copyleft-exception.json",
-      "referenceNumber": 211,
-      "name": "Mozilla Public License 2.0 (no copyleft exception)",
-      "licenseId": "MPL-2.0-no-copyleft-exception",
-      "seeAlso": [
-        "https://www.mozilla.org/MPL/2.0/",
-        "https://opensource.org/licenses/MPL-2.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/LiLiQ-Rplus-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/LiLiQ-Rplus-1.1.json",
-      "referenceNumber": 212,
-      "name": "Licence Libre du Québec – Réciprocité forte version 1.1",
-      "licenseId": "LiLiQ-Rplus-1.1",
-      "seeAlso": [
-        "https://www.forge.gouv.qc.ca/participez/licence-logicielle/licence-libre-du-quebec-liliq-en-francais/licence-libre-du-quebec-reciprocite-forte-liliq-r-v1-1/",
-        "http://opensource.org/licenses/LiLiQ-Rplus-1.1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/AFL-1.2.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/AFL-1.2.json",
-      "referenceNumber": 213,
-      "name": "Academic Free License v1.2",
-      "licenseId": "AFL-1.2",
-      "seeAlso": [
-        "http://opensource.linux-mirror.org/licenses/afl-1.2.txt",
-        "http://wayback.archive.org/web/20021204204652/http://www.opensource.org/licenses/academic.php"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/OSL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/OSL-1.0.json",
-      "referenceNumber": 214,
-      "name": "Open Software License 1.0",
-      "licenseId": "OSL-1.0",
-      "seeAlso": [
-        "https://opensource.org/licenses/OSL-1.0"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/GPL-1.0-only.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/GPL-1.0-only.json",
-      "referenceNumber": 215,
-      "name": "GNU General Public License v1.0 only",
-      "licenseId": "GPL-1.0-only",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/APSL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/APSL-1.0.json",
-      "referenceNumber": 216,
-      "name": "Apple Public Source License 1.0",
-      "licenseId": "APSL-1.0",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Apple_Public_Source_License_1.0"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/OGL-Canada-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/OGL-Canada-2.0.json",
-      "referenceNumber": 217,
-      "name": "Open Government Licence - Canada",
-      "licenseId": "OGL-Canada-2.0",
-      "seeAlso": [
-        "https://open.canada.ca/en/open-government-licence-canada"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/CPAL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CPAL-1.0.json",
-      "referenceNumber": 218,
-      "name": "Common Public Attribution License 1.0",
-      "licenseId": "CPAL-1.0",
-      "seeAlso": [
-        "https://opensource.org/licenses/CPAL-1.0"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/Latex2e.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Latex2e.json",
-      "referenceNumber": 219,
-      "name": "Latex2e License",
-      "licenseId": "Latex2e",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Latex2e"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/Zend-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Zend-2.0.json",
-      "referenceNumber": 220,
-      "name": "Zend License v2.0",
-      "licenseId": "Zend-2.0",
-      "seeAlso": [
-        "https://web.archive.org/web/20130517195954/http://www.zend.com/license/2_00.txt"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/Unlicense.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Unlicense.json",
-      "referenceNumber": 221,
-      "name": "The Unlicense",
-      "licenseId": "Unlicense",
-      "seeAlso": [
-        "https://unlicense.org/"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/xpp.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/xpp.json",
-      "referenceNumber": 222,
-      "name": "XPP License",
-      "licenseId": "xpp",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/xpp"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/CC-BY-NC-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-1.0.json",
-      "referenceNumber": 223,
-      "name": "Creative Commons Attribution Non Commercial 1.0 Generic",
-      "licenseId": "CC-BY-NC-1.0",
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nc/1.0/legalcode"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/GPL-3.0-with-autoconf-exception.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "https://spdx.org/licenses/GPL-3.0-with-autoconf-exception.json",
-      "referenceNumber": 224,
-      "name": "GNU General Public License v3.0 w/Autoconf exception",
-      "licenseId": "GPL-3.0-with-autoconf-exception",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/autoconf-exception-3.0.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/CC-BY-NC-SA-3.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-3.0.json",
-      "referenceNumber": 225,
-      "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 Unported",
-      "licenseId": "CC-BY-NC-SA-3.0",
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nc-sa/3.0/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/TCP-wrappers.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/TCP-wrappers.json",
-      "referenceNumber": 226,
-      "name": "TCP Wrappers License",
-      "licenseId": "TCP-wrappers",
-      "seeAlso": [
-        "http://rc.quest.com/topics/openssh/license.php#tcpwrappers"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/SCEA.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/SCEA.json",
-      "referenceNumber": 227,
-      "name": "SCEA Shared Source License",
-      "licenseId": "SCEA",
-      "seeAlso": [
-        "http://research.scea.com/scea_shared_source_license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/SSH-short.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/SSH-short.json",
-      "referenceNumber": 228,
-      "name": "SSH short notice",
-      "licenseId": "SSH-short",
-      "seeAlso": [
-        "https://github.com/openssh/openssh-portable/blob/1b11ea7c58cd5c59838b5fa574cd456d6047b2d4/pathnames.h",
-        "http://web.mit.edu/kolya/.f/root/athena.mit.edu/sipb.mit.edu/project/openssh/OldFiles/src/openssh-2.9.9p2/ssh-add.1",
-        "https://joinup.ec.europa.eu/svn/lesoll/trunk/italc/lib/src/dsa_key.cpp"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/CC-BY-3.0-NL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-NL.json",
-      "referenceNumber": 229,
-      "name": "Creative Commons Attribution 3.0 Netherlands",
-      "licenseId": "CC-BY-3.0-NL",
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by/3.0/nl/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/SchemeReport.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/SchemeReport.json",
-      "referenceNumber": 230,
-      "name": "Scheme Language Report License",
-      "licenseId": "SchemeReport",
-      "seeAlso": [],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/CC-BY-3.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0.json",
-      "referenceNumber": 231,
-      "name": "Creative Commons Attribution 3.0 Unported",
-      "licenseId": "CC-BY-3.0",
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by/3.0/legalcode"
+        "https://fedoraproject.org/wiki/Licensing/Haskell_Language_Report_License"
       ],
       "isOsiApproved": false
     },
@@ -2907,7 +1825,7 @@
       "reference": "https://spdx.org/licenses/MPL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MPL-2.0.json",
-      "referenceNumber": 232,
+      "referenceNumber": 145,
       "name": "Mozilla Public License 2.0",
       "licenseId": "MPL-2.0",
       "seeAlso": [
@@ -2918,94 +1836,149 @@
       "isFsfLibre": true
     },
     {
-      "reference": "https://spdx.org/licenses/Unicode-TOU.html",
+      "reference": "https://spdx.org/licenses/TCL.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Unicode-TOU.json",
-      "referenceNumber": 233,
-      "name": "Unicode Terms of Use",
-      "licenseId": "Unicode-TOU",
+      "detailsUrl": "https://spdx.org/licenses/TCL.json",
+      "referenceNumber": 146,
+      "name": "TCL/TK License",
+      "licenseId": "TCL",
       "seeAlso": [
-        "http://www.unicode.org/copyright.html"
+        "http://www.tcl.tk/software/tcltk/license.html",
+        "https://fedoraproject.org/wiki/Licensing/TCL"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/CC-BY-NC-ND-1.0.html",
+      "reference": "https://spdx.org/licenses/CC-BY-2.5-AU.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-1.0.json",
-      "referenceNumber": 234,
-      "name": "Creative Commons Attribution Non Commercial No Derivatives 1.0 Generic",
-      "licenseId": "CC-BY-NC-ND-1.0",
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-2.5-AU.json",
+      "referenceNumber": 147,
+      "name": "Creative Commons Attribution 2.5 Australia",
+      "licenseId": "CC-BY-2.5-AU",
       "seeAlso": [
-        "https://creativecommons.org/licenses/by-nd-nc/1.0/legalcode"
+        "https://creativecommons.org/licenses/by/2.5/au/legalcode"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/Entessa.html",
+      "reference": "https://spdx.org/licenses/LZMA-SDK-9.22.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Entessa.json",
-      "referenceNumber": 235,
-      "name": "Entessa Public License v1.0",
-      "licenseId": "Entessa",
+      "detailsUrl": "https://spdx.org/licenses/LZMA-SDK-9.22.json",
+      "referenceNumber": 148,
+      "name": "LZMA SDK License (versions 9.22 and beyond)",
+      "licenseId": "LZMA-SDK-9.22",
       "seeAlso": [
-        "https://opensource.org/licenses/Entessa"
+        "https://www.7-zip.org/sdk.html",
+        "https://sourceforge.net/projects/sevenzip/files/LZMA%20SDK/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/curl.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/curl.json",
+      "referenceNumber": 149,
+      "name": "curl License",
+      "licenseId": "curl",
+      "seeAlso": [
+        "https://github.com/bagder/curl/blob/master/COPYING"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/mpi-permissive.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/mpi-permissive.json",
+      "referenceNumber": 150,
+      "name": "mpi Permissive License",
+      "licenseId": "mpi-permissive",
+      "seeAlso": [
+        "https://sources.debian.org/src/openmpi/4.1.0-10/ompi/debuggers/msgq_interface.h/?hl\u003d19#L19"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-SA-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-1.0.json",
+      "referenceNumber": 151,
+      "name": "Creative Commons Attribution Non Commercial Share Alike 1.0 Generic",
+      "licenseId": "CC-BY-NC-SA-1.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-sa/1.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OFL-1.1-RFN.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OFL-1.1-RFN.json",
+      "referenceNumber": 152,
+      "name": "SIL Open Font License 1.1 with Reserved Font Name",
+      "licenseId": "OFL-1.1-RFN",
+      "seeAlso": [
+        "http://scripts.sil.org/cms/scripts/page.php?item_id\u003dOFL_web",
+        "https://opensource.org/licenses/OFL-1.1"
       ],
       "isOsiApproved": true
     },
     {
-      "reference": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License.html",
+      "reference": "https://spdx.org/licenses/GD.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License.json",
-      "referenceNumber": 236,
-      "name": "BSD 3-Clause No Nuclear License",
-      "licenseId": "BSD-3-Clause-No-Nuclear-License",
+      "detailsUrl": "https://spdx.org/licenses/GD.json",
+      "referenceNumber": 153,
+      "name": "GD License",
+      "licenseId": "GD",
       "seeAlso": [
-        "http://download.oracle.com/otn-pub/java/licenses/bsd.txt?AuthParam\u003d1467140197_43d516ce1776bd08a58235a7785be1cc"
+        "https://libgd.github.io/manuals/2.3.0/files/license-txt.html"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/SWL.html",
+      "reference": "https://spdx.org/licenses/ODbL-1.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/SWL.json",
-      "referenceNumber": 237,
-      "name": "Scheme Widget Library (SWL) Software License Agreement",
-      "licenseId": "SWL",
+      "detailsUrl": "https://spdx.org/licenses/ODbL-1.0.json",
+      "referenceNumber": 154,
+      "name": "Open Data Commons Open Database License v1.0",
+      "licenseId": "ODbL-1.0",
       "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/SWL"
+        "http://www.opendatacommons.org/licenses/odbl/1.0/",
+        "https://opendatacommons.org/licenses/odbl/1-0/"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": false,
+      "isFsfLibre": true
     },
     {
-      "reference": "https://spdx.org/licenses/GFDL-1.2-no-invariants-only.html",
+      "reference": "https://spdx.org/licenses/Apache-2.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-no-invariants-only.json",
-      "referenceNumber": 238,
-      "name": "GNU Free Documentation License v1.2 only - no invariants",
-      "licenseId": "GFDL-1.2-no-invariants-only",
+      "detailsUrl": "https://spdx.org/licenses/Apache-2.0.json",
+      "referenceNumber": 155,
+      "name": "Apache License 2.0",
+      "licenseId": "Apache-2.0",
       "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
+        "https://www.apache.org/licenses/LICENSE-2.0",
+        "https://opensource.org/licenses/Apache-2.0"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": true,
+      "isFsfLibre": true
     },
     {
-      "reference": "https://spdx.org/licenses/Parity-7.0.0.html",
+      "reference": "https://spdx.org/licenses/CUA-OPL-1.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Parity-7.0.0.json",
-      "referenceNumber": 239,
-      "name": "The Parity Public License 7.0.0",
-      "licenseId": "Parity-7.0.0",
+      "detailsUrl": "https://spdx.org/licenses/CUA-OPL-1.0.json",
+      "referenceNumber": 156,
+      "name": "CUA Office Public License v1.0",
+      "licenseId": "CUA-OPL-1.0",
       "seeAlso": [
-        "https://paritylicense.com/versions/7.0.0.html"
+        "https://opensource.org/licenses/CUA-OPL-1.0"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": true
     },
     {
       "reference": "https://spdx.org/licenses/OLDAP-2.2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.2.1.json",
-      "referenceNumber": 240,
+      "referenceNumber": 157,
       "name": "Open LDAP Public License v2.2.1",
       "licenseId": "OLDAP-2.2.1",
       "seeAlso": [
@@ -3014,14 +1987,393 @@
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/SGI-B-1.1.html",
+      "reference": "https://spdx.org/licenses/FDK-AAC.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/SGI-B-1.1.json",
-      "referenceNumber": 241,
-      "name": "SGI Free Software License B v1.1",
-      "licenseId": "SGI-B-1.1",
+      "detailsUrl": "https://spdx.org/licenses/FDK-AAC.json",
+      "referenceNumber": 158,
+      "name": "Fraunhofer FDK AAC Codec Library",
+      "licenseId": "FDK-AAC",
       "seeAlso": [
-        "http://oss.sgi.com/projects/FreeB/"
+        "https://fedoraproject.org/wiki/Licensing/FDK-AAC",
+        "https://directory.fsf.org/wiki/License:Fdk"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/ImageMagick.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ImageMagick.json",
+      "referenceNumber": 159,
+      "name": "ImageMagick License",
+      "licenseId": "ImageMagick",
+      "seeAlso": [
+        "http://www.imagemagick.org/script/license.php"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CPAL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CPAL-1.0.json",
+      "referenceNumber": 160,
+      "name": "Common Public Attribution License 1.0",
+      "licenseId": "CPAL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/CPAL-1.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.2-no-invariants-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-no-invariants-only.json",
+      "referenceNumber": 161,
+      "name": "GNU Free Documentation License v1.2 only - no invariants",
+      "licenseId": "GFDL-1.2-no-invariants-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/O-UDA-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/O-UDA-1.0.json",
+      "referenceNumber": 162,
+      "name": "Open Use of Data Agreement v1.0",
+      "licenseId": "O-UDA-1.0",
+      "seeAlso": [
+        "https://github.com/microsoft/Open-Use-of-Data-Agreement/blob/v1.0/O-UDA-1.0.md",
+        "https://cdla.dev/open-use-of-data-agreement-v1-0/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/LGPL-2.0-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LGPL-2.0-or-later.json",
+      "referenceNumber": 163,
+      "name": "GNU Library General Public License v2 or later",
+      "licenseId": "LGPL-2.0-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CDLA-Permissive-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CDLA-Permissive-2.0.json",
+      "referenceNumber": 164,
+      "name": "Community Data License Agreement Permissive 2.0",
+      "licenseId": "CDLA-Permissive-2.0",
+      "seeAlso": [
+        "https://cdla.dev/permissive-2-0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Community-Spec-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Community-Spec-1.0.json",
+      "referenceNumber": 165,
+      "name": "Community Specification License 1.0",
+      "licenseId": "Community-Spec-1.0",
+      "seeAlso": [
+        "https://github.com/CommunitySpecification/1.0/blob/master/1._Community_Specification_License-v1.md"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CECILL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CECILL-1.1.json",
+      "referenceNumber": 166,
+      "name": "CeCILL Free Software License Agreement v1.1",
+      "licenseId": "CECILL-1.1",
+      "seeAlso": [
+        "http://www.cecill.info/licences/Licence_CeCILL_V1.1-US.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/ICU.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ICU.json",
+      "referenceNumber": 167,
+      "name": "ICU License",
+      "licenseId": "ICU",
+      "seeAlso": [
+        "http://source.icu-project.org/repos/icu/icu/trunk/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/bzip2-1.0.5.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/bzip2-1.0.5.json",
+      "referenceNumber": 168,
+      "name": "bzip2 and libbzip2 License v1.0.5",
+      "licenseId": "bzip2-1.0.5",
+      "seeAlso": [
+        "https://sourceware.org/bzip2/1.0.5/bzip2-manual-1.0.5.html",
+        "http://bzip.org/1.0.5/bzip2-manual-1.0.5.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Net-SNMP.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Net-SNMP.json",
+      "referenceNumber": 169,
+      "name": "Net-SNMP License",
+      "licenseId": "Net-SNMP",
+      "seeAlso": [
+        "http://net-snmp.sourceforge.net/about/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CrystalStacker.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CrystalStacker.json",
+      "referenceNumber": 170,
+      "name": "CrystalStacker License",
+      "licenseId": "CrystalStacker",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing:CrystalStacker?rd\u003dLicensing/CrystalStacker"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-4-Clause.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-4-Clause.json",
+      "referenceNumber": 171,
+      "name": "BSD 4-Clause \"Original\" or \"Old\" License",
+      "licenseId": "BSD-4-Clause",
+      "seeAlso": [
+        "http://directory.fsf.org/wiki/License:BSD_4Clause"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/OFL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OFL-1.1.json",
+      "referenceNumber": 172,
+      "name": "SIL Open Font License 1.1",
+      "licenseId": "OFL-1.1",
+      "seeAlso": [
+        "http://scripts.sil.org/cms/scripts/page.php?item_id\u003dOFL_web",
+        "https://opensource.org/licenses/OFL-1.1"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CERN-OHL-S-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CERN-OHL-S-2.0.json",
+      "referenceNumber": 173,
+      "name": "CERN Open Hardware Licence Version 2 - Strongly Reciprocal",
+      "licenseId": "CERN-OHL-S-2.0",
+      "seeAlso": [
+        "https://www.ohwr.org/project/cernohl/wikis/Documents/CERN-OHL-version-2"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/LiLiQ-R-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LiLiQ-R-1.1.json",
+      "referenceNumber": 174,
+      "name": "Licence Libre du Québec – Réciprocité version 1.1",
+      "licenseId": "LiLiQ-R-1.1",
+      "seeAlso": [
+        "https://www.forge.gouv.qc.ca/participez/licence-logicielle/licence-libre-du-quebec-liliq-en-francais/licence-libre-du-quebec-reciprocite-liliq-r-v1-1/",
+        "http://opensource.org/licenses/LiLiQ-R-1.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Beerware.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Beerware.json",
+      "referenceNumber": 175,
+      "name": "Beerware License",
+      "licenseId": "Beerware",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Beerware",
+        "https://people.freebsd.org/~phk/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Fair.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Fair.json",
+      "referenceNumber": 176,
+      "name": "Fair License",
+      "licenseId": "Fair",
+      "seeAlso": [
+        "http://fairlicense.org/",
+        "https://opensource.org/licenses/Fair"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-2-Clause-Views.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-Views.json",
+      "referenceNumber": 177,
+      "name": "BSD 2-Clause with views sentence",
+      "licenseId": "BSD-2-Clause-Views",
+      "seeAlso": [
+        "http://www.freebsd.org/copyright/freebsd-license.html",
+        "https://people.freebsd.org/~ivoras/wine/patch-wine-nvidia.sh",
+        "https://github.com/protegeproject/protege/blob/master/license.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/ClArtistic.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ClArtistic.json",
+      "referenceNumber": 178,
+      "name": "Clarified Artistic License",
+      "licenseId": "ClArtistic",
+      "seeAlso": [
+        "http://gianluca.dellavedova.org/2011/01/03/clarified-artistic-license/",
+        "http://www.ncftp.com/ncftp/doc/LICENSE.txt"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-3-Clause-LBNL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-LBNL.json",
+      "referenceNumber": 179,
+      "name": "Lawrence Berkeley National Labs BSD variant license",
+      "licenseId": "BSD-3-Clause-LBNL",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/LBNLBSD"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/StandardML-NJ.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/StandardML-NJ.json",
+      "referenceNumber": 180,
+      "name": "Standard ML of New Jersey License",
+      "licenseId": "StandardML-NJ",
+      "seeAlso": [
+        "http://www.smlnj.org//license.html"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/MirOS.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MirOS.json",
+      "referenceNumber": 181,
+      "name": "The MirOS Licence",
+      "licenseId": "MirOS",
+      "seeAlso": [
+        "https://opensource.org/licenses/MirOS"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-2.0-with-GCC-exception.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-GCC-exception.json",
+      "referenceNumber": 182,
+      "name": "GNU General Public License v2.0 w/GCC Runtime Library exception",
+      "licenseId": "GPL-2.0-with-GCC-exception",
+      "seeAlso": [
+        "https://gcc.gnu.org/git/?p\u003dgcc.git;a\u003dblob;f\u003dgcc/libgcc1.c;h\u003d762f5143fc6eed57b6797c82710f3538aa52b40b;hb\u003dcb143a3ce4fb417c68f5fa2691a1b1b1053dfba9#l10"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/mplus.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/mplus.json",
+      "referenceNumber": 183,
+      "name": "mplus Font License",
+      "licenseId": "mplus",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing:Mplus?rd\u003dLicensing/mplus"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/ISC.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ISC.json",
+      "referenceNumber": 184,
+      "name": "ISC License",
+      "licenseId": "ISC",
+      "seeAlso": [
+        "https://www.isc.org/licenses/",
+        "https://www.isc.org/downloads/software-support-policy/isc-license/",
+        "https://opensource.org/licenses/ISC"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Minpack.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Minpack.json",
+      "referenceNumber": 185,
+      "name": "Minpack License",
+      "licenseId": "Minpack",
+      "seeAlso": [
+        "http://www.netlib.org/minpack/disclaimer",
+        "https://gitlab.com/libeigen/eigen/-/blob/master/COPYING.MINPACK"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.2-invariants-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-invariants-or-later.json",
+      "referenceNumber": 186,
+      "name": "GNU Free Documentation License v1.2 or later - invariants",
+      "licenseId": "GFDL-1.2-invariants-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SSPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SSPL-1.0.json",
+      "referenceNumber": 187,
+      "name": "Server Side Public License, v 1",
+      "licenseId": "SSPL-1.0",
+      "seeAlso": [
+        "https://www.mongodb.com/licensing/server-side-public-license"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OGC-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OGC-1.0.json",
+      "referenceNumber": 188,
+      "name": "OGC Software License, Version 1.0",
+      "licenseId": "OGC-1.0",
+      "seeAlso": [
+        "https://www.ogc.org/ogc/software/1.0"
       ],
       "isOsiApproved": false
     },
@@ -3029,7 +2381,7 @@
       "reference": "https://spdx.org/licenses/FTL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FTL.json",
-      "referenceNumber": 242,
+      "referenceNumber": 189,
       "name": "Freetype Project License",
       "licenseId": "FTL",
       "seeAlso": [
@@ -3041,109 +2393,74 @@
       "isFsfLibre": true
     },
     {
-      "reference": "https://spdx.org/licenses/OLDAP-2.4.html",
+      "reference": "https://spdx.org/licenses/BSD-Source-Code.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.4.json",
-      "referenceNumber": 243,
-      "name": "Open LDAP Public License v2.4",
-      "licenseId": "OLDAP-2.4",
+      "detailsUrl": "https://spdx.org/licenses/BSD-Source-Code.json",
+      "referenceNumber": 190,
+      "name": "BSD Source Code Attribution",
+      "licenseId": "BSD-Source-Code",
       "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003dcd1284c4a91a8a380d904eee68d1583f989ed386"
+        "https://github.com/robbiehanson/CocoaHTTPServer/blob/master/LICENSE.txt"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/CC-BY-NC-4.0.html",
+      "reference": "https://spdx.org/licenses/VOSTROM.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-4.0.json",
-      "referenceNumber": 244,
-      "name": "Creative Commons Attribution Non Commercial 4.0 International",
-      "licenseId": "CC-BY-NC-4.0",
+      "detailsUrl": "https://spdx.org/licenses/VOSTROM.json",
+      "referenceNumber": 191,
+      "name": "VOSTROM Public License for Open Source",
+      "licenseId": "VOSTROM",
       "seeAlso": [
-        "https://creativecommons.org/licenses/by-nc/4.0/legalcode"
+        "https://fedoraproject.org/wiki/Licensing/VOSTROM"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OSL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OSL-1.1.json",
+      "referenceNumber": 192,
+      "name": "Open Software License 1.1",
+      "licenseId": "OSL-1.1",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/OSL1.1"
       ],
       "isOsiApproved": false,
-      "isFsfLibre": false
+      "isFsfLibre": true
     },
     {
-      "reference": "https://spdx.org/licenses/bzip2-1.0.6.html",
+      "reference": "https://spdx.org/licenses/AFL-3.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/bzip2-1.0.6.json",
-      "referenceNumber": 245,
-      "name": "bzip2 and libbzip2 License v1.0.6",
-      "licenseId": "bzip2-1.0.6",
+      "detailsUrl": "https://spdx.org/licenses/AFL-3.0.json",
+      "referenceNumber": 193,
+      "name": "Academic Free License v3.0",
+      "licenseId": "AFL-3.0",
       "seeAlso": [
-        "https://sourceware.org/git/?p\u003dbzip2.git;a\u003dblob;f\u003dLICENSE;hb\u003dbzip2-1.0.6",
-        "http://bzip.org/1.0.5/bzip2-manual-1.0.5.html"
+        "http://www.rosenlaw.com/AFL3.0.htm",
+        "https://opensource.org/licenses/afl-3.0"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": true,
+      "isFsfLibre": true
     },
     {
-      "reference": "https://spdx.org/licenses/copyleft-next-0.3.0.html",
+      "reference": "https://spdx.org/licenses/ECL-2.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/copyleft-next-0.3.0.json",
-      "referenceNumber": 246,
-      "name": "copyleft-next 0.3.0",
-      "licenseId": "copyleft-next-0.3.0",
+      "detailsUrl": "https://spdx.org/licenses/ECL-2.0.json",
+      "referenceNumber": 194,
+      "name": "Educational Community License v2.0",
+      "licenseId": "ECL-2.0",
       "seeAlso": [
-        "https://github.com/copyleft-next/copyleft-next/blob/master/Releases/copyleft-next-0.3.0"
+        "https://opensource.org/licenses/ECL-2.0"
       ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/MakeIndex.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/MakeIndex.json",
-      "referenceNumber": 247,
-      "name": "MakeIndex License",
-      "licenseId": "MakeIndex",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/MakeIndex"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/NRL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/NRL.json",
-      "referenceNumber": 248,
-      "name": "NRL License",
-      "licenseId": "NRL",
-      "seeAlso": [
-        "http://web.mit.edu/network/isakmp/nrllicense.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/GFDL-1.3-invariants-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-invariants-or-later.json",
-      "referenceNumber": 249,
-      "name": "GNU Free Documentation License v1.3 or later - invariants",
-      "licenseId": "GFDL-1.3-invariants-or-later",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/fdl-1.3.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/CC-BY-NC-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-2.0.json",
-      "referenceNumber": 250,
-      "name": "Creative Commons Attribution Non Commercial 2.0 Generic",
-      "licenseId": "CC-BY-NC-2.0",
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nc/2.0/legalcode"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": false
+      "isOsiApproved": true,
+      "isFsfLibre": true
     },
     {
       "reference": "https://spdx.org/licenses/SugarCRM-1.1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SugarCRM-1.1.3.json",
-      "referenceNumber": 251,
+      "referenceNumber": 195,
       "name": "SugarCRM Public License v1.1.3",
       "licenseId": "SugarCRM-1.1.3",
       "seeAlso": [
@@ -3152,514 +2469,220 @@
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/AFL-2.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/AFL-2.1.json",
-      "referenceNumber": 252,
-      "name": "Academic Free License v2.1",
-      "licenseId": "AFL-2.1",
-      "seeAlso": [
-        "http://opensource.linux-mirror.org/licenses/afl-2.1.txt"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/GPL-2.0-only.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/GPL-2.0-only.json",
-      "referenceNumber": 253,
-      "name": "GNU General Public License v2.0 only",
-      "licenseId": "GPL-2.0-only",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
-        "https://opensource.org/licenses/GPL-2.0"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/GFDL-1.3-invariants-only.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-invariants-only.json",
-      "referenceNumber": 254,
-      "name": "GNU Free Documentation License v1.3 only - invariants",
-      "licenseId": "GFDL-1.3-invariants-only",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/fdl-1.3.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/TORQUE-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/TORQUE-1.1.json",
-      "referenceNumber": 255,
-      "name": "TORQUE v2.5+ Software License v1.1",
-      "licenseId": "TORQUE-1.1",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/TORQUEv1.1"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/Ruby.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Ruby.json",
-      "referenceNumber": 256,
-      "name": "Ruby License",
-      "licenseId": "Ruby",
-      "seeAlso": [
-        "http://www.ruby-lang.org/en/LICENSE.txt"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/X11.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/X11.json",
-      "referenceNumber": 257,
-      "name": "X11 License",
-      "licenseId": "X11",
-      "seeAlso": [
-        "http://www.xfree86.org/3.3.6/COPYRIGHT2.html#3"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/Borceux.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Borceux.json",
-      "referenceNumber": 258,
-      "name": "Borceux license",
-      "licenseId": "Borceux",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Borceux"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/Libpng.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Libpng.json",
-      "referenceNumber": 259,
-      "name": "libpng License",
-      "licenseId": "Libpng",
-      "seeAlso": [
-        "http://www.libpng.org/pub/png/src/libpng-LICENSE.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/X11-distribute-modifications-variant.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/X11-distribute-modifications-variant.json",
-      "referenceNumber": 260,
-      "name": "X11 License Distribution Modification Variant",
-      "licenseId": "X11-distribute-modifications-variant",
-      "seeAlso": [
-        "https://github.com/mirror/ncurses/blob/master/COPYING"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/Frameworx-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Frameworx-1.0.json",
-      "referenceNumber": 261,
-      "name": "Frameworx Open License 1.0",
-      "licenseId": "Frameworx-1.0",
-      "seeAlso": [
-        "https://opensource.org/licenses/Frameworx-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/NCGL-UK-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/NCGL-UK-2.0.json",
-      "referenceNumber": 262,
-      "name": "Non-Commercial Government Licence",
-      "licenseId": "NCGL-UK-2.0",
-      "seeAlso": [
-        "http://www.nationalarchives.gov.uk/doc/non-commercial-government-licence/version/2/"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/CECILL-2.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CECILL-2.1.json",
-      "referenceNumber": 263,
-      "name": "CeCILL Free Software License Agreement v2.1",
-      "licenseId": "CECILL-2.1",
-      "seeAlso": [
-        "http://www.cecill.info/licences/Licence_CeCILL_V2.1-en.html"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/CC-BY-3.0-AT.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-AT.json",
-      "referenceNumber": 264,
-      "name": "Creative Commons Attribution 3.0 Austria",
-      "licenseId": "CC-BY-3.0-AT",
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by/3.0/at/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/CNRI-Python.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CNRI-Python.json",
-      "referenceNumber": 265,
-      "name": "CNRI Python License",
-      "licenseId": "CNRI-Python",
-      "seeAlso": [
-        "https://opensource.org/licenses/CNRI-Python"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/NCSA.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/NCSA.json",
-      "referenceNumber": 266,
-      "name": "University of Illinois/NCSA Open Source License",
-      "licenseId": "NCSA",
-      "seeAlso": [
-        "http://otm.illinois.edu/uiuc_openSource",
-        "https://opensource.org/licenses/NCSA"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/gSOAP-1.3b.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/gSOAP-1.3b.json",
-      "referenceNumber": 267,
-      "name": "gSOAP Public License v1.3b",
-      "licenseId": "gSOAP-1.3b",
-      "seeAlso": [
-        "http://www.cs.fsu.edu/~engelen/license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/EUPL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/EUPL-1.1.json",
-      "referenceNumber": 268,
-      "name": "European Union Public License 1.1",
-      "licenseId": "EUPL-1.1",
-      "seeAlso": [
-        "https://joinup.ec.europa.eu/software/page/eupl/licence-eupl",
-        "https://joinup.ec.europa.eu/sites/default/files/custom-page/attachment/eupl1.1.-licence-en_0.pdf",
-        "https://opensource.org/licenses/EUPL-1.1"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/AMDPLPA.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/AMDPLPA.json",
-      "referenceNumber": 269,
-      "name": "AMD\u0027s plpa_map.c License",
-      "licenseId": "AMDPLPA",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/AMD_plpa_map_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/Imlib2.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Imlib2.json",
-      "referenceNumber": 270,
-      "name": "Imlib2 License",
-      "licenseId": "Imlib2",
-      "seeAlso": [
-        "http://trac.enlightenment.org/e/browser/trunk/imlib2/COPYING",
-        "https://git.enlightenment.org/legacy/imlib2.git/tree/COPYING"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/CDDL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CDDL-1.1.json",
-      "referenceNumber": 271,
-      "name": "Common Development and Distribution License 1.1",
-      "licenseId": "CDDL-1.1",
-      "seeAlso": [
-        "http://glassfish.java.net/public/CDDL+GPL_1_1.html",
-        "https://javaee.github.io/glassfish/LICENSE"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/WTFPL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/WTFPL.json",
-      "referenceNumber": 272,
-      "name": "Do What The F*ck You Want To Public License",
-      "licenseId": "WTFPL",
-      "seeAlso": [
-        "http://www.wtfpl.net/about/",
-        "http://sam.zoy.org/wtfpl/COPYING"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/LPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/LPL-1.0.json",
-      "referenceNumber": 273,
-      "name": "Lucent Public License Version 1.0",
-      "licenseId": "LPL-1.0",
-      "seeAlso": [
-        "https://opensource.org/licenses/LPL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/EPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/EPL-1.0.json",
-      "referenceNumber": 274,
-      "name": "Eclipse Public License 1.0",
-      "licenseId": "EPL-1.0",
-      "seeAlso": [
-        "http://www.eclipse.org/legal/epl-v10.html",
-        "https://opensource.org/licenses/EPL-1.0"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/BSD-3-Clause-Attribution.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Attribution.json",
-      "referenceNumber": 275,
-      "name": "BSD with attribution",
-      "licenseId": "BSD-3-Clause-Attribution",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/BSD_with_Attribution"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/OSL-3.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/OSL-3.0.json",
-      "referenceNumber": 276,
-      "name": "Open Software License 3.0",
-      "licenseId": "OSL-3.0",
-      "seeAlso": [
-        "https://web.archive.org/web/20120101081418/http://rosenlaw.com:80/OSL3.0.htm",
-        "https://opensource.org/licenses/OSL-3.0"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/RHeCos-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/RHeCos-1.1.json",
-      "referenceNumber": 277,
-      "name": "Red Hat eCos Public License v1.1",
-      "licenseId": "RHeCos-1.1",
-      "seeAlso": [
-        "http://ecos.sourceware.org/old-license.html"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/PHP-3.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/PHP-3.0.json",
-      "referenceNumber": 278,
-      "name": "PHP License v3.0",
-      "licenseId": "PHP-3.0",
-      "seeAlso": [
-        "http://www.php.net/license/3_0.txt",
-        "https://opensource.org/licenses/PHP-3.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/BSD-Protection.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/BSD-Protection.json",
-      "referenceNumber": 279,
-      "name": "BSD Protection License",
-      "licenseId": "BSD-Protection",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/BSD_Protection_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/CC-BY-NC-3.0-DE.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-3.0-DE.json",
-      "referenceNumber": 280,
-      "name": "Creative Commons Attribution Non Commercial 3.0 Germany",
-      "licenseId": "CC-BY-NC-3.0-DE",
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nc/3.0/de/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/APL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/APL-1.0.json",
-      "referenceNumber": 281,
-      "name": "Adaptive Public License 1.0",
-      "licenseId": "APL-1.0",
-      "seeAlso": [
-        "https://opensource.org/licenses/APL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/EUDatagrid.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/EUDatagrid.json",
-      "referenceNumber": 282,
-      "name": "EU DataGrid Software License",
-      "licenseId": "EUDatagrid",
-      "seeAlso": [
-        "http://eu-datagrid.web.cern.ch/eu-datagrid/license.html",
-        "https://opensource.org/licenses/EUDatagrid"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/GPL-1.0.html",
+      "reference": "https://spdx.org/licenses/GPL-2.0-with-bison-exception.html",
       "isDeprecatedLicenseId": true,
-      "detailsUrl": "https://spdx.org/licenses/GPL-1.0.json",
-      "referenceNumber": 283,
-      "name": "GNU General Public License v1.0 only",
-      "licenseId": "GPL-1.0",
+      "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-bison-exception.json",
+      "referenceNumber": 196,
+      "name": "GNU General Public License v2.0 w/Bison exception",
+      "licenseId": "GPL-2.0-with-bison-exception",
       "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
+        "http://git.savannah.gnu.org/cgit/bison.git/tree/data/yacc.c?id\u003d193d7c7054ba7197b0789e14965b739162319b5e#n141"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/SHL-0.5.html",
+      "reference": "https://spdx.org/licenses/CC-BY-ND-3.0-DE.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/SHL-0.5.json",
-      "referenceNumber": 284,
-      "name": "Solderpad Hardware License v0.5",
-      "licenseId": "SHL-0.5",
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-3.0-DE.json",
+      "referenceNumber": 197,
+      "name": "Creative Commons Attribution No Derivatives 3.0 Germany",
+      "licenseId": "CC-BY-ND-3.0-DE",
       "seeAlso": [
-        "https://solderpad.org/licenses/SHL-0.5/"
+        "https://creativecommons.org/licenses/by-nd/3.0/de/legalcode"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/CC-BY-SA-2.0.html",
+      "reference": "https://spdx.org/licenses/NIST-PD-fallback.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-2.0.json",
-      "referenceNumber": 285,
-      "name": "Creative Commons Attribution Share Alike 2.0 Generic",
-      "licenseId": "CC-BY-SA-2.0",
+      "detailsUrl": "https://spdx.org/licenses/NIST-PD-fallback.json",
+      "referenceNumber": 198,
+      "name": "NIST Public Domain Notice with license fallback",
+      "licenseId": "NIST-PD-fallback",
       "seeAlso": [
-        "https://creativecommons.org/licenses/by-sa/2.0/legalcode"
+        "https://github.com/usnistgov/jsip/blob/59700e6926cbe96c5cdae897d9a7d2656b42abe3/LICENSE",
+        "https://github.com/usnistgov/fipy/blob/86aaa5c2ba2c6f1be19593c5986071cf6568cc34/LICENSE.rst"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/CC-BY-SA-3.0-AT.html",
+      "reference": "https://spdx.org/licenses/NLOD-2.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-3.0-AT.json",
-      "referenceNumber": 286,
-      "name": "Creative Commons Attribution Share Alike 3.0 Austria",
-      "licenseId": "CC-BY-SA-3.0-AT",
+      "detailsUrl": "https://spdx.org/licenses/NLOD-2.0.json",
+      "referenceNumber": 199,
+      "name": "Norwegian Licence for Open Government Data (NLOD) 2.0",
+      "licenseId": "NLOD-2.0",
       "seeAlso": [
-        "https://creativecommons.org/licenses/by-sa/3.0/at/legalcode"
+        "http://data.norge.no/nlod/en/2.0"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/CC-BY-NC-SA-3.0-IGO.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-3.0-IGO.json",
-      "referenceNumber": 287,
-      "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 IGO",
-      "licenseId": "CC-BY-NC-SA-3.0-IGO",
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nc-sa/3.0/igo/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/Adobe-2006.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Adobe-2006.json",
-      "referenceNumber": 288,
-      "name": "Adobe Systems Incorporated Source Code License Agreement",
-      "licenseId": "Adobe-2006",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/AdobeLicense"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/Newsletr.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Newsletr.json",
-      "referenceNumber": 289,
-      "name": "Newsletr License",
-      "licenseId": "Newsletr",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Newsletr"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/Nunit.html",
+      "reference": "https://spdx.org/licenses/BSD-2-Clause-NetBSD.html",
       "isDeprecatedLicenseId": true,
-      "detailsUrl": "https://spdx.org/licenses/Nunit.json",
-      "referenceNumber": 290,
-      "name": "Nunit License",
-      "licenseId": "Nunit",
+      "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-NetBSD.json",
+      "referenceNumber": 200,
+      "name": "BSD 2-Clause NetBSD License",
+      "licenseId": "BSD-2-Clause-NetBSD",
       "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Nunit"
+        "http://www.netbsd.org/about/redistribution.html#default"
       ],
       "isOsiApproved": false,
       "isFsfLibre": true
     },
     {
-      "reference": "https://spdx.org/licenses/Multics.html",
+      "reference": "https://spdx.org/licenses/PolyForm-Noncommercial-1.0.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Multics.json",
-      "referenceNumber": 291,
-      "name": "Multics License",
-      "licenseId": "Multics",
+      "detailsUrl": "https://spdx.org/licenses/PolyForm-Noncommercial-1.0.0.json",
+      "referenceNumber": 201,
+      "name": "PolyForm Noncommercial License 1.0.0",
+      "licenseId": "PolyForm-Noncommercial-1.0.0",
       "seeAlso": [
-        "https://opensource.org/licenses/Multics"
+        "https://polyformproject.org/licenses/noncommercial/1.0.0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-SA-2.1-JP.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-2.1-JP.json",
+      "referenceNumber": 202,
+      "name": "Creative Commons Attribution Share Alike 2.1 Japan",
+      "licenseId": "CC-BY-SA-2.1-JP",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-sa/2.1/jp/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-SA-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-2.0.json",
+      "referenceNumber": 203,
+      "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 Generic",
+      "licenseId": "CC-BY-NC-SA-2.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-sa/2.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.1-invariants-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-invariants-only.json",
+      "referenceNumber": 204,
+      "name": "GNU Free Documentation License v1.1 only - invariants",
+      "licenseId": "GFDL-1.1-invariants-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/ZPL-2.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ZPL-2.1.json",
+      "referenceNumber": 205,
+      "name": "Zope Public License 2.1",
+      "licenseId": "ZPL-2.1",
+      "seeAlso": [
+        "http://old.zope.org/Resources/ZPL/"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/MPL-2.0-no-copyleft-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MPL-2.0-no-copyleft-exception.json",
+      "referenceNumber": 206,
+      "name": "Mozilla Public License 2.0 (no copyleft exception)",
+      "licenseId": "MPL-2.0-no-copyleft-exception",
+      "seeAlso": [
+        "https://www.mozilla.org/MPL/2.0/",
+        "https://opensource.org/licenses/MPL-2.0"
       ],
       "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Mup.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Mup.json",
+      "referenceNumber": 207,
+      "name": "Mup License",
+      "licenseId": "Mup",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Mup"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Eurosym.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Eurosym.json",
+      "referenceNumber": 208,
+      "name": "Eurosym License",
+      "licenseId": "Eurosym",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Eurosym"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OGDL-Taiwan-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OGDL-Taiwan-1.0.json",
+      "referenceNumber": 209,
+      "name": "Taiwan Open Government Data License, version 1.0",
+      "licenseId": "OGDL-Taiwan-1.0",
+      "seeAlso": [
+        "https://data.gov.tw/license"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Plexus.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Plexus.json",
+      "referenceNumber": 210,
+      "name": "Plexus Classworlds License",
+      "licenseId": "Plexus",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Plexus_Classworlds_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/COIL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/COIL-1.0.json",
+      "referenceNumber": 211,
+      "name": "Copyfree Open Innovation License",
+      "licenseId": "COIL-1.0",
+      "seeAlso": [
+        "https://coil.apotheon.org/plaintext/01.0.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/AGPL-3.0-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/AGPL-3.0-or-later.json",
+      "referenceNumber": 212,
+      "name": "GNU Affero General Public License v3.0 or later",
+      "licenseId": "AGPL-3.0-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/agpl.txt",
+        "https://opensource.org/licenses/AGPL-3.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
     },
     {
       "reference": "https://spdx.org/licenses/OGL-UK-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OGL-UK-1.0.json",
-      "referenceNumber": 292,
+      "referenceNumber": 213,
       "name": "Open Government Licence v1.0",
       "licenseId": "OGL-UK-1.0",
       "seeAlso": [
@@ -3668,23 +2691,94 @@
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/Vim.html",
+      "reference": "https://spdx.org/licenses/MIT-feh.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Vim.json",
-      "referenceNumber": 293,
-      "name": "Vim License",
-      "licenseId": "Vim",
+      "detailsUrl": "https://spdx.org/licenses/MIT-feh.json",
+      "referenceNumber": 214,
+      "name": "feh License",
+      "licenseId": "MIT-feh",
       "seeAlso": [
-        "http://vimdoc.sourceforge.net/htmldoc/uganda.html"
+        "https://fedoraproject.org/wiki/Licensing/MIT#feh"
       ],
-      "isOsiApproved": false,
-      "isFsfLibre": true
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/APAFML.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/APAFML.json",
+      "referenceNumber": 215,
+      "name": "Adobe Postscript AFM License",
+      "licenseId": "APAFML",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/AdobePostscriptAFM"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/NetCDF.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NetCDF.json",
+      "referenceNumber": 216,
+      "name": "NetCDF license",
+      "licenseId": "NetCDF",
+      "seeAlso": [
+        "http://www.unidata.ucar.edu/software/netcdf/copyright.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CECILL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CECILL-1.0.json",
+      "referenceNumber": 217,
+      "name": "CeCILL Free Software License Agreement v1.0",
+      "licenseId": "CECILL-1.0",
+      "seeAlso": [
+        "http://www.cecill.info/licences/Licence_CeCILL_V1-fr.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/TU-Berlin-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/TU-Berlin-2.0.json",
+      "referenceNumber": 218,
+      "name": "Technische Universitaet Berlin License 2.0",
+      "licenseId": "TU-Berlin-2.0",
+      "seeAlso": [
+        "https://github.com/CorsixTH/deps/blob/fd339a9f526d1d9c9f01ccf39e438a015da50035/licences/libgsm.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/NLPL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NLPL.json",
+      "referenceNumber": 219,
+      "name": "No Limit Public License",
+      "licenseId": "NLPL",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/NLPL"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/EPICS.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/EPICS.json",
+      "referenceNumber": 220,
+      "name": "EPICS Open License",
+      "licenseId": "EPICS",
+      "seeAlso": [
+        "https://epics.anl.gov/license/open.php"
+      ],
+      "isOsiApproved": false
     },
     {
       "reference": "https://spdx.org/licenses/eCos-2.0.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/eCos-2.0.json",
-      "referenceNumber": 294,
+      "referenceNumber": 221,
       "name": "eCos license version 2.0",
       "licenseId": "eCos-2.0",
       "seeAlso": [
@@ -3694,74 +2788,690 @@
       "isFsfLibre": true
     },
     {
-      "reference": "https://spdx.org/licenses/Zimbra-1.3.html",
+      "reference": "https://spdx.org/licenses/OLDAP-1.4.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Zimbra-1.3.json",
-      "referenceNumber": 295,
-      "name": "Zimbra Public License v1.3",
-      "licenseId": "Zimbra-1.3",
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-1.4.json",
+      "referenceNumber": 222,
+      "name": "Open LDAP Public License v1.4",
+      "licenseId": "OLDAP-1.4",
       "seeAlso": [
-        "http://web.archive.org/web/20100302225219/http://www.zimbra.com/license/zimbra-public-license-1-3.html"
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003dc9f95c2f3f2ffb5e0ae55fe7388af75547660941"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Zend-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Zend-2.0.json",
+      "referenceNumber": 223,
+      "name": "Zend License v2.0",
+      "licenseId": "Zend-2.0",
+      "seeAlso": [
+        "https://web.archive.org/web/20130517195954/http://www.zend.com/license/2_00.txt"
       ],
       "isOsiApproved": false,
       "isFsfLibre": true
     },
     {
-      "reference": "https://spdx.org/licenses/eGenix.html",
+      "reference": "https://spdx.org/licenses/GFDL-1.2-only.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/eGenix.json",
-      "referenceNumber": 296,
-      "name": "eGenix.com Public License 1.1.0",
-      "licenseId": "eGenix",
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-only.json",
+      "referenceNumber": 224,
+      "name": "GNU Free Documentation License v1.2 only",
+      "licenseId": "GFDL-1.2-only",
       "seeAlso": [
-        "http://www.egenix.com/products/eGenix.com-Public-License-1.1.0.pdf",
-        "https://fedoraproject.org/wiki/Licensing/eGenix.com_Public_License_1.1.0"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/IBM-pibs.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/IBM-pibs.json",
-      "referenceNumber": 297,
-      "name": "IBM PowerPC Initialization and Boot Software",
-      "licenseId": "IBM-pibs",
-      "seeAlso": [
-        "http://git.denx.de/?p\u003du-boot.git;a\u003dblob;f\u003darch/powerpc/cpu/ppc4xx/miiphy.c;h\u003d297155fdafa064b955e53e9832de93bfb0cfb85b;hb\u003d9fab4bf4cc077c21e43941866f3f2c196f28670d"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/BitTorrent-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/BitTorrent-1.1.json",
-      "referenceNumber": 298,
-      "name": "BitTorrent Open Source License v1.1",
-      "licenseId": "BitTorrent-1.1",
-      "seeAlso": [
-        "http://directory.fsf.org/wiki/License:BitTorrentOSL1.1"
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
       ],
       "isOsiApproved": false,
       "isFsfLibre": true
     },
     {
-      "reference": "https://spdx.org/licenses/OFL-1.1-no-RFN.html",
+      "reference": "https://spdx.org/licenses/LPL-1.02.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/OFL-1.1-no-RFN.json",
-      "referenceNumber": 299,
-      "name": "SIL Open Font License 1.1 with no Reserved Font Name",
-      "licenseId": "OFL-1.1-no-RFN",
+      "detailsUrl": "https://spdx.org/licenses/LPL-1.02.json",
+      "referenceNumber": 225,
+      "name": "Lucent Public License v1.02",
+      "licenseId": "LPL-1.02",
       "seeAlso": [
-        "http://scripts.sil.org/cms/scripts/page.php?item_id\u003dOFL_web",
-        "https://opensource.org/licenses/OFL-1.1"
+        "http://plan9.bell-labs.com/plan9/license.html",
+        "https://opensource.org/licenses/LPL-1.02"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CDDL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CDDL-1.0.json",
+      "referenceNumber": 226,
+      "name": "Common Development and Distribution License 1.0",
+      "licenseId": "CDDL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/cddl1"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/iMatix.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/iMatix.json",
+      "referenceNumber": 227,
+      "name": "iMatix Standard Function Library Agreement",
+      "licenseId": "iMatix",
+      "seeAlso": [
+        "http://legacy.imatix.com/html/sfl/sfl4.htm#license"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-1.0-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GPL-1.0-only.json",
+      "referenceNumber": 228,
+      "name": "GNU General Public License v1.0 only",
+      "licenseId": "GPL-1.0-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/ADSL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ADSL.json",
+      "referenceNumber": 229,
+      "name": "Amazon Digital Services License",
+      "licenseId": "ADSL",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/AmazonDigitalServicesLicense"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OLDAP-2.3.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.3.json",
+      "referenceNumber": 230,
+      "name": "Open LDAP Public License v2.3",
+      "licenseId": "OLDAP-2.3",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003dd32cf54a32d581ab475d23c810b0a7fbaf8d63c3"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/ANTLR-PD-fallback.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ANTLR-PD-fallback.json",
+      "referenceNumber": 231,
+      "name": "ANTLR Software Rights Notice with license fallback",
+      "licenseId": "ANTLR-PD-fallback",
+      "seeAlso": [
+        "http://www.antlr2.org/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Linux-man-pages-copyleft.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Linux-man-pages-copyleft.json",
+      "referenceNumber": 232,
+      "name": "Linux man-pages Copyleft",
+      "licenseId": "Linux-man-pages-copyleft",
+      "seeAlso": [
+        "https://www.kernel.org/doc/man-pages/licenses.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/X11-distribute-modifications-variant.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/X11-distribute-modifications-variant.json",
+      "referenceNumber": 233,
+      "name": "X11 License Distribution Modification Variant",
+      "licenseId": "X11-distribute-modifications-variant",
+      "seeAlso": [
+        "https://github.com/mirror/ncurses/blob/master/COPYING"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MIT.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MIT.json",
+      "referenceNumber": 234,
+      "name": "MIT License",
+      "licenseId": "MIT",
+      "seeAlso": [
+        "https://opensource.org/licenses/MIT"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Hippocratic-2.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Hippocratic-2.1.json",
+      "referenceNumber": 235,
+      "name": "Hippocratic License 2.1",
+      "licenseId": "Hippocratic-2.1",
+      "seeAlso": [
+        "https://firstdonoharm.dev/version/2/1/license.html",
+        "https://github.com/EthicalSource/hippocratic-license/blob/58c0e646d64ff6fbee275bfe2b9492f914e3ab2a/LICENSE.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MulanPSL-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MulanPSL-2.0.json",
+      "referenceNumber": 236,
+      "name": "Mulan Permissive Software License, Version 2",
+      "licenseId": "MulanPSL-2.0",
+      "seeAlso": [
+        "https://license.coscl.org.cn/MulanPSL2/"
       ],
       "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/SGI-B-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SGI-B-1.0.json",
+      "referenceNumber": 237,
+      "name": "SGI Free Software License B v1.0",
+      "licenseId": "SGI-B-1.0",
+      "seeAlso": [
+        "http://oss.sgi.com/projects/FreeB/SGIFreeSWLicB.1.0.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Nunit.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/Nunit.json",
+      "referenceNumber": 238,
+      "name": "Nunit License",
+      "licenseId": "Nunit",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Nunit"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/LZMA-SDK-9.11-to-9.20.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LZMA-SDK-9.11-to-9.20.json",
+      "referenceNumber": 239,
+      "name": "LZMA SDK License (versions 9.11 to 9.20)",
+      "licenseId": "LZMA-SDK-9.11-to-9.20",
+      "seeAlso": [
+        "https://www.7-zip.org/sdk.html",
+        "https://sourceforge.net/projects/sevenzip/files/LZMA%20SDK/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-2.0-with-autoconf-exception.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-autoconf-exception.json",
+      "referenceNumber": 240,
+      "name": "GNU General Public License v2.0 w/Autoconf exception",
+      "licenseId": "GPL-2.0-with-autoconf-exception",
+      "seeAlso": [
+        "http://ac-archive.sourceforge.net/doc/copyright.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND.json",
+      "referenceNumber": 241,
+      "name": "Historical Permission Notice and Disclaimer",
+      "licenseId": "HPND",
+      "seeAlso": [
+        "https://opensource.org/licenses/HPND"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-3.0.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/GPL-3.0.json",
+      "referenceNumber": 242,
+      "name": "GNU General Public License v3.0 only",
+      "licenseId": "GPL-3.0",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
+        "https://opensource.org/licenses/GPL-3.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CDDL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CDDL-1.1.json",
+      "referenceNumber": 243,
+      "name": "Common Development and Distribution License 1.1",
+      "licenseId": "CDDL-1.1",
+      "seeAlso": [
+        "http://glassfish.java.net/public/CDDL+GPL_1_1.html",
+        "https://javaee.github.io/glassfish/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-2.0-with-classpath-exception.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-classpath-exception.json",
+      "referenceNumber": 244,
+      "name": "GNU General Public License v2.0 w/Classpath exception",
+      "licenseId": "GPL-2.0-with-classpath-exception",
+      "seeAlso": [
+        "https://www.gnu.org/software/classpath/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-SA-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-2.0.json",
+      "referenceNumber": 245,
+      "name": "Creative Commons Attribution Share Alike 2.0 Generic",
+      "licenseId": "CC-BY-SA-2.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-sa/2.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/C-UDA-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/C-UDA-1.0.json",
+      "referenceNumber": 246,
+      "name": "Computational Use of Data Agreement v1.0",
+      "licenseId": "C-UDA-1.0",
+      "seeAlso": [
+        "https://github.com/microsoft/Computational-Use-of-Data-Agreement/blob/master/C-UDA-1.0.md",
+        "https://cdla.dev/computational-use-of-data-agreement-v1-0/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.1-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-only.json",
+      "referenceNumber": 247,
+      "name": "GNU Free Documentation License v1.1 only",
+      "licenseId": "GFDL-1.1-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/OCLC-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OCLC-2.0.json",
+      "referenceNumber": 248,
+      "name": "OCLC Research Public License 2.0",
+      "licenseId": "OCLC-2.0",
+      "seeAlso": [
+        "http://www.oclc.org/research/activities/software/license/v2final.htm",
+        "https://opensource.org/licenses/OCLC-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Crossword.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Crossword.json",
+      "referenceNumber": 249,
+      "name": "Crossword License",
+      "licenseId": "Crossword",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Crossword"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/libtiff.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/libtiff.json",
+      "referenceNumber": 250,
+      "name": "libtiff License",
+      "licenseId": "libtiff",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/libtiff"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/IPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/IPL-1.0.json",
+      "referenceNumber": 251,
+      "name": "IBM Public License v1.0",
+      "licenseId": "IPL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/IPL-1.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/MS-LPL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MS-LPL.json",
+      "referenceNumber": 252,
+      "name": "Microsoft Limited Public License",
+      "licenseId": "MS-LPL",
+      "seeAlso": [
+        "https://www.openhub.net/licenses/mslpl",
+        "https://github.com/gabegundy/atlserver/blob/master/License.txt",
+        "https://en.wikipedia.org/wiki/Shared_Source_Initiative#Microsoft_Limited_Public_License_(Ms-LPL)"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MS-PL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MS-PL.json",
+      "referenceNumber": 253,
+      "name": "Microsoft Public License",
+      "licenseId": "MS-PL",
+      "seeAlso": [
+        "http://www.microsoft.com/opensource/licenses.mspx",
+        "https://opensource.org/licenses/MS-PL"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.3-no-invariants-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-no-invariants-or-later.json",
+      "referenceNumber": 254,
+      "name": "GNU Free Documentation License v1.3 or later - no invariants",
+      "licenseId": "GFDL-1.3-no-invariants-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/fdl-1.3.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/AFL-2.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/AFL-2.1.json",
+      "referenceNumber": 255,
+      "name": "Academic Free License v2.1",
+      "licenseId": "AFL-2.1",
+      "seeAlso": [
+        "http://opensource.linux-mirror.org/licenses/afl-2.1.txt"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/OLDAP-2.0.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.0.1.json",
+      "referenceNumber": 256,
+      "name": "Open LDAP Public License v2.0.1",
+      "licenseId": "OLDAP-2.0.1",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003db6d68acd14e51ca3aab4428bf26522aa74873f0e"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-SA-4.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-4.0.json",
+      "referenceNumber": 257,
+      "name": "Creative Commons Attribution Non Commercial Share Alike 4.0 International",
+      "licenseId": "CC-BY-NC-SA-4.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Unicode-DFS-2016.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Unicode-DFS-2016.json",
+      "referenceNumber": 258,
+      "name": "Unicode License Agreement - Data Files and Software (2016)",
+      "licenseId": "Unicode-DFS-2016",
+      "seeAlso": [
+        "http://www.unicode.org/copyright.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/ErlPL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ErlPL-1.1.json",
+      "referenceNumber": 259,
+      "name": "Erlang Public License v1.1",
+      "licenseId": "ErlPL-1.1",
+      "seeAlso": [
+        "http://www.erlang.org/EPLICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-3-Clause-Clear.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Clear.json",
+      "referenceNumber": 260,
+      "name": "BSD 3-Clause Clear License",
+      "licenseId": "BSD-3-Clause-Clear",
+      "seeAlso": [
+        "http://labs.metacarta.com/license-explanation.html#license"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-3.0-NL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-NL.json",
+      "referenceNumber": 261,
+      "name": "Creative Commons Attribution 3.0 Netherlands",
+      "licenseId": "CC-BY-3.0-NL",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by/3.0/nl/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MIT-open-group.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MIT-open-group.json",
+      "referenceNumber": 262,
+      "name": "MIT Open Group variant",
+      "licenseId": "MIT-open-group",
+      "seeAlso": [
+        "https://gitlab.freedesktop.org/xorg/app/iceauth/-/blob/master/COPYING",
+        "https://gitlab.freedesktop.org/xorg/app/xvinfo/-/blob/master/COPYING",
+        "https://gitlab.freedesktop.org/xorg/app/xsetroot/-/blob/master/COPYING",
+        "https://gitlab.freedesktop.org/xorg/app/xauth/-/blob/master/COPYING"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SchemeReport.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SchemeReport.json",
+      "referenceNumber": 263,
+      "name": "Scheme Language Report License",
+      "licenseId": "SchemeReport",
+      "seeAlso": [],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-ND-4.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-4.0.json",
+      "referenceNumber": 264,
+      "name": "Creative Commons Attribution Non Commercial No Derivatives 4.0 International",
+      "licenseId": "CC-BY-NC-ND-4.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Elastic-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Elastic-2.0.json",
+      "referenceNumber": 265,
+      "name": "Elastic License 2.0",
+      "licenseId": "Elastic-2.0",
+      "seeAlso": [
+        "https://www.elastic.co/licensing/elastic-license",
+        "https://github.com/elastic/elasticsearch/blob/master/licenses/ELASTIC-LICENSE-2.0.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC0-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC0-1.0.json",
+      "referenceNumber": 266,
+      "name": "Creative Commons Zero v1.0 Universal",
+      "licenseId": "CC0-1.0",
+      "seeAlso": [
+        "https://creativecommons.org/publicdomain/zero/1.0/legalcode"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Motosoto.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Motosoto.json",
+      "referenceNumber": 267,
+      "name": "Motosoto License",
+      "licenseId": "Motosoto",
+      "seeAlso": [
+        "https://opensource.org/licenses/Motosoto"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/TMate.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/TMate.json",
+      "referenceNumber": 268,
+      "name": "TMate Open Source License",
+      "licenseId": "TMate",
+      "seeAlso": [
+        "http://svnkit.com/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MITNFA.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MITNFA.json",
+      "referenceNumber": 269,
+      "name": "MIT +no-false-attribs license",
+      "licenseId": "MITNFA",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/MITNFA"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/PDDL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/PDDL-1.0.json",
+      "referenceNumber": 270,
+      "name": "Open Data Commons Public Domain Dedication \u0026 License 1.0",
+      "licenseId": "PDDL-1.0",
+      "seeAlso": [
+        "http://opendatacommons.org/licenses/pddl/1.0/",
+        "https://opendatacommons.org/licenses/pddl/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MulanPSL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MulanPSL-1.0.json",
+      "referenceNumber": 271,
+      "name": "Mulan Permissive Software License, Version 1",
+      "licenseId": "MulanPSL-1.0",
+      "seeAlso": [
+        "https://license.coscl.org.cn/MulanPSL/",
+        "https://github.com/yuwenlong/longphp/blob/25dfb70cc2a466dc4bb55ba30901cbce08d164b5/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-1.0.json",
+      "referenceNumber": 272,
+      "name": "Creative Commons Attribution 1.0 Generic",
+      "licenseId": "CC-BY-1.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by/1.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OLDAP-2.6.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.6.json",
+      "referenceNumber": 273,
+      "name": "Open LDAP Public License v2.6",
+      "licenseId": "OLDAP-2.6",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d1cae062821881f41b73012ba816434897abf4205"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-3.0-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GPL-3.0-only.json",
+      "referenceNumber": 274,
+      "name": "GNU General Public License v3.0 only",
+      "licenseId": "GPL-3.0-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
+        "https://opensource.org/licenses/GPL-3.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/SCEA.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SCEA.json",
+      "referenceNumber": 275,
+      "name": "SCEA Shared Source License",
+      "licenseId": "SCEA",
+      "seeAlso": [
+        "http://research.scea.com/scea_shared_source_license.html"
+      ],
+      "isOsiApproved": false
     },
     {
       "reference": "https://spdx.org/licenses/psfrag.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/psfrag.json",
-      "referenceNumber": 300,
+      "referenceNumber": 276,
       "name": "psfrag License",
       "licenseId": "psfrag",
       "seeAlso": [
@@ -3770,39 +3480,346 @@
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/CC-BY-ND-2.0.html",
+      "reference": "https://spdx.org/licenses/Frameworx-1.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-2.0.json",
-      "referenceNumber": 301,
-      "name": "Creative Commons Attribution No Derivatives 2.0 Generic",
-      "licenseId": "CC-BY-ND-2.0",
+      "detailsUrl": "https://spdx.org/licenses/Frameworx-1.0.json",
+      "referenceNumber": 277,
+      "name": "Frameworx Open License 1.0",
+      "licenseId": "Frameworx-1.0",
       "seeAlso": [
-        "https://creativecommons.org/licenses/by-nd/2.0/legalcode"
+        "https://opensource.org/licenses/Frameworx-1.0"
       ],
-      "isOsiApproved": false,
-      "isFsfLibre": false
+      "isOsiApproved": true
     },
     {
-      "reference": "https://spdx.org/licenses/SHL-0.51.html",
+      "reference": "https://spdx.org/licenses/NAIST-2003.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/SHL-0.51.json",
-      "referenceNumber": 302,
-      "name": "Solderpad Hardware License, Version 0.51",
-      "licenseId": "SHL-0.51",
+      "detailsUrl": "https://spdx.org/licenses/NAIST-2003.json",
+      "referenceNumber": 278,
+      "name": "Nara Institute of Science and Technology License (2003)",
+      "licenseId": "NAIST-2003",
       "seeAlso": [
-        "https://solderpad.org/licenses/SHL-0.51/"
+        "https://enterprise.dejacode.com/licenses/public/naist-2003/#license-text",
+        "https://github.com/nodejs/node/blob/4a19cc8947b1bba2b2d27816ec3d0edf9b28e503/LICENSE#L343"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/FreeBSD-DOC.html",
+      "reference": "https://spdx.org/licenses/W3C-19980720.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/FreeBSD-DOC.json",
-      "referenceNumber": 303,
-      "name": "FreeBSD Documentation License",
-      "licenseId": "FreeBSD-DOC",
+      "detailsUrl": "https://spdx.org/licenses/W3C-19980720.json",
+      "referenceNumber": 279,
+      "name": "W3C Software Notice and License (1998-07-20)",
+      "licenseId": "W3C-19980720",
       "seeAlso": [
-        "https://www.freebsd.org/copyright/freebsd-doc-license/"
+        "http://www.w3.org/Consortium/Legal/copyright-software-19980720.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MS-RL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MS-RL.json",
+      "referenceNumber": 280,
+      "name": "Microsoft Reciprocal License",
+      "licenseId": "MS-RL",
+      "seeAlso": [
+        "http://www.microsoft.com/opensource/licenses.mspx",
+        "https://opensource.org/licenses/MS-RL"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/JPNIC.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/JPNIC.json",
+      "referenceNumber": 281,
+      "name": "Japan Network Information Center License",
+      "licenseId": "JPNIC",
+      "seeAlso": [
+        "https://gitlab.isc.org/isc-projects/bind9/blob/master/COPYRIGHT#L366"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Glulxe.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Glulxe.json",
+      "referenceNumber": 282,
+      "name": "Glulxe License",
+      "licenseId": "Glulxe",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Glulxe"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/QPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/QPL-1.0.json",
+      "referenceNumber": 283,
+      "name": "Q Public License 1.0",
+      "licenseId": "QPL-1.0",
+      "seeAlso": [
+        "http://doc.qt.nokia.com/3.3/license.html",
+        "https://opensource.org/licenses/QPL-1.0",
+        "https://doc.qt.io/archives/3.3/license.html"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/AAL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/AAL.json",
+      "referenceNumber": 284,
+      "name": "Attribution Assurance License",
+      "licenseId": "AAL",
+      "seeAlso": [
+        "https://opensource.org/licenses/attribution"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Newsletr.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Newsletr.json",
+      "referenceNumber": 285,
+      "name": "Newsletr License",
+      "licenseId": "Newsletr",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Newsletr"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OPUBL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OPUBL-1.0.json",
+      "referenceNumber": 286,
+      "name": "Open Publication License v1.0",
+      "licenseId": "OPUBL-1.0",
+      "seeAlso": [
+        "http://opencontent.org/openpub/",
+        "https://www.debian.org/opl",
+        "https://www.ctan.org/license/opl"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/LGPL-3.0-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LGPL-3.0-or-later.json",
+      "referenceNumber": 287,
+      "name": "GNU Lesser General Public License v3.0 or later",
+      "licenseId": "LGPL-3.0-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
+        "https://www.gnu.org/licenses/lgpl+gpl-3.0.txt",
+        "https://opensource.org/licenses/LGPL-3.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/gnuplot.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/gnuplot.json",
+      "referenceNumber": 288,
+      "name": "gnuplot License",
+      "licenseId": "gnuplot",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Gnuplot"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Jam.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Jam.json",
+      "referenceNumber": 289,
+      "name": "Jam License",
+      "licenseId": "Jam",
+      "seeAlso": [
+        "https://www.boost.org/doc/libs/1_35_0/doc/html/jam.html",
+        "https://web.archive.org/web/20160330173339/https://swarm.workshop.perforce.com/files/guest/perforce_software/jam/src/README"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.1-no-invariants-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-no-invariants-only.json",
+      "referenceNumber": 290,
+      "name": "GNU Free Documentation License v1.1 only - no invariants",
+      "licenseId": "GFDL-1.1-no-invariants-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CAL-1.0-Combined-Work-Exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CAL-1.0-Combined-Work-Exception.json",
+      "referenceNumber": 291,
+      "name": "Cryptographic Autonomy License 1.0 (Combined Work Exception)",
+      "licenseId": "CAL-1.0-Combined-Work-Exception",
+      "seeAlso": [
+        "http://cryptographicautonomylicense.com/license-text.html",
+        "https://opensource.org/licenses/CAL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/OLDAP-2.7.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.7.json",
+      "referenceNumber": 292,
+      "name": "Open LDAP Public License v2.7",
+      "licenseId": "OLDAP-2.7",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d47c2415c1df81556eeb39be6cad458ef87c534a2"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Nokia.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Nokia.json",
+      "referenceNumber": 293,
+      "name": "Nokia Open Source License",
+      "licenseId": "Nokia",
+      "seeAlso": [
+        "https://opensource.org/licenses/nokia"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Adobe-2006.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Adobe-2006.json",
+      "referenceNumber": 294,
+      "name": "Adobe Systems Incorporated Source Code License Agreement",
+      "licenseId": "Adobe-2006",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/AdobeLicense"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Cube.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Cube.json",
+      "referenceNumber": 295,
+      "name": "Cube License",
+      "licenseId": "Cube",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Cube"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Sleepycat.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Sleepycat.json",
+      "referenceNumber": 296,
+      "name": "Sleepycat License",
+      "licenseId": "Sleepycat",
+      "seeAlso": [
+        "https://opensource.org/licenses/Sleepycat"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/EFL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/EFL-1.0.json",
+      "referenceNumber": 297,
+      "name": "Eiffel Forum License v1.0",
+      "licenseId": "EFL-1.0",
+      "seeAlso": [
+        "http://www.eiffel-nice.org/license/forum.txt",
+        "https://opensource.org/licenses/EFL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CDLA-Sharing-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CDLA-Sharing-1.0.json",
+      "referenceNumber": 298,
+      "name": "Community Data License Agreement Sharing 1.0",
+      "licenseId": "CDLA-Sharing-1.0",
+      "seeAlso": [
+        "https://cdla.io/sharing-1-0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BlueOak-1.0.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BlueOak-1.0.0.json",
+      "referenceNumber": 299,
+      "name": "Blue Oak Model License 1.0.0",
+      "licenseId": "BlueOak-1.0.0",
+      "seeAlso": [
+        "https://blueoakcouncil.org/license/1.0.0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/X11.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/X11.json",
+      "referenceNumber": 300,
+      "name": "X11 License",
+      "licenseId": "X11",
+      "seeAlso": [
+        "http://www.xfree86.org/3.3.6/COPYRIGHT2.html#3"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Spencer-99.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Spencer-99.json",
+      "referenceNumber": 301,
+      "name": "Spencer License 99",
+      "licenseId": "Spencer-99",
+      "seeAlso": [
+        "http://www.opensource.apple.com/source/tcl/tcl-5/tcl/generic/regfronts.c"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-2.0-with-font-exception.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-font-exception.json",
+      "referenceNumber": 302,
+      "name": "GNU General Public License v2.0 w/Font exception",
+      "licenseId": "GPL-2.0-with-font-exception",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/gpl-faq.html#FontException"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Sendmail-8.23.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Sendmail-8.23.json",
+      "referenceNumber": 303,
+      "name": "Sendmail License 8.23",
+      "licenseId": "Sendmail-8.23",
+      "seeAlso": [
+        "https://www.proofpoint.com/sites/default/files/sendmail-license.pdf",
+        "https://web.archive.org/web/20181003101040/https://www.proofpoint.com/sites/default/files/sendmail-license.pdf"
       ],
       "isOsiApproved": false
     },
@@ -3820,994 +3837,35 @@
       "isFsfLibre": true
     },
     {
-      "reference": "https://spdx.org/licenses/Mup.html",
+      "reference": "https://spdx.org/licenses/UPL-1.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Mup.json",
+      "detailsUrl": "https://spdx.org/licenses/UPL-1.0.json",
       "referenceNumber": 305,
-      "name": "Mup License",
-      "licenseId": "Mup",
+      "name": "Universal Permissive License v1.0",
+      "licenseId": "UPL-1.0",
       "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Mup"
+        "https://opensource.org/licenses/UPL"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": true,
+      "isFsfLibre": true
     },
     {
-      "reference": "https://spdx.org/licenses/BSD-4-Clause-Shortened.html",
+      "reference": "https://spdx.org/licenses/copyleft-next-0.3.1.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/BSD-4-Clause-Shortened.json",
+      "detailsUrl": "https://spdx.org/licenses/copyleft-next-0.3.1.json",
       "referenceNumber": 306,
-      "name": "BSD 4 Clause Shortened",
-      "licenseId": "BSD-4-Clause-Shortened",
+      "name": "copyleft-next 0.3.1",
+      "licenseId": "copyleft-next-0.3.1",
       "seeAlso": [
-        "https://metadata.ftp-master.debian.org/changelogs//main/a/arpwatch/arpwatch_2.1a15-7_copyright"
+        "https://github.com/copyleft-next/copyleft-next/blob/master/Releases/copyleft-next-0.3.1"
       ],
       "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/CC-BY-NC-SA-4.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-4.0.json",
-      "referenceNumber": 307,
-      "name": "Creative Commons Attribution Non Commercial Share Alike 4.0 International",
-      "licenseId": "CC-BY-NC-SA-4.0",
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/HPND.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/HPND.json",
-      "referenceNumber": 308,
-      "name": "Historical Permission Notice and Disclaimer",
-      "licenseId": "HPND",
-      "seeAlso": [
-        "https://opensource.org/licenses/HPND"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/OLDAP-2.6.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.6.json",
-      "referenceNumber": 309,
-      "name": "Open LDAP Public License v2.6",
-      "licenseId": "OLDAP-2.6",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d1cae062821881f41b73012ba816434897abf4205"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/MPL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/MPL-1.1.json",
-      "referenceNumber": 310,
-      "name": "Mozilla Public License 1.1",
-      "licenseId": "MPL-1.1",
-      "seeAlso": [
-        "http://www.mozilla.org/MPL/MPL-1.1.html",
-        "https://opensource.org/licenses/MPL-1.1"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/GPL-2.0-with-GCC-exception.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-GCC-exception.json",
-      "referenceNumber": 311,
-      "name": "GNU General Public License v2.0 w/GCC Runtime Library exception",
-      "licenseId": "GPL-2.0-with-GCC-exception",
-      "seeAlso": [
-        "https://gcc.gnu.org/git/?p\u003dgcc.git;a\u003dblob;f\u003dgcc/libgcc1.c;h\u003d762f5143fc6eed57b6797c82710f3538aa52b40b;hb\u003dcb143a3ce4fb417c68f5fa2691a1b1b1053dfba9#l10"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/HaskellReport.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/HaskellReport.json",
-      "referenceNumber": 312,
-      "name": "Haskell Language Report License",
-      "licenseId": "HaskellReport",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Haskell_Language_Report_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/ECL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/ECL-1.0.json",
-      "referenceNumber": 313,
-      "name": "Educational Community License v1.0",
-      "licenseId": "ECL-1.0",
-      "seeAlso": [
-        "https://opensource.org/licenses/ECL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/LGPL-2.1-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/LGPL-2.1-or-later.json",
-      "referenceNumber": 314,
-      "name": "GNU Lesser General Public License v2.1 or later",
-      "licenseId": "LGPL-2.1-or-later",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
-        "https://opensource.org/licenses/LGPL-2.1"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/OFL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/OFL-1.0.json",
-      "referenceNumber": 315,
-      "name": "SIL Open Font License 1.0",
-      "licenseId": "OFL-1.0",
-      "seeAlso": [
-        "http://scripts.sil.org/cms/scripts/page.php?item_id\u003dOFL10_web"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/APSL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/APSL-1.1.json",
-      "referenceNumber": 316,
-      "name": "Apple Public Source License 1.1",
-      "licenseId": "APSL-1.1",
-      "seeAlso": [
-        "http://www.opensource.apple.com/source/IOSerialFamily/IOSerialFamily-7/APPLE_LICENSE"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/MITNFA.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/MITNFA.json",
-      "referenceNumber": 317,
-      "name": "MIT +no-false-attribs license",
-      "licenseId": "MITNFA",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/MITNFA"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/CECILL-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CECILL-2.0.json",
-      "referenceNumber": 318,
-      "name": "CeCILL Free Software License Agreement v2.0",
-      "licenseId": "CECILL-2.0",
-      "seeAlso": [
-        "http://www.cecill.info/licences/Licence_CeCILL_V2-en.html"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/Crossword.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Crossword.json",
-      "referenceNumber": 319,
-      "name": "Crossword License",
-      "licenseId": "Crossword",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Crossword"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/Aladdin.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Aladdin.json",
-      "referenceNumber": 320,
-      "name": "Aladdin Free Public License",
-      "licenseId": "Aladdin",
-      "seeAlso": [
-        "http://pages.cs.wisc.edu/~ghost/doc/AFPL/6.01/Public.htm"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/Baekmuk.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Baekmuk.json",
-      "referenceNumber": 321,
-      "name": "Baekmuk License",
-      "licenseId": "Baekmuk",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing:Baekmuk?rd\u003dLicensing/Baekmuk"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/XFree86-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/XFree86-1.1.json",
-      "referenceNumber": 322,
-      "name": "XFree86 License 1.1",
-      "licenseId": "XFree86-1.1",
-      "seeAlso": [
-        "http://www.xfree86.org/current/LICENSE4.html"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/GPL-1.0-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/GPL-1.0-or-later.json",
-      "referenceNumber": 323,
-      "name": "GNU General Public License v1.0 or later",
-      "licenseId": "GPL-1.0-or-later",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/CERN-OHL-W-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CERN-OHL-W-2.0.json",
-      "referenceNumber": 324,
-      "name": "CERN Open Hardware Licence Version 2 - Weakly Reciprocal",
-      "licenseId": "CERN-OHL-W-2.0",
-      "seeAlso": [
-        "https://www.ohwr.org/project/cernohl/wikis/Documents/CERN-OHL-version-2"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/CC-BY-SA-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-1.0.json",
-      "referenceNumber": 325,
-      "name": "Creative Commons Attribution Share Alike 1.0 Generic",
-      "licenseId": "CC-BY-SA-1.0",
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-sa/1.0/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/NTP.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/NTP.json",
-      "referenceNumber": 326,
-      "name": "NTP License",
-      "licenseId": "NTP",
-      "seeAlso": [
-        "https://opensource.org/licenses/NTP"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/PHP-3.01.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/PHP-3.01.json",
-      "referenceNumber": 327,
-      "name": "PHP License v3.01",
-      "licenseId": "PHP-3.01",
-      "seeAlso": [
-        "http://www.php.net/license/3_01.txt"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/OCLC-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/OCLC-2.0.json",
-      "referenceNumber": 328,
-      "name": "OCLC Research Public License 2.0",
-      "licenseId": "OCLC-2.0",
-      "seeAlso": [
-        "http://www.oclc.org/research/activities/software/license/v2final.htm",
-        "https://opensource.org/licenses/OCLC-2.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/CC-BY-3.0-DE.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-DE.json",
-      "referenceNumber": 329,
-      "name": "Creative Commons Attribution 3.0 Germany",
-      "licenseId": "CC-BY-3.0-DE",
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by/3.0/de/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/CC-BY-NC-2.5.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-2.5.json",
-      "referenceNumber": 330,
-      "name": "Creative Commons Attribution Non Commercial 2.5 Generic",
-      "licenseId": "CC-BY-NC-2.5",
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nc/2.5/legalcode"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/Zlib.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Zlib.json",
-      "referenceNumber": 331,
-      "name": "zlib License",
-      "licenseId": "Zlib",
-      "seeAlso": [
-        "http://www.zlib.net/zlib_license.html",
-        "https://opensource.org/licenses/Zlib"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/CATOSL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CATOSL-1.1.json",
-      "referenceNumber": 332,
-      "name": "Computer Associates Trusted Open Source License 1.1",
-      "licenseId": "CATOSL-1.1",
-      "seeAlso": [
-        "https://opensource.org/licenses/CATOSL-1.1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/LGPL-3.0+.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "https://spdx.org/licenses/LGPL-3.0+.json",
-      "referenceNumber": 333,
-      "name": "GNU Lesser General Public License v3.0 or later",
-      "licenseId": "LGPL-3.0+",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
-        "https://www.gnu.org/licenses/lgpl+gpl-3.0.txt",
-        "https://opensource.org/licenses/LGPL-3.0"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/CAL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CAL-1.0.json",
-      "referenceNumber": 334,
-      "name": "Cryptographic Autonomy License 1.0",
-      "licenseId": "CAL-1.0",
-      "seeAlso": [
-        "http://cryptographicautonomylicense.com/license-text.html",
-        "https://opensource.org/licenses/CAL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/NPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/NPL-1.0.json",
-      "referenceNumber": 335,
-      "name": "Netscape Public License v1.0",
-      "licenseId": "NPL-1.0",
-      "seeAlso": [
-        "http://www.mozilla.org/MPL/NPL/1.0/"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/SMLNJ.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/SMLNJ.json",
-      "referenceNumber": 336,
-      "name": "Standard ML of New Jersey License",
-      "licenseId": "SMLNJ",
-      "seeAlso": [
-        "https://www.smlnj.org/license.html"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/GPL-2.0+.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "https://spdx.org/licenses/GPL-2.0+.json",
-      "referenceNumber": 337,
-      "name": "GNU General Public License v2.0 or later",
-      "licenseId": "GPL-2.0+",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
-        "https://opensource.org/licenses/GPL-2.0"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/OLDAP-2.5.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.5.json",
-      "referenceNumber": 338,
-      "name": "Open LDAP Public License v2.5",
-      "licenseId": "OLDAP-2.5",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d6852b9d90022e8593c98205413380536b1b5a7cf"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/JasPer-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/JasPer-2.0.json",
-      "referenceNumber": 339,
-      "name": "JasPer License",
-      "licenseId": "JasPer-2.0",
-      "seeAlso": [
-        "http://www.ece.uvic.ca/~mdadams/jasper/LICENSE"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/GPL-2.0-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/GPL-2.0-or-later.json",
-      "referenceNumber": 340,
-      "name": "GNU General Public License v2.0 or later",
-      "licenseId": "GPL-2.0-or-later",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
-        "https://opensource.org/licenses/GPL-2.0"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/BSD-2-Clause-Patent.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-Patent.json",
-      "referenceNumber": 341,
-      "name": "BSD-2-Clause Plus Patent License",
-      "licenseId": "BSD-2-Clause-Patent",
-      "seeAlso": [
-        "https://opensource.org/licenses/BSDplusPatent"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/MS-RL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/MS-RL.json",
-      "referenceNumber": 342,
-      "name": "Microsoft Reciprocal License",
-      "licenseId": "MS-RL",
-      "seeAlso": [
-        "http://www.microsoft.com/opensource/licenses.mspx",
-        "https://opensource.org/licenses/MS-RL"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/CUA-OPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CUA-OPL-1.0.json",
-      "referenceNumber": 343,
-      "name": "CUA Office Public License v1.0",
-      "licenseId": "CUA-OPL-1.0",
-      "seeAlso": [
-        "https://opensource.org/licenses/CUA-OPL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/IPA.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/IPA.json",
-      "referenceNumber": 344,
-      "name": "IPA Font License",
-      "licenseId": "IPA",
-      "seeAlso": [
-        "https://opensource.org/licenses/IPA"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/NLPL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/NLPL.json",
-      "referenceNumber": 345,
-      "name": "No Limit Public License",
-      "licenseId": "NLPL",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/NLPL"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/O-UDA-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/O-UDA-1.0.json",
-      "referenceNumber": 346,
-      "name": "Open Use of Data Agreement v1.0",
-      "licenseId": "O-UDA-1.0",
-      "seeAlso": [
-        "https://github.com/microsoft/Open-Use-of-Data-Agreement/blob/v1.0/O-UDA-1.0.md",
-        "https://cdla.dev/open-use-of-data-agreement-v1-0/"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/MIT-Modern-Variant.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/MIT-Modern-Variant.json",
-      "referenceNumber": 347,
-      "name": "MIT License Modern Variant",
-      "licenseId": "MIT-Modern-Variant",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing:MIT#Modern_Variants",
-        "https://ptolemy.berkeley.edu/copyright.htm",
-        "https://pirlwww.lpl.arizona.edu/resources/guide/software/PerlTk/Tixlic.html"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/OLDAP-1.2.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/OLDAP-1.2.json",
-      "referenceNumber": 348,
-      "name": "Open LDAP Public License v1.2",
-      "licenseId": "OLDAP-1.2",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d42b0383c50c299977b5893ee695cf4e486fb0dc7"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/BSD-2-Clause-FreeBSD.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-FreeBSD.json",
-      "referenceNumber": 349,
-      "name": "BSD 2-Clause FreeBSD License",
-      "licenseId": "BSD-2-Clause-FreeBSD",
-      "seeAlso": [
-        "http://www.freebsd.org/copyright/freebsd-license.html"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/Info-ZIP.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Info-ZIP.json",
-      "referenceNumber": 350,
-      "name": "Info-ZIP License",
-      "licenseId": "Info-ZIP",
-      "seeAlso": [
-        "http://www.info-zip.org/license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-FR.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-FR.json",
-      "referenceNumber": 351,
-      "name": "Creative Commons Attribution-NonCommercial-ShareAlike 2.0 France",
-      "licenseId": "CC-BY-NC-SA-2.0-FR",
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nc-sa/2.0/fr/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/0BSD.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/0BSD.json",
-      "referenceNumber": 352,
-      "name": "BSD Zero Clause License",
-      "licenseId": "0BSD",
-      "seeAlso": [
-        "http://landley.net/toybox/license.html",
-        "https://opensource.org/licenses/0BSD"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/Unicode-DFS-2016.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Unicode-DFS-2016.json",
-      "referenceNumber": 353,
-      "name": "Unicode License Agreement - Data Files and Software (2016)",
-      "licenseId": "Unicode-DFS-2016",
-      "seeAlso": [
-        "http://www.unicode.org/copyright.html"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/OFL-1.0-RFN.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/OFL-1.0-RFN.json",
-      "referenceNumber": 354,
-      "name": "SIL Open Font License 1.0 with Reserved Font Name",
-      "licenseId": "OFL-1.0-RFN",
-      "seeAlso": [
-        "http://scripts.sil.org/cms/scripts/page.php?item_id\u003dOFL10_web"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/Intel.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Intel.json",
-      "referenceNumber": 355,
-      "name": "Intel Open Source License",
-      "licenseId": "Intel",
-      "seeAlso": [
-        "https://opensource.org/licenses/Intel"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/AFL-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/AFL-2.0.json",
-      "referenceNumber": 356,
-      "name": "Academic Free License v2.0",
-      "licenseId": "AFL-2.0",
-      "seeAlso": [
-        "http://wayback.archive.org/web/20060924134533/http://www.opensource.org/licenses/afl-2.0.txt"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/GL2PS.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/GL2PS.json",
-      "referenceNumber": 357,
-      "name": "GL2PS License",
-      "licenseId": "GL2PS",
-      "seeAlso": [
-        "http://www.geuz.org/gl2ps/COPYING.GL2PS"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/TAPR-OHL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/TAPR-OHL-1.0.json",
-      "referenceNumber": 358,
-      "name": "TAPR Open Hardware License v1.0",
-      "licenseId": "TAPR-OHL-1.0",
-      "seeAlso": [
-        "https://www.tapr.org/OHL"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/Apache-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Apache-1.0.json",
-      "referenceNumber": 359,
-      "name": "Apache License 1.0",
-      "licenseId": "Apache-1.0",
-      "seeAlso": [
-        "http://www.apache.org/licenses/LICENSE-1.0"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/MTLL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/MTLL.json",
-      "referenceNumber": 360,
-      "name": "Matrix Template Library License",
-      "licenseId": "MTLL",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Matrix_Template_Library_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/Motosoto.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Motosoto.json",
-      "referenceNumber": 361,
-      "name": "Motosoto License",
-      "licenseId": "Motosoto",
-      "seeAlso": [
-        "https://opensource.org/licenses/Motosoto"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/RSA-MD.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/RSA-MD.json",
-      "referenceNumber": 362,
-      "name": "RSA Message-Digest License",
-      "licenseId": "RSA-MD",
-      "seeAlso": [
-        "http://www.faqs.org/rfcs/rfc1321.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/Community-Spec-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Community-Spec-1.0.json",
-      "referenceNumber": 363,
-      "name": "Community Specification License 1.0",
-      "licenseId": "Community-Spec-1.0",
-      "seeAlso": [
-        "https://github.com/CommunitySpecification/1.0/blob/master/1._Community_Specification_License-v1.md"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/ODC-By-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/ODC-By-1.0.json",
-      "referenceNumber": 364,
-      "name": "Open Data Commons Attribution License v1.0",
-      "licenseId": "ODC-By-1.0",
-      "seeAlso": [
-        "https://opendatacommons.org/licenses/by/1.0/"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/zlib-acknowledgement.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/zlib-acknowledgement.json",
-      "referenceNumber": 365,
-      "name": "zlib/libpng License with Acknowledgement",
-      "licenseId": "zlib-acknowledgement",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/ZlibWithAcknowledgement"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/DL-DE-BY-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/DL-DE-BY-2.0.json",
-      "referenceNumber": 366,
-      "name": "Data licence Germany – attribution – version 2.0",
-      "licenseId": "DL-DE-BY-2.0",
-      "seeAlso": [
-        "https://www.govdata.de/dl-de/by-2-0"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/VSL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/VSL-1.0.json",
-      "referenceNumber": 367,
-      "name": "Vovida Software License v1.0",
-      "licenseId": "VSL-1.0",
-      "seeAlso": [
-        "https://opensource.org/licenses/VSL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/LiLiQ-R-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/LiLiQ-R-1.1.json",
-      "referenceNumber": 368,
-      "name": "Licence Libre du Québec – Réciprocité version 1.1",
-      "licenseId": "LiLiQ-R-1.1",
-      "seeAlso": [
-        "https://www.forge.gouv.qc.ca/participez/licence-logicielle/licence-libre-du-quebec-liliq-en-francais/licence-libre-du-quebec-reciprocite-liliq-r-v1-1/",
-        "http://opensource.org/licenses/LiLiQ-R-1.1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/OPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/OPL-1.0.json",
-      "referenceNumber": 369,
-      "name": "Open Public License v1.0",
-      "licenseId": "OPL-1.0",
-      "seeAlso": [
-        "http://old.koalateam.com/jackaroo/OPL_1_0.TXT",
-        "https://fedoraproject.org/wiki/Licensing/Open_Public_License"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/GPL-3.0+.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "https://spdx.org/licenses/GPL-3.0+.json",
-      "referenceNumber": 370,
-      "name": "GNU General Public License v3.0 or later",
-      "licenseId": "GPL-3.0+",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
-        "https://opensource.org/licenses/GPL-3.0"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/MulanPSL-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/MulanPSL-2.0.json",
-      "referenceNumber": 371,
-      "name": "Mulan Permissive Software License, Version 2",
-      "licenseId": "MulanPSL-2.0",
-      "seeAlso": [
-        "https://license.coscl.org.cn/MulanPSL2/"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/APSL-1.2.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/APSL-1.2.json",
-      "referenceNumber": 372,
-      "name": "Apple Public Source License 1.2",
-      "licenseId": "APSL-1.2",
-      "seeAlso": [
-        "http://www.samurajdata.se/opensource/mirror/licenses/apsl.php"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/OGDL-Taiwan-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/OGDL-Taiwan-1.0.json",
-      "referenceNumber": 373,
-      "name": "Taiwan Open Government Data License, version 1.0",
-      "licenseId": "OGDL-Taiwan-1.0",
-      "seeAlso": [
-        "https://data.gov.tw/license"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/RSCPL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/RSCPL.json",
-      "referenceNumber": 374,
-      "name": "Ricoh Source Code Public License",
-      "licenseId": "RSCPL",
-      "seeAlso": [
-        "http://wayback.archive.org/web/20060715140826/http://www.risource.org/RPL/RPL-1.0A.shtml",
-        "https://opensource.org/licenses/RSCPL"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/OGC-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/OGC-1.0.json",
-      "referenceNumber": 375,
-      "name": "OGC Software License, Version 1.0",
-      "licenseId": "OGC-1.0",
-      "seeAlso": [
-        "https://www.ogc.org/ogc/software/1.0"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/EFL-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/EFL-2.0.json",
-      "referenceNumber": 376,
-      "name": "Eiffel Forum License v2.0",
-      "licenseId": "EFL-2.0",
-      "seeAlso": [
-        "http://www.eiffel-nice.org/license/eiffel-forum-license-2.html",
-        "https://opensource.org/licenses/EFL-2.0"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/CAL-1.0-Combined-Work-Exception.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CAL-1.0-Combined-Work-Exception.json",
-      "referenceNumber": 377,
-      "name": "Cryptographic Autonomy License 1.0 (Combined Work Exception)",
-      "licenseId": "CAL-1.0-Combined-Work-Exception",
-      "seeAlso": [
-        "http://cryptographicautonomylicense.com/license-text.html",
-        "https://opensource.org/licenses/CAL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/MS-PL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/MS-PL.json",
-      "referenceNumber": 378,
-      "name": "Microsoft Public License",
-      "licenseId": "MS-PL",
-      "seeAlso": [
-        "http://www.microsoft.com/opensource/licenses.mspx",
-        "https://opensource.org/licenses/MS-PL"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/Plexus.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Plexus.json",
-      "referenceNumber": 379,
-      "name": "Plexus Classworlds License",
-      "licenseId": "Plexus",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Plexus_Classworlds_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/Sendmail-8.23.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Sendmail-8.23.json",
-      "referenceNumber": 380,
-      "name": "Sendmail License 8.23",
-      "licenseId": "Sendmail-8.23",
-      "seeAlso": [
-        "https://www.proofpoint.com/sites/default/files/sendmail-license.pdf",
-        "https://web.archive.org/web/20181003101040/https://www.proofpoint.com/sites/default/files/sendmail-license.pdf"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/Cube.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Cube.json",
-      "referenceNumber": 381,
-      "name": "Cube License",
-      "licenseId": "Cube",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Cube"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/JSON.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/JSON.json",
-      "referenceNumber": 382,
-      "name": "JSON License",
-      "licenseId": "JSON",
-      "seeAlso": [
-        "http://www.json.org/license.html"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": false
     },
     {
       "reference": "https://spdx.org/licenses/EUPL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/EUPL-1.2.json",
-      "referenceNumber": 383,
+      "referenceNumber": 307,
       "name": "European Union Public License 1.2",
       "licenseId": "EUPL-1.2",
       "seeAlso": [
@@ -4822,226 +3880,161 @@
       "isFsfLibre": true
     },
     {
-      "reference": "https://spdx.org/licenses/Adobe-Glyph.html",
+      "reference": "https://spdx.org/licenses/CC-BY-SA-3.0-AT.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Adobe-Glyph.json",
-      "referenceNumber": 384,
-      "name": "Adobe Glyph List License",
-      "licenseId": "Adobe-Glyph",
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-3.0-AT.json",
+      "referenceNumber": 308,
+      "name": "Creative Commons Attribution Share Alike 3.0 Austria",
+      "licenseId": "CC-BY-SA-3.0-AT",
       "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/MIT#AdobeGlyph"
+        "https://creativecommons.org/licenses/by-sa/3.0/at/legalcode"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/FreeImage.html",
+      "reference": "https://spdx.org/licenses/SSH-short.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/FreeImage.json",
-      "referenceNumber": 385,
-      "name": "FreeImage Public License v1.0",
-      "licenseId": "FreeImage",
+      "detailsUrl": "https://spdx.org/licenses/SSH-short.json",
+      "referenceNumber": 309,
+      "name": "SSH short notice",
+      "licenseId": "SSH-short",
       "seeAlso": [
-        "http://freeimage.sourceforge.net/freeimage-license.txt"
+        "https://github.com/openssh/openssh-portable/blob/1b11ea7c58cd5c59838b5fa574cd456d6047b2d4/pathnames.h",
+        "http://web.mit.edu/kolya/.f/root/athena.mit.edu/sipb.mit.edu/project/openssh/OldFiles/src/openssh-2.9.9p2/ssh-add.1",
+        "https://joinup.ec.europa.eu/svn/lesoll/trunk/italc/lib/src/dsa_key.cpp"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/Watcom-1.0.html",
+      "reference": "https://spdx.org/licenses/CC-BY-3.0-AT.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Watcom-1.0.json",
-      "referenceNumber": 386,
-      "name": "Sybase Open Watcom Public License 1.0",
-      "licenseId": "Watcom-1.0",
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-AT.json",
+      "referenceNumber": 310,
+      "name": "Creative Commons Attribution 3.0 Austria",
+      "licenseId": "CC-BY-3.0-AT",
       "seeAlso": [
-        "https://opensource.org/licenses/Watcom-1.0"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/Jam.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Jam.json",
-      "referenceNumber": 387,
-      "name": "Jam License",
-      "licenseId": "Jam",
-      "seeAlso": [
-        "https://www.boost.org/doc/libs/1_35_0/doc/html/jam.html",
-        "https://web.archive.org/web/20160330173339/https://swarm.workshop.perforce.com/files/guest/perforce_software/jam/src/README"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/Hippocratic-2.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Hippocratic-2.1.json",
-      "referenceNumber": 388,
-      "name": "Hippocratic License 2.1",
-      "licenseId": "Hippocratic-2.1",
-      "seeAlso": [
-        "https://firstdonoharm.dev/version/2/1/license.html",
-        "https://github.com/EthicalSource/hippocratic-license/blob/58c0e646d64ff6fbee275bfe2b9492f914e3ab2a/LICENSE.txt"
+        "https://creativecommons.org/licenses/by/3.0/at/legalcode"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/OLDAP-2.0.1.html",
+      "reference": "https://spdx.org/licenses/MIT-enna.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.0.1.json",
-      "referenceNumber": 389,
-      "name": "Open LDAP Public License v2.0.1",
-      "licenseId": "OLDAP-2.0.1",
+      "detailsUrl": "https://spdx.org/licenses/MIT-enna.json",
+      "referenceNumber": 311,
+      "name": "enna License",
+      "licenseId": "MIT-enna",
       "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003db6d68acd14e51ca3aab4428bf26522aa74873f0e"
+        "https://fedoraproject.org/wiki/Licensing/MIT#enna"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/CC-BY-NC-SA-2.0.html",
+      "reference": "https://spdx.org/licenses/CC-BY-3.0-US.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-2.0.json",
-      "referenceNumber": 390,
-      "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 Generic",
-      "licenseId": "CC-BY-NC-SA-2.0",
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-US.json",
+      "referenceNumber": 312,
+      "name": "Creative Commons Attribution 3.0 United States",
+      "licenseId": "CC-BY-3.0-US",
       "seeAlso": [
-        "https://creativecommons.org/licenses/by-nc-sa/2.0/legalcode"
+        "https://creativecommons.org/licenses/by/3.0/us/legalcode"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/Nokia.html",
+      "reference": "https://spdx.org/licenses/xpp.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Nokia.json",
-      "referenceNumber": 391,
-      "name": "Nokia Open Source License",
-      "licenseId": "Nokia",
+      "detailsUrl": "https://spdx.org/licenses/xpp.json",
+      "referenceNumber": 313,
+      "name": "XPP License",
+      "licenseId": "xpp",
       "seeAlso": [
-        "https://opensource.org/licenses/nokia"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/OCCT-PL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/OCCT-PL.json",
-      "referenceNumber": 392,
-      "name": "Open CASCADE Technology Public License",
-      "licenseId": "OCCT-PL",
-      "seeAlso": [
-        "http://www.opencascade.com/content/occt-public-license"
+        "https://fedoraproject.org/wiki/Licensing/xpp"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/ErlPL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/ErlPL-1.1.json",
-      "referenceNumber": 393,
-      "name": "Erlang Public License v1.1",
-      "licenseId": "ErlPL-1.1",
-      "seeAlso": [
-        "http://www.erlang.org/EPLICENSE"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/TOSL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/TOSL.json",
-      "referenceNumber": 394,
-      "name": "Trusster Open Source License",
-      "licenseId": "TOSL",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/TOSL"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/OSL-2.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/OSL-2.1.json",
-      "referenceNumber": 395,
-      "name": "Open Software License 2.1",
-      "licenseId": "OSL-2.1",
-      "seeAlso": [
-        "http://web.archive.org/web/20050212003940/http://www.rosenlaw.com/osl21.htm",
-        "https://opensource.org/licenses/OSL-2.1"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/ClArtistic.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/ClArtistic.json",
-      "referenceNumber": 396,
-      "name": "Clarified Artistic License",
-      "licenseId": "ClArtistic",
-      "seeAlso": [
-        "http://gianluca.dellavedova.org/2011/01/03/clarified-artistic-license/",
-        "http://www.ncftp.com/ncftp/doc/LICENSE.txt"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/xinetd.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/xinetd.json",
-      "referenceNumber": 397,
-      "name": "xinetd License",
-      "licenseId": "xinetd",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Xinetd_License"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/GPL-3.0-with-GCC-exception.html",
+      "reference": "https://spdx.org/licenses/GFDL-1.1.html",
       "isDeprecatedLicenseId": true,
-      "detailsUrl": "https://spdx.org/licenses/GPL-3.0-with-GCC-exception.json",
-      "referenceNumber": 398,
-      "name": "GNU General Public License v3.0 w/GCC Runtime Library exception",
-      "licenseId": "GPL-3.0-with-GCC-exception",
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.1.json",
+      "referenceNumber": 314,
+      "name": "GNU Free Documentation License v1.1",
+      "licenseId": "GFDL-1.1",
       "seeAlso": [
-        "https://www.gnu.org/licenses/gcc-exception-3.1.html"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/ODbL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/ODbL-1.0.json",
-      "referenceNumber": 399,
-      "name": "Open Data Commons Open Database License v1.0",
-      "licenseId": "ODbL-1.0",
-      "seeAlso": [
-        "http://www.opendatacommons.org/licenses/odbl/1.0/",
-        "https://opendatacommons.org/licenses/odbl/1-0/"
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
       ],
       "isOsiApproved": false,
       "isFsfLibre": true
     },
     {
-      "reference": "https://spdx.org/licenses/MIT.html",
+      "reference": "https://spdx.org/licenses/Condor-1.1.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/MIT.json",
-      "referenceNumber": 400,
-      "name": "MIT License",
-      "licenseId": "MIT",
+      "detailsUrl": "https://spdx.org/licenses/Condor-1.1.json",
+      "referenceNumber": 315,
+      "name": "Condor Public License v1.1",
+      "licenseId": "Condor-1.1",
       "seeAlso": [
-        "https://opensource.org/licenses/MIT"
+        "http://research.cs.wisc.edu/condor/license.html#condor",
+        "http://web.archive.org/web/20111123062036/http://research.cs.wisc.edu/condor/license.html#condor"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Bitstream-Vera.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Bitstream-Vera.json",
+      "referenceNumber": 316,
+      "name": "Bitstream Vera Font License",
+      "licenseId": "Bitstream-Vera",
+      "seeAlso": [
+        "https://web.archive.org/web/20080207013128/http://www.gnome.org/fonts/",
+        "https://docubrain.com/sites/default/files/licenses/bitstream-vera.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SPL-1.0.json",
+      "referenceNumber": 317,
+      "name": "Sun Public License v1.0",
+      "licenseId": "SPL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/SPL-1.0"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Baekmuk.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Baekmuk.json",
+      "referenceNumber": 318,
+      "name": "Baekmuk License",
+      "licenseId": "Baekmuk",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing:Baekmuk?rd\u003dLicensing/Baekmuk"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/DL-DE-BY-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/DL-DE-BY-2.0.json",
+      "referenceNumber": 319,
+      "name": "Data licence Germany – attribution – version 2.0",
+      "licenseId": "DL-DE-BY-2.0",
+      "seeAlso": [
+        "https://www.govdata.de/dl-de/by-2-0"
+      ],
+      "isOsiApproved": false
     },
     {
       "reference": "https://spdx.org/licenses/LGPL-2.1+.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/LGPL-2.1+.json",
-      "referenceNumber": 401,
+      "referenceNumber": 320,
       "name": "GNU Library General Public License v2.1 or later",
       "licenseId": "LGPL-2.1+",
       "seeAlso": [
@@ -5052,159 +4045,376 @@
       "isFsfLibre": true
     },
     {
-      "reference": "https://spdx.org/licenses/LGPL-2.1-only.html",
+      "reference": "https://spdx.org/licenses/GFDL-1.2-invariants-only.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/LGPL-2.1-only.json",
-      "referenceNumber": 402,
-      "name": "GNU Lesser General Public License v2.1 only",
-      "licenseId": "LGPL-2.1-only",
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-invariants-only.json",
+      "referenceNumber": 321,
+      "name": "GNU Free Documentation License v1.2 only - invariants",
+      "licenseId": "GFDL-1.2-invariants-only",
       "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
-        "https://opensource.org/licenses/LGPL-2.1"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/CrystalStacker.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CrystalStacker.json",
-      "referenceNumber": 403,
-      "name": "CrystalStacker License",
-      "licenseId": "CrystalStacker",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing:CrystalStacker?rd\u003dLicensing/CrystalStacker"
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/ECL-2.0.html",
+      "reference": "https://spdx.org/licenses/JSON.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/ECL-2.0.json",
-      "referenceNumber": 404,
-      "name": "Educational Community License v2.0",
-      "licenseId": "ECL-2.0",
+      "detailsUrl": "https://spdx.org/licenses/JSON.json",
+      "referenceNumber": 322,
+      "name": "JSON License",
+      "licenseId": "JSON",
       "seeAlso": [
-        "https://opensource.org/licenses/ECL-2.0"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/LPPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/LPPL-1.0.json",
-      "referenceNumber": 405,
-      "name": "LaTeX Project Public License v1.0",
-      "licenseId": "LPPL-1.0",
-      "seeAlso": [
-        "http://www.latex-project.org/lppl/lppl-1-0.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/iMatix.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/iMatix.json",
-      "referenceNumber": 406,
-      "name": "iMatix Standard Function Library Agreement",
-      "licenseId": "iMatix",
-      "seeAlso": [
-        "http://legacy.imatix.com/html/sfl/sfl4.htm#license"
+        "http://www.json.org/license.html"
       ],
       "isOsiApproved": false,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-3.0-with-autoconf-exception.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/GPL-3.0-with-autoconf-exception.json",
+      "referenceNumber": 323,
+      "name": "GNU General Public License v3.0 w/Autoconf exception",
+      "licenseId": "GPL-3.0-with-autoconf-exception",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/autoconf-exception-3.0.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/PostgreSQL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/PostgreSQL.json",
+      "referenceNumber": 324,
+      "name": "PostgreSQL License",
+      "licenseId": "PostgreSQL",
+      "seeAlso": [
+        "http://www.postgresql.org/about/licence",
+        "https://opensource.org/licenses/PostgreSQL"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/APSL-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/APSL-2.0.json",
+      "referenceNumber": 325,
+      "name": "Apple Public Source License 2.0",
+      "licenseId": "APSL-2.0",
+      "seeAlso": [
+        "http://www.opensource.apple.com/license/apsl/"
+      ],
+      "isOsiApproved": true,
       "isFsfLibre": true
     },
     {
-      "reference": "https://spdx.org/licenses/CC-BY-NC-ND-3.0-IGO.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-3.0-IGO.json",
-      "referenceNumber": 407,
-      "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 IGO",
-      "licenseId": "CC-BY-NC-ND-3.0-IGO",
+      "reference": "https://spdx.org/licenses/GPL-3.0+.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/GPL-3.0+.json",
+      "referenceNumber": 326,
+      "name": "GNU General Public License v3.0 or later",
+      "licenseId": "GPL-3.0+",
       "seeAlso": [
-        "https://creativecommons.org/licenses/by-nc-nd/3.0/igo/legalcode"
+        "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
+        "https://opensource.org/licenses/GPL-3.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/OGL-Canada-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OGL-Canada-2.0.json",
+      "referenceNumber": 327,
+      "name": "Open Government Licence - Canada",
+      "licenseId": "OGL-Canada-2.0",
+      "seeAlso": [
+        "https://open.canada.ca/en/open-government-licence-canada"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/BSD-Source-Code.html",
+      "reference": "https://spdx.org/licenses/Glide.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/BSD-Source-Code.json",
-      "referenceNumber": 408,
-      "name": "BSD Source Code Attribution",
-      "licenseId": "BSD-Source-Code",
+      "detailsUrl": "https://spdx.org/licenses/Glide.json",
+      "referenceNumber": 328,
+      "name": "3dfx Glide License",
+      "licenseId": "Glide",
       "seeAlso": [
-        "https://github.com/robbiehanson/CocoaHTTPServer/blob/master/LICENSE.txt"
+        "http://www.users.on.net/~triforce/glidexp/COPYING.txt"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/Parity-6.0.0.html",
+      "reference": "https://spdx.org/licenses/TOSL.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Parity-6.0.0.json",
-      "referenceNumber": 409,
-      "name": "The Parity Public License 6.0.0",
-      "licenseId": "Parity-6.0.0",
+      "detailsUrl": "https://spdx.org/licenses/TOSL.json",
+      "referenceNumber": 329,
+      "name": "Trusster Open Source License",
+      "licenseId": "TOSL",
       "seeAlso": [
-        "https://paritylicense.com/versions/6.0.0.html"
+        "https://fedoraproject.org/wiki/Licensing/TOSL"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/TCL.html",
+      "reference": "https://spdx.org/licenses/CC-BY-NC-ND-2.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/TCL.json",
-      "referenceNumber": 410,
-      "name": "TCL/TK License",
-      "licenseId": "TCL",
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-2.0.json",
+      "referenceNumber": 330,
+      "name": "Creative Commons Attribution Non Commercial No Derivatives 2.0 Generic",
+      "licenseId": "CC-BY-NC-ND-2.0",
       "seeAlso": [
-        "http://www.tcl.tk/software/tcltk/license.html",
-        "https://fedoraproject.org/wiki/Licensing/TCL"
+        "https://creativecommons.org/licenses/by-nc-nd/2.0/legalcode"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/Arphic-1999.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Arphic-1999.json",
-      "referenceNumber": 411,
-      "name": "Arphic Public License",
-      "licenseId": "Arphic-1999",
+      "reference": "https://spdx.org/licenses/wxWindows.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/wxWindows.json",
+      "referenceNumber": 331,
+      "name": "wxWindows Library License",
+      "licenseId": "wxWindows",
       "seeAlso": [
-        "http://ftp.gnu.org/gnu/non-gnu/chinese-fonts-truetype/LICENSE"
+        "https://opensource.org/licenses/WXwindows"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/NCGL-UK-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NCGL-UK-2.0.json",
+      "referenceNumber": 332,
+      "name": "Non-Commercial Government Licence",
+      "licenseId": "NCGL-UK-2.0",
+      "seeAlso": [
+        "http://www.nationalarchives.gov.uk/doc/non-commercial-government-licence/version/2/"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/CC-BY-SA-3.0.html",
+      "reference": "https://spdx.org/licenses/OGL-UK-3.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-3.0.json",
-      "referenceNumber": 412,
-      "name": "Creative Commons Attribution Share Alike 3.0 Unported",
-      "licenseId": "CC-BY-SA-3.0",
+      "detailsUrl": "https://spdx.org/licenses/OGL-UK-3.0.json",
+      "referenceNumber": 333,
+      "name": "Open Government Licence v3.0",
+      "licenseId": "OGL-UK-3.0",
       "seeAlso": [
-        "https://creativecommons.org/licenses/by-sa/3.0/legalcode"
+        "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/Caldera.html",
+      "reference": "https://spdx.org/licenses/OSL-1.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Caldera.json",
-      "referenceNumber": 413,
-      "name": "Caldera License",
-      "licenseId": "Caldera",
+      "detailsUrl": "https://spdx.org/licenses/OSL-1.0.json",
+      "referenceNumber": 334,
+      "name": "Open Software License 1.0",
+      "licenseId": "OSL-1.0",
       "seeAlso": [
-        "http://www.lemis.com/grog/UNIX/ancient-source-all.pdf"
+        "https://opensource.org/licenses/OSL-1.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-SA-2.5.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-2.5.json",
+      "referenceNumber": 335,
+      "name": "Creative Commons Attribution Non Commercial Share Alike 2.5 Generic",
+      "licenseId": "CC-BY-NC-SA-2.5",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-sa/2.5/legalcode"
       ],
       "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Artistic-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Artistic-2.0.json",
+      "referenceNumber": 336,
+      "name": "Artistic License 2.0",
+      "licenseId": "Artistic-2.0",
+      "seeAlso": [
+        "http://www.perlfoundation.org/artistic_license_2_0",
+        "https://www.perlfoundation.org/artistic-license-20.html",
+        "https://opensource.org/licenses/artistic-license-2.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/OLDAP-2.2.2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.2.2.json",
+      "referenceNumber": 337,
+      "name": "Open LDAP Public License 2.2.2",
+      "licenseId": "OLDAP-2.2.2",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003ddf2cc1e21eb7c160695f5b7cffd6296c151ba188"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/diffmark.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/diffmark.json",
+      "referenceNumber": 338,
+      "name": "diffmark license",
+      "licenseId": "diffmark",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/diffmark"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-3-Clause-Attribution.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Attribution.json",
+      "referenceNumber": 339,
+      "name": "BSD with attribution",
+      "licenseId": "BSD-3-Clause-Attribution",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/BSD_with_Attribution"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Dotseqn.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Dotseqn.json",
+      "referenceNumber": 340,
+      "name": "Dotseqn License",
+      "licenseId": "Dotseqn",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Dotseqn"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-ND-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-3.0.json",
+      "referenceNumber": 341,
+      "name": "Creative Commons Attribution No Derivatives 3.0 Unported",
+      "licenseId": "CC-BY-ND-3.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nd/3.0/legalcode"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/0BSD.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/0BSD.json",
+      "referenceNumber": 342,
+      "name": "BSD Zero Clause License",
+      "licenseId": "0BSD",
+      "seeAlso": [
+        "http://landley.net/toybox/license.html",
+        "https://opensource.org/licenses/0BSD"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/AGPL-3.0-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/AGPL-3.0-only.json",
+      "referenceNumber": 343,
+      "name": "GNU Affero General Public License v3.0 only",
+      "licenseId": "AGPL-3.0-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/agpl.txt",
+        "https://opensource.org/licenses/AGPL-3.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/OSL-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OSL-3.0.json",
+      "referenceNumber": 344,
+      "name": "Open Software License 3.0",
+      "licenseId": "OSL-3.0",
+      "seeAlso": [
+        "https://web.archive.org/web/20120101081418/http://rosenlaw.com:80/OSL3.0.htm",
+        "https://opensource.org/licenses/OSL-3.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Multics.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Multics.json",
+      "referenceNumber": 345,
+      "name": "Multics License",
+      "licenseId": "Multics",
+      "seeAlso": [
+        "https://opensource.org/licenses/Multics"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/NBPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NBPL-1.0.json",
+      "referenceNumber": 346,
+      "name": "Net Boolean Public License v1",
+      "licenseId": "NBPL-1.0",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d37b4b3f6cc4bf34e1d3dec61e69914b9819d8894"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/LGPL-2.0+.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/LGPL-2.0+.json",
+      "referenceNumber": 347,
+      "name": "GNU Library General Public License v2 or later",
+      "licenseId": "LGPL-2.0+",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-3.0-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GPL-3.0-or-later.json",
+      "referenceNumber": 348,
+      "name": "GNU General Public License v3.0 or later",
+      "licenseId": "GPL-3.0-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
+        "https://opensource.org/licenses/GPL-3.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-2-Clause.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause.json",
+      "referenceNumber": 349,
+      "name": "BSD 2-Clause \"Simplified\" License",
+      "licenseId": "BSD-2-Clause",
+      "seeAlso": [
+        "https://opensource.org/licenses/BSD-2-Clause"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
     },
     {
       "reference": "https://spdx.org/licenses/AGPL-1.0.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/AGPL-1.0.json",
-      "referenceNumber": 414,
+      "referenceNumber": 350,
       "name": "Affero General Public License v1.0",
       "licenseId": "AGPL-1.0",
       "seeAlso": [
@@ -5214,23 +4424,263 @@
       "isFsfLibre": true
     },
     {
-      "reference": "https://spdx.org/licenses/IPL-1.0.html",
+      "reference": "https://spdx.org/licenses/gSOAP-1.3b.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/IPL-1.0.json",
-      "referenceNumber": 415,
-      "name": "IBM Public License v1.0",
-      "licenseId": "IPL-1.0",
+      "detailsUrl": "https://spdx.org/licenses/gSOAP-1.3b.json",
+      "referenceNumber": 351,
+      "name": "gSOAP Public License v1.3b",
+      "licenseId": "gSOAP-1.3b",
       "seeAlso": [
-        "https://opensource.org/licenses/IPL-1.0"
+        "http://www.cs.fsu.edu/~engelen/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-4-Clause-UC.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-4-Clause-UC.json",
+      "referenceNumber": 352,
+      "name": "BSD-4-Clause (University of California-Specific)",
+      "licenseId": "BSD-4-Clause-UC",
+      "seeAlso": [
+        "http://www.freebsd.org/copyright/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/APL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/APL-1.0.json",
+      "referenceNumber": 353,
+      "name": "Adaptive Public License 1.0",
+      "licenseId": "APL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/APL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/eGenix.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/eGenix.json",
+      "referenceNumber": 354,
+      "name": "eGenix.com Public License 1.1.0",
+      "licenseId": "eGenix",
+      "seeAlso": [
+        "http://www.egenix.com/products/eGenix.com-Public-License-1.1.0.pdf",
+        "https://fedoraproject.org/wiki/Licensing/eGenix.com_Public_License_1.1.0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CERN-OHL-W-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CERN-OHL-W-2.0.json",
+      "referenceNumber": 355,
+      "name": "CERN Open Hardware Licence Version 2 - Weakly Reciprocal",
+      "licenseId": "CERN-OHL-W-2.0",
+      "seeAlso": [
+        "https://www.ohwr.org/project/cernohl/wikis/Documents/CERN-OHL-version-2"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-4.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-4.0.json",
+      "referenceNumber": 356,
+      "name": "Creative Commons Attribution Non Commercial 4.0 International",
+      "licenseId": "CC-BY-NC-4.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc/4.0/legalcode"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Bahyph.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Bahyph.json",
+      "referenceNumber": 357,
+      "name": "Bahyph License",
+      "licenseId": "Bahyph",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Bahyph"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/LGPL-3.0-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LGPL-3.0-only.json",
+      "referenceNumber": 358,
+      "name": "GNU Lesser General Public License v3.0 only",
+      "licenseId": "LGPL-3.0-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
+        "https://www.gnu.org/licenses/lgpl+gpl-3.0.txt",
+        "https://opensource.org/licenses/LGPL-3.0"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
     },
     {
+      "reference": "https://spdx.org/licenses/SNIA.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SNIA.json",
+      "referenceNumber": 359,
+      "name": "SNIA Public License 1.1",
+      "licenseId": "SNIA",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/SNIA_Public_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MIT-Modern-Variant.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MIT-Modern-Variant.json",
+      "referenceNumber": 360,
+      "name": "MIT License Modern Variant",
+      "licenseId": "MIT-Modern-Variant",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing:MIT#Modern_Variants",
+        "https://ptolemy.berkeley.edu/copyright.htm",
+        "https://pirlwww.lpl.arizona.edu/resources/guide/software/PerlTk/Tixlic.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Zlib.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Zlib.json",
+      "referenceNumber": 361,
+      "name": "zlib License",
+      "licenseId": "Zlib",
+      "seeAlso": [
+        "http://www.zlib.net/zlib_license.html",
+        "https://opensource.org/licenses/Zlib"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-SA-3.0-DE.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-3.0-DE.json",
+      "referenceNumber": 362,
+      "name": "Creative Commons Attribution Share Alike 3.0 Germany",
+      "licenseId": "CC-BY-SA-3.0-DE",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-sa/3.0/de/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/PHP-3.01.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/PHP-3.01.json",
+      "referenceNumber": 363,
+      "name": "PHP License v3.01",
+      "licenseId": "PHP-3.01",
+      "seeAlso": [
+        "http://www.php.net/license/3_01.txt"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/APSL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/APSL-1.1.json",
+      "referenceNumber": 364,
+      "name": "Apple Public Source License 1.1",
+      "licenseId": "APSL-1.1",
+      "seeAlso": [
+        "http://www.opensource.apple.com/source/IOSerialFamily/IOSerialFamily-7/APPLE_LICENSE"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-sell-variant.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-sell-variant.json",
+      "referenceNumber": 365,
+      "name": "Historical Permission Notice and Disclaimer - sell variant",
+      "licenseId": "HPND-sell-variant",
+      "seeAlso": [
+        "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/net/sunrpc/auth_gss/gss_generic_token.c?h\u003dv4.19"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-ND-4.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-4.0.json",
+      "referenceNumber": 366,
+      "name": "Creative Commons Attribution No Derivatives 4.0 International",
+      "licenseId": "CC-BY-ND-4.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nd/4.0/legalcode"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License.json",
+      "referenceNumber": 367,
+      "name": "BSD 3-Clause No Nuclear License",
+      "licenseId": "BSD-3-Clause-No-Nuclear-License",
+      "seeAlso": [
+        "http://download.oracle.com/otn-pub/java/licenses/bsd.txt?AuthParam\u003d1467140197_43d516ce1776bd08a58235a7785be1cc"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SWL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SWL.json",
+      "referenceNumber": 368,
+      "name": "Scheme Widget Library (SWL) Software License Agreement",
+      "licenseId": "SWL",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/SWL"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MPL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MPL-1.1.json",
+      "referenceNumber": 369,
+      "name": "Mozilla Public License 1.1",
+      "licenseId": "MPL-1.1",
+      "seeAlso": [
+        "http://www.mozilla.org/MPL/MPL-1.1.html",
+        "https://opensource.org/licenses/MPL-1.1"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CERN-OHL-P-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CERN-OHL-P-2.0.json",
+      "referenceNumber": 370,
+      "name": "CERN Open Hardware Licence Version 2 - Permissive",
+      "licenseId": "CERN-OHL-P-2.0",
+      "seeAlso": [
+        "https://www.ohwr.org/project/cernohl/wikis/Documents/CERN-OHL-version-2"
+      ],
+      "isOsiApproved": true
+    },
+    {
       "reference": "https://spdx.org/licenses/LAL-1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LAL-1.3.json",
-      "referenceNumber": 416,
+      "referenceNumber": 371,
       "name": "Licence Art Libre 1.3",
       "licenseId": "LAL-1.3",
       "seeAlso": [
@@ -5239,260 +4689,22 @@
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/EPICS.html",
+      "reference": "https://spdx.org/licenses/IBM-pibs.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/EPICS.json",
-      "referenceNumber": 417,
-      "name": "EPICS Open License",
-      "licenseId": "EPICS",
+      "detailsUrl": "https://spdx.org/licenses/IBM-pibs.json",
+      "referenceNumber": 372,
+      "name": "IBM PowerPC Initialization and Boot Software",
+      "licenseId": "IBM-pibs",
       "seeAlso": [
-        "https://epics.anl.gov/license/open.php"
+        "http://git.denx.de/?p\u003du-boot.git;a\u003dblob;f\u003darch/powerpc/cpu/ppc4xx/miiphy.c;h\u003d297155fdafa064b955e53e9832de93bfb0cfb85b;hb\u003d9fab4bf4cc077c21e43941866f3f2c196f28670d"
       ],
       "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/NGPL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/NGPL.json",
-      "referenceNumber": 418,
-      "name": "Nethack General Public License",
-      "licenseId": "NGPL",
-      "seeAlso": [
-        "https://opensource.org/licenses/NGPL"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/DRL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/DRL-1.0.json",
-      "referenceNumber": 419,
-      "name": "Detection Rule License 1.0",
-      "licenseId": "DRL-1.0",
-      "seeAlso": [
-        "https://github.com/Neo23x0/sigma/blob/master/LICENSE.Detection.Rules.md"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/BSD-2-Clause-NetBSD.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-NetBSD.json",
-      "referenceNumber": 420,
-      "name": "BSD 2-Clause NetBSD License",
-      "licenseId": "BSD-2-Clause-NetBSD",
-      "seeAlso": [
-        "http://www.netbsd.org/about/redistribution.html#default"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/ZPL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/ZPL-1.1.json",
-      "referenceNumber": 421,
-      "name": "Zope Public License 1.1",
-      "licenseId": "ZPL-1.1",
-      "seeAlso": [
-        "http://old.zope.org/Resources/License/ZPL-1.1"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/GD.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/GD.json",
-      "referenceNumber": 422,
-      "name": "GD License",
-      "licenseId": "GD",
-      "seeAlso": [
-        "https://libgd.github.io/manuals/2.3.0/files/license-txt.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/LPPL-1.2.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/LPPL-1.2.json",
-      "referenceNumber": 423,
-      "name": "LaTeX Project Public License v1.2",
-      "licenseId": "LPPL-1.2",
-      "seeAlso": [
-        "http://www.latex-project.org/lppl/lppl-1-2.txt"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/Dotseqn.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Dotseqn.json",
-      "referenceNumber": 424,
-      "name": "Dotseqn License",
-      "licenseId": "Dotseqn",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Dotseqn"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/Spencer-99.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Spencer-99.json",
-      "referenceNumber": 425,
-      "name": "Spencer License 99",
-      "licenseId": "Spencer-99",
-      "seeAlso": [
-        "http://www.opensource.apple.com/source/tcl/tcl-5/tcl/generic/regfronts.c"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/OLDAP-2.3.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.3.json",
-      "referenceNumber": 426,
-      "name": "Open LDAP Public License v2.3",
-      "licenseId": "OLDAP-2.3",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003dd32cf54a32d581ab475d23c810b0a7fbaf8d63c3"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/YPL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/YPL-1.1.json",
-      "referenceNumber": 427,
-      "name": "Yahoo! Public License v1.1",
-      "licenseId": "YPL-1.1",
-      "seeAlso": [
-        "http://www.zimbra.com/license/yahoo_public_license_1.1.html"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/Fair.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Fair.json",
-      "referenceNumber": 428,
-      "name": "Fair License",
-      "licenseId": "Fair",
-      "seeAlso": [
-        "http://fairlicense.org/",
-        "https://opensource.org/licenses/Fair"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/Qhull.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Qhull.json",
-      "referenceNumber": 429,
-      "name": "Qhull License",
-      "licenseId": "Qhull",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Qhull"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/GFDL-1.1-no-invariants-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-no-invariants-or-later.json",
-      "referenceNumber": 430,
-      "name": "GNU Free Documentation License v1.1 or later - no invariants",
-      "licenseId": "GFDL-1.1-no-invariants-or-later",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/CECILL-C.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CECILL-C.json",
-      "referenceNumber": 431,
-      "name": "CeCILL-C Free Software License Agreement",
-      "licenseId": "CECILL-C",
-      "seeAlso": [
-        "http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.html"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/MulanPSL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/MulanPSL-1.0.json",
-      "referenceNumber": 432,
-      "name": "Mulan Permissive Software License, Version 1",
-      "licenseId": "MulanPSL-1.0",
-      "seeAlso": [
-        "https://license.coscl.org.cn/MulanPSL/",
-        "https://github.com/yuwenlong/longphp/blob/25dfb70cc2a466dc4bb55ba30901cbce08d164b5/LICENSE"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/OLDAP-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/OLDAP-1.1.json",
-      "referenceNumber": 433,
-      "name": "Open LDAP Public License v1.1",
-      "licenseId": "OLDAP-1.1",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d806557a5ad59804ef3a44d5abfbe91d706b0791f"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/OLDAP-2.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.1.json",
-      "referenceNumber": 434,
-      "name": "Open LDAP Public License v2.1",
-      "licenseId": "OLDAP-2.1",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003db0d176738e96a0d3b9f85cb51e140a86f21be715"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/LPL-1.02.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/LPL-1.02.json",
-      "referenceNumber": 435,
-      "name": "Lucent Public License v1.02",
-      "licenseId": "LPL-1.02",
-      "seeAlso": [
-        "http://plan9.bell-labs.com/plan9/license.html",
-        "https://opensource.org/licenses/LPL-1.02"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/UPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/UPL-1.0.json",
-      "referenceNumber": 436,
-      "name": "Universal Permissive License v1.0",
-      "licenseId": "UPL-1.0",
-      "seeAlso": [
-        "https://opensource.org/licenses/UPL"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
     },
     {
       "reference": "https://spdx.org/licenses/Abstyles.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Abstyles.json",
-      "referenceNumber": 437,
+      "referenceNumber": 373,
       "name": "Abstyles License",
       "licenseId": "Abstyles",
       "seeAlso": [
@@ -5501,24 +4713,60 @@
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/ZPL-2.0.html",
+      "reference": "https://spdx.org/licenses/GFDL-1.3-or-later.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/ZPL-2.0.json",
-      "referenceNumber": 438,
-      "name": "Zope Public License 2.0",
-      "licenseId": "ZPL-2.0",
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-or-later.json",
+      "referenceNumber": 374,
+      "name": "GNU Free Documentation License v1.3 or later",
+      "licenseId": "GFDL-1.3-or-later",
       "seeAlso": [
-        "http://old.zope.org/Resources/License/ZPL-2.0",
-        "https://opensource.org/licenses/ZPL-2.0"
+        "https://www.gnu.org/licenses/fdl-1.3.txt"
       ],
-      "isOsiApproved": true,
+      "isOsiApproved": false,
       "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CECILL-B.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CECILL-B.json",
+      "referenceNumber": 375,
+      "name": "CeCILL-B Free Software License Agreement",
+      "licenseId": "CECILL-B",
+      "seeAlso": [
+        "http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.html"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.1-no-invariants-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-no-invariants-or-later.json",
+      "referenceNumber": 376,
+      "name": "GNU Free Documentation License v1.1 or later - no invariants",
+      "licenseId": "GFDL-1.1-no-invariants-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CECILL-2.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CECILL-2.1.json",
+      "referenceNumber": 377,
+      "name": "CeCILL Free Software License Agreement v2.1",
+      "licenseId": "CECILL-2.1",
+      "seeAlso": [
+        "http://www.cecill.info/licences/Licence_CeCILL_V2.1-en.html"
+      ],
+      "isOsiApproved": true
     },
     {
       "reference": "https://spdx.org/licenses/MIT-0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-0.json",
-      "referenceNumber": 439,
+      "referenceNumber": 378,
       "name": "MIT No Attribution",
       "licenseId": "MIT-0",
       "seeAlso": [
@@ -5527,6 +4775,775 @@
         "https://github.com/awsdocs/aws-cloud9-user-guide/blob/master/LICENSE-SAMPLECODE"
       ],
       "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Sendmail.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Sendmail.json",
+      "referenceNumber": 379,
+      "name": "Sendmail License",
+      "licenseId": "Sendmail",
+      "seeAlso": [
+        "http://www.sendmail.com/pdfs/open_source/sendmail_license.pdf",
+        "https://web.archive.org/web/20160322142305/https://www.sendmail.com/pdfs/open_source/sendmail_license.pdf"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/AMDPLPA.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/AMDPLPA.json",
+      "referenceNumber": 380,
+      "name": "AMD\u0027s plpa_map.c License",
+      "licenseId": "AMDPLPA",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/AMD_plpa_map_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/FreeBSD-DOC.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/FreeBSD-DOC.json",
+      "referenceNumber": 381,
+      "name": "FreeBSD Documentation License",
+      "licenseId": "FreeBSD-DOC",
+      "seeAlso": [
+        "https://www.freebsd.org/copyright/freebsd-doc-license/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/WTFPL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/WTFPL.json",
+      "referenceNumber": 382,
+      "name": "Do What The F*ck You Want To Public License",
+      "licenseId": "WTFPL",
+      "seeAlso": [
+        "http://www.wtfpl.net/about/",
+        "http://sam.zoy.org/wtfpl/COPYING"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/NASA-1.3.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NASA-1.3.json",
+      "referenceNumber": 383,
+      "name": "NASA Open Source Agreement 1.3",
+      "licenseId": "NASA-1.3",
+      "seeAlso": [
+        "http://ti.arc.nasa.gov/opensource/nosa/",
+        "https://opensource.org/licenses/NASA-1.3"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/mpich2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/mpich2.json",
+      "referenceNumber": 384,
+      "name": "mpich2 License",
+      "licenseId": "mpich2",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/MIT"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-ND-3.0-DE.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-3.0-DE.json",
+      "referenceNumber": 385,
+      "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 Germany",
+      "licenseId": "CC-BY-NC-ND-3.0-DE",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-nd/3.0/de/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/EPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/EPL-1.0.json",
+      "referenceNumber": 386,
+      "name": "Eclipse Public License 1.0",
+      "licenseId": "EPL-1.0",
+      "seeAlso": [
+        "http://www.eclipse.org/legal/epl-v10.html",
+        "https://opensource.org/licenses/EPL-1.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/DOC.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/DOC.json",
+      "referenceNumber": 387,
+      "name": "DOC License",
+      "licenseId": "DOC",
+      "seeAlso": [
+        "http://www.cs.wustl.edu/~schmidt/ACE-copying.html",
+        "https://www.dre.vanderbilt.edu/~schmidt/ACE-copying.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-2-Clause-Patent.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-Patent.json",
+      "referenceNumber": 388,
+      "name": "BSD-2-Clause Plus Patent License",
+      "licenseId": "BSD-2-Clause-Patent",
+      "seeAlso": [
+        "https://opensource.org/licenses/BSDplusPatent"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/AGPL-1.0-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/AGPL-1.0-only.json",
+      "referenceNumber": 389,
+      "name": "Affero General Public License v1.0 only",
+      "licenseId": "AGPL-1.0-only",
+      "seeAlso": [
+        "http://www.affero.org/oagpl.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Latex2e.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Latex2e.json",
+      "referenceNumber": 390,
+      "name": "Latex2e License",
+      "licenseId": "Latex2e",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Latex2e"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/UCL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/UCL-1.0.json",
+      "referenceNumber": 391,
+      "name": "Upstream Compatibility License v1.0",
+      "licenseId": "UCL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/UCL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/ECL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ECL-1.0.json",
+      "referenceNumber": 392,
+      "name": "Educational Community License v1.0",
+      "licenseId": "ECL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/ECL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-SA-2.0-UK.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-2.0-UK.json",
+      "referenceNumber": 393,
+      "name": "Creative Commons Attribution Share Alike 2.0 England and Wales",
+      "licenseId": "CC-BY-SA-2.0-UK",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-sa/2.0/uk/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-2.0-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GPL-2.0-only.json",
+      "referenceNumber": 394,
+      "name": "GNU General Public License v2.0 only",
+      "licenseId": "GPL-2.0-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
+        "https://opensource.org/licenses/GPL-2.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Unicode-DFS-2015.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Unicode-DFS-2015.json",
+      "referenceNumber": 395,
+      "name": "Unicode License Agreement - Data Files and Software (2015)",
+      "licenseId": "Unicode-DFS-2015",
+      "seeAlso": [
+        "https://web.archive.org/web/20151224134844/http://unicode.org/copyright.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/PolyForm-Small-Business-1.0.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/PolyForm-Small-Business-1.0.0.json",
+      "referenceNumber": 396,
+      "name": "PolyForm Small Business License 1.0.0",
+      "licenseId": "PolyForm-Small-Business-1.0.0",
+      "seeAlso": [
+        "https://polyformproject.org/licenses/small-business/1.0.0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.2.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.2.json",
+      "referenceNumber": 397,
+      "name": "GNU Free Documentation License v1.2",
+      "licenseId": "GFDL-1.2",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/TU-Berlin-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/TU-Berlin-1.0.json",
+      "referenceNumber": 398,
+      "name": "Technische Universitaet Berlin License 1.0",
+      "licenseId": "TU-Berlin-1.0",
+      "seeAlso": [
+        "https://github.com/swh/ladspa/blob/7bf6f3799fdba70fda297c2d8fd9f526803d9680/gsm/COPYRIGHT"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Apache-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Apache-1.1.json",
+      "referenceNumber": 399,
+      "name": "Apache License 1.1",
+      "licenseId": "Apache-1.1",
+      "seeAlso": [
+        "http://apache.org/licenses/LICENSE-1.1",
+        "https://opensource.org/licenses/Apache-1.1"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/GLWTPL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GLWTPL.json",
+      "referenceNumber": 400,
+      "name": "Good Luck With That Public License",
+      "licenseId": "GLWTPL",
+      "seeAlso": [
+        "https://github.com/me-shaon/GLWTPL/commit/da5f6bc734095efbacb442c0b31e33a65b9d6e85"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Giftware.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Giftware.json",
+      "referenceNumber": 401,
+      "name": "Giftware License",
+      "licenseId": "Giftware",
+      "seeAlso": [
+        "http://liballeg.org/license.html#allegro-4-the-giftware-license"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OLDAP-2.4.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.4.json",
+      "referenceNumber": 402,
+      "name": "Open LDAP Public License v2.4",
+      "licenseId": "OLDAP-2.4",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003dcd1284c4a91a8a380d904eee68d1583f989ed386"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/NRL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NRL.json",
+      "referenceNumber": 403,
+      "name": "NRL License",
+      "licenseId": "NRL",
+      "seeAlso": [
+        "http://web.mit.edu/network/isakmp/nrllicense.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Caldera.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Caldera.json",
+      "referenceNumber": 404,
+      "name": "Caldera License",
+      "licenseId": "Caldera",
+      "seeAlso": [
+        "http://www.lemis.com/grog/UNIX/ancient-source-all.pdf"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/bzip2-1.0.6.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/bzip2-1.0.6.json",
+      "referenceNumber": 405,
+      "name": "bzip2 and libbzip2 License v1.0.6",
+      "licenseId": "bzip2-1.0.6",
+      "seeAlso": [
+        "https://sourceware.org/git/?p\u003dbzip2.git;a\u003dblob;f\u003dLICENSE;hb\u003dbzip2-1.0.6",
+        "http://bzip.org/1.0.5/bzip2-manual-1.0.5.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SGI-B-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SGI-B-1.1.json",
+      "referenceNumber": 406,
+      "name": "SGI Free Software License B v1.1",
+      "licenseId": "SGI-B-1.1",
+      "seeAlso": [
+        "http://oss.sgi.com/projects/FreeB/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/etalab-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/etalab-2.0.json",
+      "referenceNumber": 407,
+      "name": "Etalab Open License 2.0",
+      "licenseId": "etalab-2.0",
+      "seeAlso": [
+        "https://github.com/DISIC/politique-de-contribution-open-source/blob/master/LICENSE.pdf",
+        "https://raw.githubusercontent.com/DISIC/politique-de-contribution-open-source/master/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/JasPer-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/JasPer-2.0.json",
+      "referenceNumber": 408,
+      "name": "JasPer License",
+      "licenseId": "JasPer-2.0",
+      "seeAlso": [
+        "http://www.ece.uvic.ca/~mdadams/jasper/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/RHeCos-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/RHeCos-1.1.json",
+      "referenceNumber": 409,
+      "name": "Red Hat eCos Public License v1.1",
+      "licenseId": "RHeCos-1.1",
+      "seeAlso": [
+        "http://ecos.sourceware.org/old-license.html"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/NTP-0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NTP-0.json",
+      "referenceNumber": 410,
+      "name": "NTP No Attribution",
+      "licenseId": "NTP-0",
+      "seeAlso": [
+        "https://github.com/tytso/e2fsprogs/blob/master/lib/et/et_name.c"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-2.5.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-2.5.json",
+      "referenceNumber": 411,
+      "name": "Creative Commons Attribution Non Commercial 2.5 Generic",
+      "licenseId": "CC-BY-NC-2.5",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc/2.5/legalcode"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/ZPL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ZPL-1.1.json",
+      "referenceNumber": 412,
+      "name": "Zope Public License 1.1",
+      "licenseId": "ZPL-1.1",
+      "seeAlso": [
+        "http://old.zope.org/Resources/License/ZPL-1.1"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/RPL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/RPL-1.1.json",
+      "referenceNumber": 413,
+      "name": "Reciprocal Public License 1.1",
+      "licenseId": "RPL-1.1",
+      "seeAlso": [
+        "https://opensource.org/licenses/RPL-1.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/PHP-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/PHP-3.0.json",
+      "referenceNumber": 414,
+      "name": "PHP License v3.0",
+      "licenseId": "PHP-3.0",
+      "seeAlso": [
+        "http://www.php.net/license/3_0.txt",
+        "https://opensource.org/licenses/PHP-3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/SAX-PD.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SAX-PD.json",
+      "referenceNumber": 415,
+      "name": "Sax Public Domain Notice",
+      "licenseId": "SAX-PD",
+      "seeAlso": [
+        "http://www.saxproject.org/copying.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/NIST-PD.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NIST-PD.json",
+      "referenceNumber": 416,
+      "name": "NIST Public Domain Notice",
+      "licenseId": "NIST-PD",
+      "seeAlso": [
+        "https://github.com/tcheneau/simpleRPL/blob/e645e69e38dd4e3ccfeceb2db8cba05b7c2e0cd3/LICENSE.txt",
+        "https://github.com/tcheneau/Routing/blob/f09f46fcfe636107f22f2c98348188a65a135d98/README.md"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/EFL-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/EFL-2.0.json",
+      "referenceNumber": 417,
+      "name": "Eiffel Forum License v2.0",
+      "licenseId": "EFL-2.0",
+      "seeAlso": [
+        "http://www.eiffel-nice.org/license/eiffel-forum-license-2.html",
+        "https://opensource.org/licenses/EFL-2.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Info-ZIP.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Info-ZIP.json",
+      "referenceNumber": 418,
+      "name": "Info-ZIP License",
+      "licenseId": "Info-ZIP",
+      "seeAlso": [
+        "http://www.info-zip.org/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-SA-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-1.0.json",
+      "referenceNumber": 419,
+      "name": "Creative Commons Attribution Share Alike 1.0 Generic",
+      "licenseId": "CC-BY-SA-1.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-sa/1.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/LGPL-3.0+.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/LGPL-3.0+.json",
+      "referenceNumber": 420,
+      "name": "GNU Lesser General Public License v3.0 or later",
+      "licenseId": "LGPL-3.0+",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
+        "https://www.gnu.org/licenses/lgpl+gpl-3.0.txt",
+        "https://opensource.org/licenses/LGPL-3.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CDL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CDL-1.0.json",
+      "referenceNumber": 421,
+      "name": "Common Documentation License 1.0",
+      "licenseId": "CDL-1.0",
+      "seeAlso": [
+        "http://www.opensource.apple.com/cdl/",
+        "https://fedoraproject.org/wiki/Licensing/Common_Documentation_License",
+        "https://www.gnu.org/licenses/license-list.html#ACDL"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SMLNJ.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SMLNJ.json",
+      "referenceNumber": 422,
+      "name": "Standard ML of New Jersey License",
+      "licenseId": "SMLNJ",
+      "seeAlso": [
+        "https://www.smlnj.org/license.html"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-ND-2.5.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-2.5.json",
+      "referenceNumber": 423,
+      "name": "Creative Commons Attribution No Derivatives 2.5 Generic",
+      "licenseId": "CC-BY-ND-2.5",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nd/2.5/legalcode"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.2-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-or-later.json",
+      "referenceNumber": 424,
+      "name": "GNU Free Documentation License v1.2 or later",
+      "licenseId": "GFDL-1.2-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-SA-3.0-IGO.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-3.0-IGO.json",
+      "referenceNumber": 425,
+      "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 IGO",
+      "licenseId": "CC-BY-NC-SA-3.0-IGO",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-sa/3.0/igo/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Vim.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Vim.json",
+      "referenceNumber": 426,
+      "name": "Vim License",
+      "licenseId": "Vim",
+      "seeAlso": [
+        "http://vimdoc.sourceforge.net/htmldoc/uganda.html"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-SA-3.0-DE.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-3.0-DE.json",
+      "referenceNumber": 427,
+      "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 Germany",
+      "licenseId": "CC-BY-NC-SA-3.0-DE",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-sa/3.0/de/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Noweb.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Noweb.json",
+      "referenceNumber": 428,
+      "name": "Noweb License",
+      "licenseId": "Noweb",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Noweb"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Aladdin.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Aladdin.json",
+      "referenceNumber": 429,
+      "name": "Aladdin Free Public License",
+      "licenseId": "Aladdin",
+      "seeAlso": [
+        "http://pages.cs.wisc.edu/~ghost/doc/AFPL/6.01/Public.htm"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/LPPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LPPL-1.0.json",
+      "referenceNumber": 430,
+      "name": "LaTeX Project Public License v1.0",
+      "licenseId": "LPPL-1.0",
+      "seeAlso": [
+        "http://www.latex-project.org/lppl/lppl-1-0.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/W3C.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/W3C.json",
+      "referenceNumber": 431,
+      "name": "W3C Software Notice and License (2002-12-31)",
+      "licenseId": "W3C",
+      "seeAlso": [
+        "http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231.html",
+        "https://opensource.org/licenses/W3C"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/FSFAP.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/FSFAP.json",
+      "referenceNumber": 432,
+      "name": "FSF All Permissive License",
+      "licenseId": "FSFAP",
+      "seeAlso": [
+        "https://www.gnu.org/prep/maintain/html_node/License-Notices-for-Other-Files.html"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/SSH-OpenSSH.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SSH-OpenSSH.json",
+      "referenceNumber": 433,
+      "name": "SSH OpenSSH license",
+      "licenseId": "SSH-OpenSSH",
+      "seeAlso": [
+        "https://github.com/openssh/openssh-portable/blob/1b11ea7c58cd5c59838b5fa574cd456d6047b2d4/LICENCE#L10"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.3-no-invariants-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-no-invariants-only.json",
+      "referenceNumber": 434,
+      "name": "GNU Free Documentation License v1.3 only - no invariants",
+      "licenseId": "GFDL-1.3-no-invariants-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/fdl-1.3.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SISSL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SISSL.json",
+      "referenceNumber": 435,
+      "name": "Sun Industry Standards Source License v1.1",
+      "licenseId": "SISSL",
+      "seeAlso": [
+        "http://www.openoffice.org/licenses/sissl_license.html",
+        "https://opensource.org/licenses/SISSL"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CNRI-Python-GPL-Compatible.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CNRI-Python-GPL-Compatible.json",
+      "referenceNumber": 436,
+      "name": "CNRI Python Open Source GPL Compatible License Agreement",
+      "licenseId": "CNRI-Python-GPL-Compatible",
+      "seeAlso": [
+        "http://www.python.org/download/releases/1.6.1/download_win/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MPL-1.0.json",
+      "referenceNumber": 437,
+      "name": "Mozilla Public License 1.0",
+      "licenseId": "MPL-1.0",
+      "seeAlso": [
+        "http://www.mozilla.org/MPL/MPL-1.0.html",
+        "https://opensource.org/licenses/MPL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Barr.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Barr.json",
+      "referenceNumber": 438,
+      "name": "Barr License",
+      "licenseId": "Barr",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Barr"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MTLL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MTLL.json",
+      "referenceNumber": 439,
+      "name": "Matrix Template Library License",
+      "licenseId": "MTLL",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Matrix_Template_Library_License"
+      ],
+      "isOsiApproved": false
     },
     {
       "reference": "https://spdx.org/licenses/LGPL-2.0-only.html",
@@ -5541,242 +5558,38 @@
       "isOsiApproved": true
     },
     {
-      "reference": "https://spdx.org/licenses/GFDL-1.3-no-invariants-only.html",
+      "reference": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-FR.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-no-invariants-only.json",
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-FR.json",
       "referenceNumber": 441,
-      "name": "GNU Free Documentation License v1.3 only - no invariants",
-      "licenseId": "GFDL-1.3-no-invariants-only",
+      "name": "Creative Commons Attribution-NonCommercial-ShareAlike 2.0 France",
+      "licenseId": "CC-BY-NC-SA-2.0-FR",
       "seeAlso": [
-        "https://www.gnu.org/licenses/fdl-1.3.txt"
+        "https://creativecommons.org/licenses/by-nc-sa/2.0/fr/legalcode"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/AGPL-3.0.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "https://spdx.org/licenses/AGPL-3.0.json",
+      "reference": "https://spdx.org/licenses/CC-BY-3.0-IGO.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-IGO.json",
       "referenceNumber": 442,
-      "name": "GNU Affero General Public License v3.0",
-      "licenseId": "AGPL-3.0",
+      "name": "Creative Commons Attribution 3.0 IGO",
+      "licenseId": "CC-BY-3.0-IGO",
       "seeAlso": [
-        "https://www.gnu.org/licenses/agpl.txt",
-        "https://opensource.org/licenses/AGPL-3.0"
+        "https://creativecommons.org/licenses/by/3.0/igo/legalcode"
       ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
+      "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/EPL-2.0.html",
+      "reference": "https://spdx.org/licenses/AML.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/EPL-2.0.json",
+      "detailsUrl": "https://spdx.org/licenses/AML.json",
       "referenceNumber": 443,
-      "name": "Eclipse Public License 2.0",
-      "licenseId": "EPL-2.0",
+      "name": "Apple MIT License",
+      "licenseId": "AML",
       "seeAlso": [
-        "https://www.eclipse.org/legal/epl-2.0",
-        "https://www.opensource.org/licenses/EPL-2.0"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/AFL-3.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/AFL-3.0.json",
-      "referenceNumber": 444,
-      "name": "Academic Free License v3.0",
-      "licenseId": "AFL-3.0",
-      "seeAlso": [
-        "http://www.rosenlaw.com/AFL3.0.htm",
-        "https://opensource.org/licenses/afl-3.0"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/CDLA-Permissive-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CDLA-Permissive-1.0.json",
-      "referenceNumber": 445,
-      "name": "Community Data License Agreement Permissive 1.0",
-      "licenseId": "CDLA-Permissive-1.0",
-      "seeAlso": [
-        "https://cdla.io/permissive-1-0"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/Artistic-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Artistic-1.0.json",
-      "referenceNumber": 446,
-      "name": "Artistic License 1.0",
-      "licenseId": "Artistic-1.0",
-      "seeAlso": [
-        "https://opensource.org/licenses/Artistic-1.0"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/CC-BY-NC-ND-4.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-4.0.json",
-      "referenceNumber": 447,
-      "name": "Creative Commons Attribution Non Commercial No Derivatives 4.0 International",
-      "licenseId": "CC-BY-NC-ND-4.0",
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/HTMLTIDY.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/HTMLTIDY.json",
-      "referenceNumber": 448,
-      "name": "HTML Tidy License",
-      "licenseId": "HTMLTIDY",
-      "seeAlso": [
-        "https://github.com/htacg/tidy-html5/blob/next/README/LICENSE.md"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/Glide.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Glide.json",
-      "referenceNumber": 449,
-      "name": "3dfx Glide License",
-      "licenseId": "Glide",
-      "seeAlso": [
-        "http://www.users.on.net/~triforce/glidexp/COPYING.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/FSFAP.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/FSFAP.json",
-      "referenceNumber": 450,
-      "name": "FSF All Permissive License",
-      "licenseId": "FSFAP",
-      "seeAlso": [
-        "https://www.gnu.org/prep/maintain/html_node/License-Notices-for-Other-Files.html"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/LGPLLR.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/LGPLLR.json",
-      "referenceNumber": 451,
-      "name": "Lesser General Public License For Linguistic Resources",
-      "licenseId": "LGPLLR",
-      "seeAlso": [
-        "http://www-igm.univ-mlv.fr/~unitex/lgpllr.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/OGL-UK-3.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/OGL-UK-3.0.json",
-      "referenceNumber": 452,
-      "name": "Open Government Licence v3.0",
-      "licenseId": "OGL-UK-3.0",
-      "seeAlso": [
-        "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/GFDL-1.2.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "https://spdx.org/licenses/GFDL-1.2.json",
-      "referenceNumber": 453,
-      "name": "GNU Free Documentation License v1.2",
-      "licenseId": "GFDL-1.2",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/SSH-OpenSSH.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/SSH-OpenSSH.json",
-      "referenceNumber": 454,
-      "name": "SSH OpenSSH license",
-      "licenseId": "SSH-OpenSSH",
-      "seeAlso": [
-        "https://github.com/openssh/openssh-portable/blob/1b11ea7c58cd5c59838b5fa574cd456d6047b2d4/LICENCE#L10"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/GFDL-1.1-only.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-only.json",
-      "referenceNumber": 455,
-      "name": "GNU Free Documentation License v1.1 only",
-      "licenseId": "GFDL-1.1-only",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/MIT-feh.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/MIT-feh.json",
-      "referenceNumber": 456,
-      "name": "feh License",
-      "licenseId": "MIT-feh",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/MIT#feh"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/MPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/MPL-1.0.json",
-      "referenceNumber": 457,
-      "name": "Mozilla Public License 1.0",
-      "licenseId": "MPL-1.0",
-      "seeAlso": [
-        "http://www.mozilla.org/MPL/MPL-1.0.html",
-        "https://opensource.org/licenses/MPL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/PostgreSQL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/PostgreSQL.json",
-      "referenceNumber": 458,
-      "name": "PostgreSQL License",
-      "licenseId": "PostgreSQL",
-      "seeAlso": [
-        "http://www.postgresql.org/about/licence",
-        "https://opensource.org/licenses/PostgreSQL"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/OLDAP-2.2.2.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.2.2.json",
-      "referenceNumber": 459,
-      "name": "Open LDAP Public License 2.2.2",
-      "licenseId": "OLDAP-2.2.2",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003ddf2cc1e21eb7c160695f5b7cffd6296c151ba188"
+        "https://fedoraproject.org/wiki/Licensing/Apple_MIT_License"
       ],
       "isOsiApproved": false
     },
@@ -5784,7 +5597,7 @@
       "reference": "https://spdx.org/licenses/SMPPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SMPPL.json",
-      "referenceNumber": 460,
+      "referenceNumber": 444,
       "name": "Secure Messaging Protocol Public License",
       "licenseId": "SMPPL",
       "seeAlso": [
@@ -5793,36 +5606,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/OFL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/OFL-1.1.json",
-      "referenceNumber": 461,
-      "name": "SIL Open Font License 1.1",
-      "licenseId": "OFL-1.1",
-      "seeAlso": [
-        "http://scripts.sil.org/cms/scripts/page.php?item_id\u003dOFL_web",
-        "https://opensource.org/licenses/OFL-1.1"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/Leptonica.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Leptonica.json",
-      "referenceNumber": 462,
-      "name": "Leptonica License",
-      "licenseId": "Leptonica",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Leptonica"
-      ],
-      "isOsiApproved": false
-    },
-    {
       "reference": "https://spdx.org/licenses/CERN-OHL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CERN-OHL-1.1.json",
-      "referenceNumber": 463,
+      "referenceNumber": 445,
       "name": "CERN Open Hardware Licence v1.1",
       "licenseId": "CERN-OHL-1.1",
       "seeAlso": [
@@ -5831,162 +5618,571 @@
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-Warranty.html",
+      "reference": "https://spdx.org/licenses/OSL-2.1.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-Warranty.json",
-      "referenceNumber": 464,
-      "name": "BSD 3-Clause No Nuclear Warranty",
-      "licenseId": "BSD-3-Clause-No-Nuclear-Warranty",
+      "detailsUrl": "https://spdx.org/licenses/OSL-2.1.json",
+      "referenceNumber": 446,
+      "name": "Open Software License 2.1",
+      "licenseId": "OSL-2.1",
       "seeAlso": [
-        "https://jogamp.org/git/?p\u003dgluegen.git;a\u003dblob_plain;f\u003dLICENSE.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/CC-BY-ND-2.5.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-2.5.json",
-      "referenceNumber": 465,
-      "name": "Creative Commons Attribution No Derivatives 2.5 Generic",
-      "licenseId": "CC-BY-ND-2.5",
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-nd/2.5/legalcode"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/CC-BY-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/CC-BY-1.0.json",
-      "referenceNumber": 466,
-      "name": "Creative Commons Attribution 1.0 Generic",
-      "licenseId": "CC-BY-1.0",
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by/1.0/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/GFDL-1.2-only.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-only.json",
-      "referenceNumber": 467,
-      "name": "GNU Free Documentation License v1.2 only",
-      "licenseId": "GFDL-1.2-only",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/OPUBL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/OPUBL-1.0.json",
-      "referenceNumber": 468,
-      "name": "Open Publication License v1.0",
-      "licenseId": "OPUBL-1.0",
-      "seeAlso": [
-        "http://opencontent.org/openpub/",
-        "https://www.debian.org/opl",
-        "https://www.ctan.org/license/opl"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/libselinux-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/libselinux-1.0.json",
-      "referenceNumber": 469,
-      "name": "libselinux public domain notice",
-      "licenseId": "libselinux-1.0",
-      "seeAlso": [
-        "https://github.com/SELinuxProject/selinux/blob/master/libselinux/LICENSE"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/BSD-3-Clause.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause.json",
-      "referenceNumber": 470,
-      "name": "BSD 3-Clause \"New\" or \"Revised\" License",
-      "licenseId": "BSD-3-Clause",
-      "seeAlso": [
-        "https://opensource.org/licenses/BSD-3-Clause"
+        "http://web.archive.org/web/20050212003940/http://www.rosenlaw.com/osl21.htm",
+        "https://opensource.org/licenses/OSL-2.1"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
     },
     {
-      "reference": "https://spdx.org/licenses/ANTLR-PD-fallback.html",
+      "reference": "https://spdx.org/licenses/GPL-2.0-or-later.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/ANTLR-PD-fallback.json",
-      "referenceNumber": 471,
-      "name": "ANTLR Software Rights Notice with license fallback",
-      "licenseId": "ANTLR-PD-fallback",
+      "detailsUrl": "https://spdx.org/licenses/GPL-2.0-or-later.json",
+      "referenceNumber": 447,
+      "name": "GNU General Public License v2.0 or later",
+      "licenseId": "GPL-2.0-or-later",
       "seeAlso": [
-        "http://www.antlr2.org/license.html"
+        "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
+        "https://opensource.org/licenses/GPL-2.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/ODC-By-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ODC-By-1.0.json",
+      "referenceNumber": 448,
+      "name": "Open Data Commons Attribution License v1.0",
+      "licenseId": "ODC-By-1.0",
+      "seeAlso": [
+        "https://opendatacommons.org/licenses/by/1.0/"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/copyleft-next-0.3.1.html",
+      "reference": "https://spdx.org/licenses/Qhull.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/copyleft-next-0.3.1.json",
-      "referenceNumber": 472,
-      "name": "copyleft-next 0.3.1",
-      "licenseId": "copyleft-next-0.3.1",
+      "detailsUrl": "https://spdx.org/licenses/Qhull.json",
+      "referenceNumber": 449,
+      "name": "Qhull License",
+      "licenseId": "Qhull",
       "seeAlso": [
-        "https://github.com/copyleft-next/copyleft-next/blob/master/Releases/copyleft-next-0.3.1"
+        "https://fedoraproject.org/wiki/Licensing/Qhull"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/GPL-1.0+.html",
+      "reference": "https://spdx.org/licenses/BSD-1-Clause.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-1-Clause.json",
+      "referenceNumber": 450,
+      "name": "BSD 1-Clause License",
+      "licenseId": "BSD-1-Clause",
+      "seeAlso": [
+        "https://svnweb.freebsd.org/base/head/include/ifaddrs.h?revision\u003d326823"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/NCSA.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NCSA.json",
+      "referenceNumber": 451,
+      "name": "University of Illinois/NCSA Open Source License",
+      "licenseId": "NCSA",
+      "seeAlso": [
+        "http://otm.illinois.edu/uiuc_openSource",
+        "https://opensource.org/licenses/NCSA"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/AFL-1.2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/AFL-1.2.json",
+      "referenceNumber": 452,
+      "name": "Academic Free License v1.2",
+      "licenseId": "AFL-1.2",
+      "seeAlso": [
+        "http://opensource.linux-mirror.org/licenses/afl-1.2.txt",
+        "http://wayback.archive.org/web/20021204204652/http://www.opensource.org/licenses/academic.php"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/psutils.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/psutils.json",
+      "referenceNumber": 453,
+      "name": "psutils License",
+      "licenseId": "psutils",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/psutils"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/RSCPL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/RSCPL.json",
+      "referenceNumber": 454,
+      "name": "Ricoh Source Code Public License",
+      "licenseId": "RSCPL",
+      "seeAlso": [
+        "http://wayback.archive.org/web/20060715140826/http://www.risource.org/RPL/RPL-1.0A.shtml",
+        "https://opensource.org/licenses/RSCPL"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Rdisc.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Rdisc.json",
+      "referenceNumber": 455,
+      "name": "Rdisc License",
+      "licenseId": "Rdisc",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Rdisc_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/FSFUL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/FSFUL.json",
+      "referenceNumber": 456,
+      "name": "FSF Unlimited License",
+      "licenseId": "FSFUL",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/FSF_Unlimited_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Entessa.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Entessa.json",
+      "referenceNumber": 457,
+      "name": "Entessa Public License v1.0",
+      "licenseId": "Entessa",
+      "seeAlso": [
+        "https://opensource.org/licenses/Entessa"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-2.0.json",
+      "referenceNumber": 458,
+      "name": "Creative Commons Attribution 2.0 Generic",
+      "licenseId": "CC-BY-2.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by/2.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/libpng-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/libpng-2.0.json",
+      "referenceNumber": 459,
+      "name": "PNG Reference Library version 2",
+      "licenseId": "libpng-2.0",
+      "seeAlso": [
+        "http://www.libpng.org/pub/png/src/libpng-LICENSE.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/AMPAS.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/AMPAS.json",
+      "referenceNumber": 460,
+      "name": "Academy of Motion Picture Arts and Sciences BSD",
+      "licenseId": "AMPAS",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/BSD#AMPASBSD"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CATOSL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CATOSL-1.1.json",
+      "referenceNumber": 461,
+      "name": "Computer Associates Trusted Open Source License 1.1",
+      "licenseId": "CATOSL-1.1",
+      "seeAlso": [
+        "https://opensource.org/licenses/CATOSL-1.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/SGI-B-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SGI-B-2.0.json",
+      "referenceNumber": 462,
+      "name": "SGI Free Software License B v2.0",
+      "licenseId": "SGI-B-2.0",
+      "seeAlso": [
+        "http://oss.sgi.com/projects/FreeB/SGIFreeSWLicB.2.0.pdf"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-ND-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-1.0.json",
+      "referenceNumber": 463,
+      "name": "Creative Commons Attribution Non Commercial No Derivatives 1.0 Generic",
+      "licenseId": "CC-BY-NC-ND-1.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nd-nc/1.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SHL-0.51.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SHL-0.51.json",
+      "referenceNumber": 464,
+      "name": "Solderpad Hardware License, Version 0.51",
+      "licenseId": "SHL-0.51",
+      "seeAlso": [
+        "https://solderpad.org/licenses/SHL-0.51/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OLDAP-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.0.json",
+      "referenceNumber": 465,
+      "name": "Open LDAP Public License v2.0 (or possibly 2.0A and 2.0B)",
+      "licenseId": "OLDAP-2.0",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003dcbf50f4e1185a21abd4c0a54d3f4341fe28f36ea"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-1.0.html",
       "isDeprecatedLicenseId": true,
-      "detailsUrl": "https://spdx.org/licenses/GPL-1.0+.json",
-      "referenceNumber": 473,
-      "name": "GNU General Public License v1.0 or later",
-      "licenseId": "GPL-1.0+",
+      "detailsUrl": "https://spdx.org/licenses/GPL-1.0.json",
+      "referenceNumber": 466,
+      "name": "GNU General Public License v1.0 only",
+      "licenseId": "GPL-1.0",
       "seeAlso": [
         "https://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/wxWindows.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "https://spdx.org/licenses/wxWindows.json",
-      "referenceNumber": 474,
-      "name": "wxWindows Library License",
-      "licenseId": "wxWindows",
+      "reference": "https://spdx.org/licenses/CPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CPL-1.0.json",
+      "referenceNumber": 467,
+      "name": "Common Public License 1.0",
+      "licenseId": "CPL-1.0",
       "seeAlso": [
-        "https://opensource.org/licenses/WXwindows"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/LGPL-3.0.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "https://spdx.org/licenses/LGPL-3.0.json",
-      "referenceNumber": 475,
-      "name": "GNU Lesser General Public License v3.0 only",
-      "licenseId": "LGPL-3.0",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
-        "https://www.gnu.org/licenses/lgpl+gpl-3.0.txt",
-        "https://opensource.org/licenses/LGPL-3.0"
+        "https://opensource.org/licenses/CPL-1.0"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
     },
     {
+      "reference": "https://spdx.org/licenses/EUDatagrid.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/EUDatagrid.json",
+      "referenceNumber": 468,
+      "name": "EU DataGrid Software License",
+      "licenseId": "EUDatagrid",
+      "seeAlso": [
+        "http://eu-datagrid.web.cern.ch/eu-datagrid/license.html",
+        "https://opensource.org/licenses/EUDatagrid"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Wsuipa.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Wsuipa.json",
+      "referenceNumber": 469,
+      "name": "Wsuipa License",
+      "licenseId": "Wsuipa",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Wsuipa"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-3-Clause-No-Military-License.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-No-Military-License.json",
+      "referenceNumber": 470,
+      "name": "BSD 3-Clause No Military License",
+      "licenseId": "BSD-3-Clause-No-Military-License",
+      "seeAlso": [
+        "https://gitlab.syncad.com/hive/dhive/-/blob/master/LICENSE",
+        "https://github.com/greymass/swift-eosio/blob/master/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/XSkat.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/XSkat.json",
+      "referenceNumber": 471,
+      "name": "XSkat License",
+      "licenseId": "XSkat",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/XSkat_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/xinetd.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/xinetd.json",
+      "referenceNumber": 472,
+      "name": "xinetd License",
+      "licenseId": "xinetd",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Xinetd_License"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/LGPLLR.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LGPLLR.json",
+      "referenceNumber": 473,
+      "name": "Lesser General Public License For Linguistic Resources",
+      "licenseId": "LGPLLR",
+      "seeAlso": [
+        "http://www-igm.univ-mlv.fr/~unitex/lgpllr.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/NPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NPL-1.0.json",
+      "referenceNumber": 474,
+      "name": "Netscape Public License v1.0",
+      "licenseId": "NPL-1.0",
+      "seeAlso": [
+        "http://www.mozilla.org/MPL/NPL/1.0/"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/TORQUE-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/TORQUE-1.1.json",
+      "referenceNumber": 475,
+      "name": "TORQUE v2.5+ Software License v1.1",
+      "licenseId": "TORQUE-1.1",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/TORQUEv1.1"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-SA-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-3.0.json",
+      "referenceNumber": 476,
+      "name": "Creative Commons Attribution Share Alike 3.0 Unported",
+      "licenseId": "CC-BY-SA-3.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-sa/3.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/APSL-1.2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/APSL-1.2.json",
+      "referenceNumber": 477,
+      "name": "Apple Public Source License 1.2",
+      "licenseId": "APSL-1.2",
+      "seeAlso": [
+        "http://www.samurajdata.se/opensource/mirror/licenses/apsl.php"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CERN-OHL-1.2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CERN-OHL-1.2.json",
+      "referenceNumber": 478,
+      "name": "CERN Open Hardware Licence v1.2",
+      "licenseId": "CERN-OHL-1.2",
+      "seeAlso": [
+        "https://www.ohwr.org/project/licenses/wikis/cern-ohl-v1.2"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0.json",
+      "referenceNumber": 479,
+      "name": "Creative Commons Attribution 3.0 Unported",
+      "licenseId": "CC-BY-3.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by/3.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/RSA-MD.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/RSA-MD.json",
+      "referenceNumber": 480,
+      "name": "RSA Message-Digest License",
+      "licenseId": "RSA-MD",
+      "seeAlso": [
+        "http://www.faqs.org/rfcs/rfc1321.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-ND-2.5.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-2.5.json",
+      "referenceNumber": 481,
+      "name": "Creative Commons Attribution Non Commercial No Derivatives 2.5 Generic",
+      "licenseId": "CC-BY-NC-ND-2.5",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-nd/2.5/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OLDAP-1.2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-1.2.json",
+      "referenceNumber": 482,
+      "name": "Open LDAP Public License v1.2",
+      "licenseId": "OLDAP-1.2",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d42b0383c50c299977b5893ee695cf4e486fb0dc7"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/LiLiQ-Rplus-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LiLiQ-Rplus-1.1.json",
+      "referenceNumber": 483,
+      "name": "Licence Libre du Québec – Réciprocité forte version 1.1",
+      "licenseId": "LiLiQ-Rplus-1.1",
+      "seeAlso": [
+        "https://www.forge.gouv.qc.ca/participez/licence-logicielle/licence-libre-du-quebec-liliq-en-francais/licence-libre-du-quebec-reciprocite-forte-liliq-r-v1-1/",
+        "http://opensource.org/licenses/LiLiQ-Rplus-1.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Intel.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Intel.json",
+      "referenceNumber": 484,
+      "name": "Intel Open Source License",
+      "licenseId": "Intel",
+      "seeAlso": [
+        "https://opensource.org/licenses/Intel"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/OFL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OFL-1.0.json",
+      "referenceNumber": 485,
+      "name": "SIL Open Font License 1.0",
+      "licenseId": "OFL-1.0",
+      "seeAlso": [
+        "http://scripts.sil.org/cms/scripts/page.php?item_id\u003dOFL10_web"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/OLDAP-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-1.1.json",
+      "referenceNumber": 486,
+      "name": "Open LDAP Public License v1.1",
+      "licenseId": "OLDAP-1.1",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d806557a5ad59804ef3a44d5abfbe91d706b0791f"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Zimbra-1.3.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Zimbra-1.3.json",
+      "referenceNumber": 487,
+      "name": "Zimbra Public License v1.3",
+      "licenseId": "Zimbra-1.3",
+      "seeAlso": [
+        "http://web.archive.org/web/20100302225219/http://www.zimbra.com/license/zimbra-public-license-1-3.html"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.3-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-only.json",
+      "referenceNumber": 488,
+      "name": "GNU Free Documentation License v1.3 only",
+      "licenseId": "GFDL-1.3-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/fdl-1.3.txt"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/LGPL-2.0.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/LGPL-2.0.json",
+      "referenceNumber": 489,
+      "name": "GNU Library General Public License v2 only",
+      "licenseId": "LGPL-2.0",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/OLDAP-2.5.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.5.json",
+      "referenceNumber": 490,
+      "name": "Open LDAP Public License v2.5",
+      "licenseId": "OLDAP-2.5",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d6852b9d90022e8593c98205413380536b1b5a7cf"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/LGPL-2.1.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/LGPL-2.1.json",
-      "referenceNumber": 476,
+      "referenceNumber": 491,
       "name": "GNU Lesser General Public License v2.1 only",
       "licenseId": "LGPL-2.1",
       "seeAlso": [
@@ -5997,114 +6193,22 @@
       "isFsfLibre": true
     },
     {
-      "reference": "https://spdx.org/licenses/StandardML-NJ.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "https://spdx.org/licenses/StandardML-NJ.json",
-      "referenceNumber": 477,
-      "name": "Standard ML of New Jersey License",
-      "licenseId": "StandardML-NJ",
-      "seeAlso": [
-        "http://www.smlnj.org//license.html"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/BSD-4-Clause.html",
+      "reference": "https://spdx.org/licenses/NPOSL-3.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/BSD-4-Clause.json",
-      "referenceNumber": 478,
-      "name": "BSD 4-Clause \"Original\" or \"Old\" License",
-      "licenseId": "BSD-4-Clause",
+      "detailsUrl": "https://spdx.org/licenses/NPOSL-3.0.json",
+      "referenceNumber": 492,
+      "name": "Non-Profit Open Software License 3.0",
+      "licenseId": "NPOSL-3.0",
       "seeAlso": [
-        "http://directory.fsf.org/wiki/License:BSD_4Clause"
-      ],
-      "isOsiApproved": false,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/GPL-2.0-with-bison-exception.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-bison-exception.json",
-      "referenceNumber": 479,
-      "name": "GNU General Public License v2.0 w/Bison exception",
-      "licenseId": "GPL-2.0-with-bison-exception",
-      "seeAlso": [
-        "http://git.savannah.gnu.org/cgit/bison.git/tree/data/yacc.c?id\u003d193d7c7054ba7197b0789e14965b739162319b5e#n141"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/Apache-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Apache-2.0.json",
-      "referenceNumber": 480,
-      "name": "Apache License 2.0",
-      "licenseId": "Apache-2.0",
-      "seeAlso": [
-        "https://www.apache.org/licenses/LICENSE-2.0",
-        "https://opensource.org/licenses/Apache-2.0"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/Artistic-1.0-cl8.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Artistic-1.0-cl8.json",
-      "referenceNumber": 481,
-      "name": "Artistic License 1.0 w/clause 8",
-      "licenseId": "Artistic-1.0-cl8",
-      "seeAlso": [
-        "https://opensource.org/licenses/Artistic-1.0"
+        "https://opensource.org/licenses/NOSL3.0"
       ],
       "isOsiApproved": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/GPL-2.0.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "https://spdx.org/licenses/GPL-2.0.json",
-      "referenceNumber": 482,
-      "name": "GNU General Public License v2.0 only",
-      "licenseId": "GPL-2.0",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
-        "https://opensource.org/licenses/GPL-2.0"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
-    },
-    {
-      "reference": "https://spdx.org/licenses/Intel-ACPI.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/Intel-ACPI.json",
-      "referenceNumber": 483,
-      "name": "Intel ACPI Software License Agreement",
-      "licenseId": "Intel-ACPI",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Intel_ACPI_Software_License_Agreement"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "https://spdx.org/licenses/BSL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/BSL-1.0.json",
-      "referenceNumber": 484,
-      "name": "Boost Software License 1.0",
-      "licenseId": "BSL-1.0",
-      "seeAlso": [
-        "http://www.boost.org/LICENSE_1_0.txt",
-        "https://opensource.org/licenses/BSL-1.0"
-      ],
-      "isOsiApproved": true,
-      "isFsfLibre": true
     },
     {
       "reference": "https://spdx.org/licenses/Artistic-1.0-Perl.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Artistic-1.0-Perl.json",
-      "referenceNumber": 485,
+      "referenceNumber": 493,
       "name": "Artistic License 1.0 (Perl)",
       "licenseId": "Artistic-1.0-Perl",
       "seeAlso": [
@@ -6113,24 +6217,10 @@
       "isOsiApproved": true
     },
     {
-      "reference": "https://spdx.org/licenses/BSD-2-Clause-Views.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-Views.json",
-      "referenceNumber": 486,
-      "name": "BSD 2-Clause with views sentence",
-      "licenseId": "BSD-2-Clause-Views",
-      "seeAlso": [
-        "http://www.freebsd.org/copyright/freebsd-license.html",
-        "https://people.freebsd.org/~ivoras/wine/patch-wine-nvidia.sh",
-        "https://github.com/protegeproject/protege/blob/master/license.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
       "reference": "https://spdx.org/licenses/Interbase-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Interbase-1.0.json",
-      "referenceNumber": 487,
+      "referenceNumber": 494,
       "name": "Interbase Public License v1.0",
       "licenseId": "Interbase-1.0",
       "seeAlso": [
@@ -6139,17 +6229,18 @@
       "isOsiApproved": false
     },
     {
-      "reference": "https://spdx.org/licenses/NPOSL-3.0.html",
+      "reference": "https://spdx.org/licenses/CAL-1.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "https://spdx.org/licenses/NPOSL-3.0.json",
-      "referenceNumber": 488,
-      "name": "Non-Profit Open Software License 3.0",
-      "licenseId": "NPOSL-3.0",
+      "detailsUrl": "https://spdx.org/licenses/CAL-1.0.json",
+      "referenceNumber": 495,
+      "name": "Cryptographic Autonomy License 1.0",
+      "licenseId": "CAL-1.0",
       "seeAlso": [
-        "https://opensource.org/licenses/NOSL3.0"
+        "http://cryptographicautonomylicense.com/license-text.html",
+        "https://opensource.org/licenses/CAL-1.0"
       ],
       "isOsiApproved": true
     }
   ],
-  "releaseDate": "2022-05-08"
+  "releaseDate": "2022-08-12"
 }


### PR DESCRIPTION
3.18 has been released a few hours ago: https://github.com/spdx/license-list-XML/releases/tag/v3.18