### PR TITLE
pipx install poetry in GitHub CI

### DIFF
--- a/.github/workflows/pythonpackage.yaml
+++ b/.github/workflows/pythonpackage.yaml
@@ -24,13 +24,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Install poetry
+        run: pipx install 'poetry<2.0'
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: poetry
       - name: Install dependencies
         run: |
-          pip install poetry
           poetry install --no-interaction
       - name: Run tests with pytest
         run: |
@@ -43,13 +45,15 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+      - name: Install poetry
+        run: pipx install 'poetry<2.0'
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.6
+          cache: poetry
       - name: Install dependencies
         run: |
-          pip install poetry
           poetry install --no-interaction
       - name: Lint with PyLint
         run: |
@@ -59,13 +63,15 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+      - name: Install poetry
+        run: pipx install 'poetry<2.0'
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.6
+          cache: poetry
       - name: Install dependencies
         run: |
-          pip install poetry
           poetry install --no-interaction
       - name: Test formatting with black
         run: |
@@ -76,13 +82,15 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+      - name: Install poetry
+        run: pipx install 'poetry<2.0'
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.6
+          cache: poetry
       - name: Install dependencies
         run: |
-          pip install poetry
           poetry install --no-interaction --no-dev
       - name: Test REUSE compliance
         run: |
@@ -93,7 +101,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.6
       - name: Install dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ generate-setup-file = false
 script = "build.py"
 
 [build-system]
-requires = ["poetry-core>=1.1.0", "setuptools"]
+requires = ["poetry-core>=1.0.0", "setuptools"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.black]


### PR DESCRIPTION
#650 frustrated me, so I think I fixed it this time. Apparently `poetry-core` and `poetry` aren't necessarily in version sync (I think). When I installed poetry v1.1, I received poetry-core v1.0. When I installed poetry v1.0, I didn't get a poetry-core at all.

Best as I can gather, we need poetry v1.1 at a minimum, and also poetry-core v1.0 at a minimum. Later Poetry features are not supported/used, but later versions are backwards-compatible.

Instead of pinning Poetry to a specific version, I set a maximum, so that we get alerted in time in case Poetry breaks.