### PR TITLE
Treat untracked files in Git repos as "ignored"

### DIFF
--- a/src/reuse/vcs.py
+++ b/src/reuse/vcs.py
@@ -83,7 +83,6 @@ class VCSStrategyGit(VCSStrategy):
             GIT_EXE,
             "ls-files",
             "--exclude-standard",
-            "--ignored",
             "--others",
             "--directory",
             # TODO: This flag is unexpected.  I reported it as a bug in Git.
@@ -95,6 +94,11 @@ class VCSStrategyGit(VCSStrategy):
         ]
         result = execute_command(command, _LOGGER, cwd=self.project.root)
         all_files = result.stdout.decode("utf-8").split("\0")
+
+        command += ["--ignored"]
+        result = execute_command(command, _LOGGER, cwd=self.project.root)
+        all_files += result.stdout.decode("utf-8").split("\0")
+
         return {Path(file_) for file_ in all_files}
 
     def is_ignored(self, path: PathLike) -> bool:


### PR DESCRIPTION
When the Git VCS strategy is used, ignore files that are not tracked by Git. Untracked files will not be published by commands like `git push` or `git archive`, but can sometimes occur during development cycles. For example, one could write a small script to explore possible new options, without the intention of ever committing this script. Forcing a developer in this case to either add license headers anyways or to add these temporary files to a project-wide `.gitignore` file would likely be seen as a hassle rather than a helpful hint.

As soon as a file is staged for committing in Git, it becomes tracked, and therefore is checked again.

This PR solves #578.

Small note: I first tried the other option that I mentioned in [my comment there](https://github.com/fsfe/reuse-tool/issues/578#issuecomment-1288737315), which is to make a set of tracked files instead of ignored files, but I could not find a simple way to retrieve a list of directories that contain tracked files. Not having that caused trouble with other parts of the code, so I settled with calling git twice instead.