### PR TITLE
README.md: Fix Package Manager Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,13 @@ In this screencast, we are going to follow the
 There are packages available for easy install on some operating systems. You are
 welcome to help us package this tool for more distributions!
 
+- Alpine Linux: [reuse](https://pkgs.alpinelinux.org/packages?name=reuse)
 - Arch Linux: [reuse](https://archlinux.org/packages/community/any/reuse/)
 - Debian: [reuse](https://packages.debian.org/search?keywords=reuse&exact=1)
-- GNU Guix: [reuse](https://guix.gnu.org/packages/reuse-0.14.0/)
-- Fedora: [reuse](https://apps.fedoraproject.org/packages/reuse)
+- GNU Guix: [reuse](https://guix.gnu.org/en/packages/reuse-1.0.0/)
+- Fedora: [reuse](https://packages.fedoraproject.org/pkgs/reuse/reuse/)
 - MacPorts: [reuse](https://ports.macports.org/port/reuse/)
-- NixOS:
-  [reuse](https://search.nixos.org/packages?channel=21.05&from=0&size=50&sort=relevance&type=packages&query=reuse)
+- NixOS: [reuse](https://search.nixos.org/packages?show=reuse)
 - openSUSE: [reuse](https://software.opensuse.org/package/reuse)
 - VoidLinux: [reuse](https://voidlinux.org/packages/?arch=x86_64&q=reuse)
 


### PR DESCRIPTION
Changes:
- Add Alpine Linux URL.
- GNU Guix has bumped versions which are part of its URL.
- Fedora has changed its URL schema.
- The NixOS URL was especially to a now outdated version.

As an alternative, the growing list of different packages could be removed and only a link to repology.org next to a generic example - e.g. `apt-get install reuse` - could remain. 