### PR TITLE
Fix git submodule detection if .git is not a file

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -58,6 +58,8 @@ Contributors
 
 - Pietro Albini <pietro.albini@ferrous-systems.com>
 
+- Matthias Riße
+
 - Stefan Hynek <stefan.hynek@uni-goettingen.de>
 
 - rajivsunar07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,12 @@ CLI command and its behaviour. There are no guarantees of stability for the
 ### Changed
 
 - Alpine Docker image now uses 3.18 as base. (#846)
+- The Git submodule detection was made less naïve. Where previously it detected
+  a directory with a `.git` file as a submodule, it now uses the git command to
+  detect submodules. This helps detect (quoted from Git man page)
+  "[repositories] that were cloned independently and later added as a submodule
+  or old setups", which "have the submodule's git directory inside the submodule
+  instead of embedded into the superproject's git directory". (#687)
 
 ### Deprecated
 

--- a/src/reuse/project.py
+++ b/src/reuse/project.py
@@ -122,8 +122,9 @@ class Project:
                 elif the_dir.is_symlink():
                     _LOGGER.debug("skipping symlink '%s'", the_dir)
                     dirs.remove(dir_)
-                elif not self.include_submodules and self._is_submodule(
-                    the_dir
+                elif (
+                    not self.include_submodules
+                    and self.vcs_strategy.is_submodule(the_dir)
                 ):
                     _LOGGER.info(
                         "ignoring '%s' because it is a submodule", the_dir
@@ -255,35 +256,6 @@ class Project:
             return path.relative_to(self.root)
         except ValueError:
             return Path(os.path.relpath(path, start=self.root))
-
-    def _is_submodule(self, path: Path) -> bool:
-        """Is *path* a submodule specified in .gitmodules?"""
-        if not GIT_EXE:
-            # If git is not present fallback to checking if .git exists
-            return (path / ".git").exists()
-        command = [
-            GIT_EXE,
-            "config",
-            "-z",
-            "--file",
-            ".gitmodules",
-            "--get-regexp",
-            "\\.path$",
-        ]
-        result = execute_command(
-            command,
-            _LOGGER,
-            cwd=self.root,
-        )
-        submodule_entries = filter(
-            lambda x: len(x) > 0, result.stdout.decode().split("\0")
-        )
-        submodule_paths = map(lambda x: x.splitlines()[1], submodule_entries)
-        return any(
-            self.relative_from_root(path).resolve()
-            == Path(submodule_path).resolve()
-            for submodule_path in submodule_paths
-        )
 
     def _is_path_ignored(self, path: Path) -> bool:
         """Is *path* ignored by some mechanism?"""


### PR DESCRIPTION
The current heuristic to detect submodules, which checks if a directory contains a .git file, is too simple. In some cases .git might instead be a directory. This happens for example with datalad subdatasets or, according to the git submodules man page, with independently cloned repositories:
> A repository that was cloned independently and later added as a submodule or old setups have the submodules git directory inside the submodule instead of embedded into the superprojects git directory.

This PR fixes this issue by getting a list of submodules from the .gitmodules file and comparing the paths with that instead.