### PR TITLE
Add loglevel argument to pytest. [convenience feature]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ The versions follow [semantic versioning](https://semver.org).
 
 ### Added
 
+- Added loglevel argument to pytest and skip one test if loglevel is too
+  high (#645).
+
 ### Changed
 
 ### Deprecated

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,14 +43,21 @@ CWD = Path.cwd()
 TESTS_DIRECTORY = Path(__file__).parent.resolve()
 RESOURCES_DIRECTORY = TESTS_DIRECTORY / "resources"
 
+
 # REUSE-IgnoreStart
 
 
-def pytest_configure():
+def pytest_addoption(parser):
+    """Allows specification of additional commandline options to parse"""
+    parser.addoption("--loglevel", action="store", default="DEBUG")
+
+
+def pytest_configure(config):
     """Called after command line options have been parsed and all plugins and
     initial conftest files been loaded.
     """
-    setup_logging(level=logging.DEBUG)
+    loglevel = config.getoption("loglevel")
+    setup_logging(level=logging.getLevelName(loglevel))
 
 
 def pytest_runtest_setup(item):

--- a/tests/test_main_annotate.py
+++ b/tests/test_main_annotate.py
@@ -7,15 +7,16 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 """Tests for reuse._main: annotate"""
-
-# pylint: disable=too-many-lines,unused-argument
-
+import logging
 import stat
 from inspect import cleandoc
 
 import pytest
 
 from reuse._main import main
+
+# pylint: disable=too-many-lines,unused-argument
+
 
 # REUSE-IgnoreStart
 
@@ -420,7 +421,13 @@ def test_annotate_skip_unrecognised_and_style(
     )
 
     assert result == 0
-    assert "no effect" in caplog.text
+    loglevel = logging.getLogger("reuse").level
+    if loglevel > logging.WARNING:
+        pytest.skip(
+            f"Test needs LogLevel to be WARNING or lower (INFO, DEBUG). Current Level {logging.getLevelName(loglevel)}"
+        )
+    else:
+        assert "no effect" in caplog.text
 
 
 def test_annotate_no_copyright_or_license(fake_repository):
@@ -604,7 +611,6 @@ def test_annotate_template_nonexistant(fake_repository):
 def test_annotate_template_without_extension(
     fake_repository, stringio, mock_date_today, template_simple_source
 ):
-
     """Find the correct header even when not using an extension."""
     simple_file = fake_repository / "foo.py"
     simple_file.write_text("pass")

--- a/tests/test_main_annotate.py
+++ b/tests/test_main_annotate.py
@@ -424,7 +424,7 @@ def test_annotate_skip_unrecognised_and_style(
     loglevel = logging.getLogger("reuse").level
     if loglevel > logging.WARNING:
         pytest.skip(
-            f"Test needs LogLevel to be WARNING or lower (INFO, DEBUG). Current Level {logging.getLevelName(loglevel)}"
+            "Test needs LogLevel <= WARNING (e.g. WARNING, INFO, DEBUG)."
         )
     else:
         assert "no effect" in caplog.text


### PR DESCRIPTION
While starting to work on reuse-tool I first ran the tests and noticed an overwhelming flood of DEBUG outputs.

This PR is my attempt to improve the user experince of running the tests frequently by allowing for a commandline option `--loglevel <LEVEL>`. This does break one test that relies on log output, thus this test is skipped, if the loglevel is too high.

Feel free to suggest a place to put some instructions on how to use it (if it isn't self-explanatory), as I wasn't sure where an example call would fit best.