### PR TITLE
Fix sameline multiline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,8 @@ The versions follow [semantic versioning](https://semver.org).
 - Sanitize xargs input in scripts documentation
 - License identifiers in comments with symmetrical ASCII art frames are now
   properly detected (#560)
-
+- Fixed an error where copyright statements contained within a multi-line
+  comment style on a single line could not be parsed (#593).
 - In PHP files, add header after `<?php` (#543).
 
 ### Security

--- a/src/reuse/_util.py
+++ b/src/reuse/_util.py
@@ -60,17 +60,17 @@ _COPYRIGHT_PATTERNS = [
     re.compile(
         r"(?P<copyright>(?P<prefix>SPDX-FileCopyrightText:)\s+"
         r"((?P<year>\d{4} - \d{4}|\d{4}),?\s+)?"
-        r"(?P<statement>.*)?)" + _END_PATTERN
+        r"(?P<statement>.*?))" + _END_PATTERN
     ),
     re.compile(
         r"(?P<copyright>(?P<prefix>Copyright(\s?\([cC]\))?)\s+"
         r"((?P<year>\d{4} - \d{4}|\d{4}),?\s+)?"
-        r"(?P<statement>.*)?)" + _END_PATTERN
+        r"(?P<statement>.*?))" + _END_PATTERN
     ),
     re.compile(
         r"(?P<copyright>(?P<prefix>©)\s+"
         r"((?P<year>\d{4} - \d{4}|\d{4}),?\s+)?"
-        r"(?P<statement>.*)?)" + _END_PATTERN
+        r"(?P<statement>.*?))" + _END_PATTERN
     ),
 ]
 
@@ -282,7 +282,7 @@ def extract_spdx_info(text: str) -> SpdxInfo:
         for pattern in _COPYRIGHT_PATTERNS:
             match = pattern.search(line)
             if match is not None:
-                copyright_matches.add(match.groupdict()["copyright"])
+                copyright_matches.add(match.groupdict()["copyright"].strip())
                 break
 
     return SpdxInfo(expressions, copyright_matches)

--- a/src/reuse/_util.py
+++ b/src/reuse/_util.py
@@ -46,10 +46,10 @@ _END_PATTERN = r"{}$".format(  # pylint: disable=consider-using-f-string
     "".join(
         {
             r"(?:{})*".format(  # pylint: disable=consider-using-f-string
-                re.escape(style.MULTI_LINE[2])
+                re.escape(style.MULTI_LINE.end)
             )
             for style in _all_style_classes()
-            if style.MULTI_LINE[2]
+            if style.MULTI_LINE.end
         }
     )
 )

--- a/tests/test_comment.py
+++ b/tests/test_comment.py
@@ -88,6 +88,20 @@ def test_parse_comment_generic_multi(MultiStyle):
     assert MultiStyle.parse_comment(text) == expected
 
 
+def test_parse_comment_sameline_multi(MultiStyle):
+    """If a multi-line comment style is on a single line, it should still be
+    parsed.
+    """
+    text = cleandoc(
+        f"""
+        {MultiStyle.MULTI_LINE.start} Hello {MultiStyle.MULTI_LINE.end}
+        """
+    )
+    expected = "Hello"
+
+    assert MultiStyle.parse_comment(text) == expected
+
+
 def test_base_class_throws_errors():
     """When trying to do much of anything with the base class, expect errors."""
     with pytest.raises(CommentParseError):

--- a/tests/test_comment.py
+++ b/tests/test_comment.py
@@ -56,9 +56,9 @@ def test_create_comment_generic_multi(MultiStyle):
     text = "Hello"
     expected = cleandoc(
         f"""
-        {MultiStyle.MULTI_LINE[0]}
-        {MultiStyle.INDENT_BEFORE_MIDDLE}{MultiStyle.MULTI_LINE[1]}{MultiStyle.INDENT_AFTER_MIDDLE}Hello
-        {MultiStyle.INDENT_BEFORE_END}{MultiStyle.MULTI_LINE[2]}
+        {MultiStyle.MULTI_LINE.start}
+        {MultiStyle.INDENT_BEFORE_MIDDLE}{MultiStyle.MULTI_LINE.middle}{MultiStyle.INDENT_AFTER_MIDDLE}Hello
+        {MultiStyle.INDENT_BEFORE_END}{MultiStyle.MULTI_LINE.end}
         """
     )
 
@@ -78,9 +78,9 @@ def test_parse_comment_generic_multi(MultiStyle):
     # pylint: disable=line-too-long
     text = cleandoc(
         f"""
-        {MultiStyle.MULTI_LINE[0]}
-        {MultiStyle.INDENT_BEFORE_MIDDLE}{MultiStyle.MULTI_LINE[1]}{MultiStyle.INDENT_AFTER_MIDDLE}Hello
-        {MultiStyle.INDENT_BEFORE_END}{MultiStyle.MULTI_LINE[2]}
+        {MultiStyle.MULTI_LINE.start}
+        {MultiStyle.INDENT_BEFORE_MIDDLE}{MultiStyle.MULTI_LINE.middle}{MultiStyle.INDENT_AFTER_MIDDLE}Hello
+        {MultiStyle.INDENT_BEFORE_END}{MultiStyle.MULTI_LINE.end}
         """
     )
     expected = "Hello"

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -176,6 +176,16 @@ def test_extract_with_ignore_block():
     assert len(result.spdx_expressions) == 1
 
 
+def test_extract_sameline_multiline():
+    """When a copyright line is in a multi-line style comment on a single line,
+    do not include the comment end pattern as part of the copyright.
+    """
+    text = "<!-- SPDX-FileCopyrightText: Jane Doe -->"
+    result = _util.extract_spdx_info(text)
+    assert len(result.copyright_lines) == 1
+    assert result.copyright_lines == {"SPDX-FileCopyrightText: Jane Doe"}
+
+
 def test_filter_ignore_block_with_comment_style():
     """Test that the ignore block is properly removed if start and end markers
     are in comment style.


### PR DESCRIPTION
Related to #516, but doesn't really address it.

Fixes error when parsing

```
<!-- SPDX-FileCopyrightText: 2017 Jane Doe -->

<p>Hello, world!</p>
```