### PR TITLE
Add support for XQuery file comments and extensions

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -56,6 +56,8 @@ Contributors
 
 - Yaman Qalieh
 
+- Stefan Hynek <stefan.hynek@uni-goettingen.de>
+
 Translators
 -----------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,11 +39,13 @@ The versions follow [semantic versioning](https://semver.org).
 
 ### Added
 
+- Add support for XQuery comment style.
 - More file types are recognised:
 
   - Kotlin script (`.kts`)
   - Android Interface Definition Language (`.aidl`)
   - Certificate files (`.pem`)
+  - XQuery script and module files (`.xq(l|m|y|uery|)`)
 
 ### Changed
 

--- a/src/reuse/_comment.py
+++ b/src/reuse/_comment.py
@@ -7,6 +7,7 @@
 # SPDX-FileCopyrightText: 2021 Matija Šuklje <matija@suklje.name>
 # SPDX-FileCopyrightText: 2022 Florian Snow <florian@familysnow.net>
 # SPDX-FileCopyrightText: 2022 Nico Rikken <nico.rikken@fsfe.org>
+# SPDX-FileCopyrightText: 2022 Stefan Hynek <stefan.hynek@uni-goettingen.de>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -447,6 +448,17 @@ class VimCommentStyle(CommentStyle):
     INDENT_AFTER_SINGLE = " "
 
 
+class XQueryCommentStyle(CommentStyle):
+    """XQuery comment style."""
+
+    _shorthand = "xq"
+
+    MULTI_LINE = ("(:", ":", ":)")
+    INDENT_BEFORE_MIDDLE = " "
+    INDENT_AFTER_MIDDLE = " "
+    INDENT_BEFORE_END = " "
+
+
 #: A map of (common) file extensions against comment types.
 EXTENSION_COMMENT_STYLE_MAP = {
     ".adb": HaskellCommentStyle,
@@ -634,6 +646,11 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".xls": UncommentableCommentStyle,
     ".xlsx": UncommentableCommentStyle,
     ".xml": HtmlCommentStyle,
+    ".xq": XQueryCommentStyle,
+    ".xql": XQueryCommentStyle,
+    ".xqm": XQueryCommentStyle,
+    ".xqy": XQueryCommentStyle,
+    ".xquery": XQueryCommentStyle,
     ".xsd": HtmlCommentStyle,
     ".xsh": PythonCommentStyle,
     ".xsl": HtmlCommentStyle,

--- a/src/reuse/_comment.py
+++ b/src/reuse/_comment.py
@@ -451,7 +451,7 @@ class VimCommentStyle(CommentStyle):
 class XQueryCommentStyle(CommentStyle):
     """XQuery comment style."""
 
-    _shorthand = "xq"
+    _shorthand = "xquery"
 
     MULTI_LINE = ("(:", ":", ":)")
     INDENT_BEFORE_MIDDLE = " "


### PR DESCRIPTION
XQuery only supports multiline comments with a syntax currently
unsupported by the reuse-tool, see
<https://www.w3.org/TR/xquery-31/#comments>.

Close #583