### PR TITLE
Fix comment style for Scala

### DIFF
--- a/src/reuse/_comment.py
+++ b/src/reuse/_comment.py
@@ -644,7 +644,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".sbt": CCommentStyle,
     ".sc": CCommentStyle,  # SuperCollider source file
     ".scad": CCommentStyle,
-    ".scala": PythonCommentStyle,
+    ".scala": CCommentStyle,
     ".scm": LispCommentStyle,
     ".scpt": AppleScriptCommentStyle,
     ".scptd": AppleScriptCommentStyle,


### PR DESCRIPTION
Scala uses the C comment style with `//` instead of `#` for both Scala 2 [1] and 3 [2].

[1] https://www.scala-lang.org/files/archive/spec/2.13/01-lexical-syntax.html#whitespace-and-comments
[2] https://docs.scala-lang.org/scala3/book/scala-for-python-devs.html#comments