### PR TITLE
don't install docs top-level in site-packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,14 +21,14 @@ packages = [
     { include = "reuse", from = "src" }
 ]
 include = [
+    { path = "src/reuse/locale/**/*.mo", format="wheel" },
     { path = "tests", format = "sdist" },
     { path = "po", format = "sdist" },
-    { path = "src/reuse/locale/**/*.mo", format="wheel" },
-    { path = "AUTHORS.rst" },
-    { path = "README.md" },
-    { path = "CHANGELOG.md" },
-    { path = ".reuse" },
-    { path = "LICENSES" },
+    { path = "AUTHORS.rst", format = "sdist" },
+    { path = "README.md", format = "sdist" },
+    { path = "CHANGELOG.md", format = "sdist" },
+    { path = ".reuse", format = "sdist" },
+    { path = "LICENSES", format = "sdist" },
 ]
 
 homepage = "https://reuse.software/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ include = [
     { path = "CHANGELOG.md", format = "sdist" },
     { path = ".reuse", format = "sdist" },
     { path = "LICENSES", format = "sdist" },
+    { path = "docs", format = "sdist" },
 ]
 
 homepage = "https://reuse.software/"


### PR DESCRIPTION
otherwise they are found in, e.g., `/usr/lib/python3.11/site-packages/README.md`

Fixes #656 