### PR TITLE
Do not abort the whole test job if one combination in the matrix fails

### DIFF
--- a/.github/workflows/pythonpackage.yaml
+++ b/.github/workflows/pythonpackage.yaml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V. <https://fsfe.org>
+# SPDX-FileCopyrightText: 2023 DB Systel GmbH
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -15,6 +16,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 10
+      # do not abort the whole test job if one combination in the matrix fails
+      fail-fast: false
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-20.04, macos-latest, windows-latest]


### PR DESCRIPTION
We want to see the results of all combinations in the `test` job and not abort the whole job if only one fails.

This way it's easier to see in a PR which combinations are problematic, so we don't have to fix them one-by-one.