### PR TITLE
Allow overriding options for pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,7 +4,8 @@
 
 - id: reuse
   name: reuse
-  entry: reuse lint
+  entry: reuse
+  args: ["lint"]
   language: python
   pass_filenames: false
   description:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The versions follow [semantic versioning](https://semver.org).
 
 - Updated PyPI development status to 'production/stable' (#381)
 - Updated versions of pre-commit check packages
+- The pre-commit hook now passes `lint` as an overridable argument
 
 ### Deprecated
 


### PR DESCRIPTION
Meson subprojects are (surprisingly, at least to me) ignored by default even if not a git submodule, so being able to pass `--include-meson-subprojects` is essential for being able to use `reuse`, including as a pre-commit hook. This is not currently possible on the user's end.

By moving `lint` out of `entry` and into `args`, users of the hook can override the args in order to pass options like `--include-submodules` or `--include-meson-subprojects` (these options need to be given before the subcommand `lint`).

Any users that currently override args will need to add `lint` to their `args` when they update the hook version. Such users are likely rare/nonexistent because `reuse lint` currently has no options that are useful in a pre-commit hook context.

The default behavior (with no `args` in users' `.pre-commit-config.yaml`) does not change: it just runs `reuse lint`.