### PR TITLE
Add support for using LicenseRef- when initialising

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ CLI command and its behaviour. There are no guarantees of stability for the
 
 ### Added
 
+- Implement handling LicenseRef in `download` and `init`. (#697)
 - Declared support for Python 3.12. (#846)
 - More file types are recognised:
   - Julia (`.jl`) (#815)

--- a/src/reuse/_licenses.py
+++ b/src/reuse/_licenses.py
@@ -11,7 +11,6 @@
 
 import json
 import os
-import re
 from typing import Dict, List, Tuple
 
 _BASE_DIR = os.path.dirname(__file__)
@@ -58,5 +57,3 @@ ALL_NON_DEPRECATED_MAP = {
     for identifier, contents in ALL_MAP.items()
     if not contents["isDeprecatedLicenseId"]
 }
-
-REF_RE = re.compile("LicenseRef-[a-zA-Z0-9-.]+$")

--- a/src/reuse/_licenses.py
+++ b/src/reuse/_licenses.py
@@ -12,6 +12,7 @@
 import json
 import os
 from typing import Dict, List, Tuple
+import re
 
 _BASE_DIR = os.path.dirname(__file__)
 _RESOURCES_DIR = os.path.join(_BASE_DIR, "resources")
@@ -57,3 +58,5 @@ ALL_NON_DEPRECATED_MAP = {
     for identifier, contents in ALL_MAP.items()
     if not contents["isDeprecatedLicenseId"]
 }
+
+REF_RE = re.compile("LicenseRef-[a-zA-Z0-9-.]+$")

--- a/src/reuse/_licenses.py
+++ b/src/reuse/_licenses.py
@@ -11,8 +11,8 @@
 
 import json
 import os
-from typing import Dict, List, Tuple
 import re
+from typing import Dict, List, Tuple
 
 _BASE_DIR = os.path.dirname(__file__)
 _RESOURCES_DIR = os.path.join(_BASE_DIR, "resources")

--- a/src/reuse/_util.py
+++ b/src/reuse/_util.py
@@ -138,6 +138,8 @@ _COPYRIGHT_STYLES = {
     "symbol": "©",
 }
 
+_LICENSEREF_PATTERN = re.compile("LicenseRef-[a-zA-Z0-9-.]+$")
+
 # Amount of bytes that we assume will be big enough to contain the entire
 # comment header (including SPDX tags), so that we don't need to read the
 # entire file.

--- a/src/reuse/download.py
+++ b/src/reuse/download.py
@@ -18,7 +18,7 @@ from typing import IO
 from urllib.error import URLError
 from urllib.parse import urljoin
 
-from ._licenses import ALL_NON_DEPRECATED_MAP
+from ._licenses import ALL_NON_DEPRECATED_MAP, REF_RE
 from ._util import (
     PathType,
     StrPath,
@@ -34,8 +34,6 @@ _LOGGER = logging.getLogger(__name__)
 _SPDX_REPOSITORY_BASE_URL = (
     "https://raw.githubusercontent.com/spdx/license-list-data/master/text/"
 )
-
-REF_RE = re.compile("LicenseRef-[a-zA-Z0-9-.]+$")
 
 
 def download_license(spdx_identifier: str) -> str:

--- a/src/reuse/download.py
+++ b/src/reuse/download.py
@@ -7,6 +7,7 @@
 
 import errno
 import logging
+import os
 import re
 import shutil
 import sys
@@ -14,7 +15,7 @@ import urllib.request
 from argparse import ArgumentParser, Namespace
 from gettext import gettext as _
 from pathlib import Path
-from typing import IO
+from typing import IO, Optional
 from urllib.error import URLError
 from urllib.parse import urljoin
 
@@ -64,7 +65,9 @@ def _path_to_license_file(spdx_identifier: str, root: StrPath) -> Path:
 
 
 def put_license_in_file(
-    spdx_identifier: str, destination: StrPath, out: IO[str] = None
+    spdx_identifier: str,
+    destination: StrPath,
+    source: Optional[StrPath] = None,
 ) -> None:
     """Download a license and put it in the destination file.
 
@@ -73,28 +76,36 @@ def put_license_in_file(
     Args:
         spdx_identifier: SPDX License Identifier of the license.
         destination: Where to put the license.
+        source: Path to file or directory containing the text for LicenseRef
+            licenses.
 
     Raises:
         URLError: if the license could not be downloaded.
         FileExistsError: if the license file already exists.
+        FileNotFoundError: if the source could not be found in the directory.
     """
     header = ""
     destination = Path(destination)
     destination.parent.mkdir(exist_ok=True)
 
     if destination.exists():
-        raise FileExistsError(errno.EEXIST, "File exists", str(destination))
+        raise FileExistsError(
+            errno.EEXIST, os.strerror(errno.EEXIST), str(destination)
+        )
 
+    # LicenseRef- license; don't download anything.
     if re.match(REF_RE, spdx_identifier):
-        if out is not None:
-            out.write(_("Enter path to custom license file"))
-            out.write("\n")
-            result = input().strip()
-            out.write("\n")
-            source = Path(result)
+        if source:
+            source = Path(source)
             if source.is_dir():
-                source = source / "".join((spdx_identifier, ".txt"))
+                source = source / f"{spdx_identifier}.txt"
+            if not source.exists():
+                raise FileNotFoundError(
+                    errno.ENOENT, os.strerror(errno.ENOENT), str(source)
+                )
             shutil.copyfile(source, destination)
+        else:
+            destination.touch()
     else:
         text = download_license(spdx_identifier)
         with destination.open("w", encoding="utf-8") as fp:
@@ -118,6 +129,15 @@ def add_arguments(parser: ArgumentParser) -> None:
     parser.add_argument(
         "--output", "-o", dest="file", action="store", type=PathType("w")
     )
+    parser.add_argument(
+        "--source",
+        action="store",
+        type=PathType("r"),
+        help=_(
+            "source from which to copy custom LicenseRef- licenses, either"
+            " a directory that contains the file or the file itself"
+        ),
+    )
 
 
 def run(args: Namespace, project: Project, out: IO[str] = sys.stdout) -> int:
@@ -130,6 +150,9 @@ def run(args: Namespace, project: Project, out: IO[str] = sys.stdout) -> int:
             )
         )
         out.write("\n")
+
+    def _not_found(path: StrPath) -> None:
+        out.write(_("Error: {path} does not exist.").format(path=path))
 
     def _could_not_download(identifier: str) -> None:
         out.write(_("Error: Failed to download license."))
@@ -171,12 +194,17 @@ def run(args: Namespace, project: Project, out: IO[str] = sys.stdout) -> int:
         else:
             destination = _path_to_license_file(lic, project.root)
         try:
-            put_license_in_file(lic, destination=destination)
+            put_license_in_file(
+                lic, destination=destination, source=args.source
+            )
         except URLError:
             _could_not_download(lic)
             return_code = 1
         except FileExistsError as err:
             _already_exists(err.filename)
+            return_code = 1
+        except FileNotFoundError as err:
+            _not_found(err.filename)
             return_code = 1
         else:
             _successfully_downloaded(destination)

--- a/src/reuse/download.py
+++ b/src/reuse/download.py
@@ -93,11 +93,10 @@ def put_license_in_file(
             out.write("\n")
             result = input().strip()
             out.write("\n")
-            if result:
-                source = Path(result)
-                if source.is_dir():
-                    source = source / "".join((spdx_identifier, ".txt"))
-                shutil.copyfile(source, destination)
+            source = Path(result)
+            if source.is_dir():
+                source = source / "".join((spdx_identifier, ".txt"))
+            shutil.copyfile(source, destination)
     else:
         text = download_license(spdx_identifier)
         with destination.open("w", encoding="utf-8") as fp:

--- a/src/reuse/download.py
+++ b/src/reuse/download.py
@@ -35,7 +35,7 @@ _SPDX_REPOSITORY_BASE_URL = (
     "https://raw.githubusercontent.com/spdx/license-list-data/master/text/"
 )
 
-REF_RE = re.compile("LicenseRef-.+")
+REF_RE = re.compile("LicenseRef-[a-zA-Z0-9-.]+$")
 
 
 def download_license(spdx_identifier: str) -> str:

--- a/src/reuse/download.py
+++ b/src/reuse/download.py
@@ -94,7 +94,9 @@ def put_license_in_file(
             result = input().strip()
             out.write("\n")
             if result:
-                source = Path(result) / "".join((spdx_identifier, ".txt"))
+                source = Path(result)
+                if source.is_dir():
+                    source = source / "".join((spdx_identifier, ".txt"))
                 shutil.copyfile(source, destination)
     else:
         text = download_license(spdx_identifier)

--- a/src/reuse/download.py
+++ b/src/reuse/download.py
@@ -8,7 +8,6 @@
 import errno
 import logging
 import os
-import re
 import shutil
 import sys
 import urllib.request
@@ -19,8 +18,9 @@ from typing import IO, Optional
 from urllib.error import URLError
 from urllib.parse import urljoin
 
-from ._licenses import ALL_NON_DEPRECATED_MAP, REF_RE
+from ._licenses import ALL_NON_DEPRECATED_MAP
 from ._util import (
+    _LICENSEREF_PATTERN,
     PathType,
     StrPath,
     find_licenses_directory,
@@ -94,7 +94,7 @@ def put_license_in_file(
         )
 
     # LicenseRef- license; don't download anything.
-    if re.match(REF_RE, spdx_identifier):
+    if _LICENSEREF_PATTERN.match(spdx_identifier):
         if source:
             source = Path(source)
             if source.is_dir():

--- a/src/reuse/download.py
+++ b/src/reuse/download.py
@@ -91,7 +91,7 @@ def put_license_in_file(
         if out is not None:
             out.write(_("Enter path to custom license file"))
             out.write("\n")
-            result = input()
+            result = input().strip()
             out.write("\n")
             if result:
                 source = Path(result) / "".join((spdx_identifier, ".txt"))

--- a/src/reuse/init.py
+++ b/src/reuse/init.py
@@ -123,7 +123,7 @@ def run(
         try:
             out.write(_("Retrieving {}").format(lic))
             out.write("\n")
-            put_license_in_file(lic, destination=destination, out=out)
+            put_license_in_file(lic, destination=destination)
         # TODO: exceptions
         except FileExistsError:
             out.write(_("{} already exists").format(destination))

--- a/src/reuse/init.py
+++ b/src/reuse/init.py
@@ -135,7 +135,7 @@ def run(
             out.write(
                 _(
                     "Error: Could not copy {path}, "
-                    "please add manually {lic}.txt in the LICENCES/ directory."
+                    "please add {lic}.txt manually in the LICENCES/ directory."
                 ).format(path=err.filename, lic=lic)
             )
             out.write("\n")

--- a/src/reuse/init.py
+++ b/src/reuse/init.py
@@ -14,8 +14,12 @@ from typing import IO, List
 from urllib.error import URLError
 
 from ._licenses import ALL_NON_DEPRECATED_MAP
-from ._util import PathType, print_incorrect_spdx_identifier
-from .download import REF_RE, _path_to_license_file, put_license_in_file
+from ._util import (
+    _LICENSEREF_PATTERN,
+    PathType,
+    print_incorrect_spdx_identifier,
+)
+from .download import _path_to_license_file, put_license_in_file
 from .project import Project
 from .vcs import find_root
 
@@ -46,7 +50,7 @@ def prompt_licenses(out: IO[str] = sys.stdout) -> List[str]:
         if not result:
             return licenses
         if result not in ALL_NON_DEPRECATED_MAP and not re.match(
-            REF_RE, result
+            _LICENSEREF_PATTERN, result
         ):
             print_incorrect_spdx_identifier(result, out=out)
             out.write("\n\n")

--- a/src/reuse/init.py
+++ b/src/reuse/init.py
@@ -131,8 +131,13 @@ def run(
         except URLError:
             out.write(_("Could not download {}").format(lic))
             out.write("\n")
-        except FileNotFoundError:
-            out.write(_("Could not copy {}").format(lic))
+        except FileNotFoundError as err:
+            out.write(
+                _(
+                    "Error: Could not copy {path}, "
+                    "please add manually {lic}.txt in the LICENCES/ directory."
+                ).format(path=err.filename, lic=lic)
+            )
             out.write("\n")
 
     out.write("\n")

--- a/src/reuse/project.py
+++ b/src/reuse/project.py
@@ -12,6 +12,8 @@ import glob
 import logging
 import os
 import warnings
+import re
+
 from gettext import gettext as _
 from pathlib import Path
 from typing import Dict, Iterator, List, Optional, Union, cast
@@ -29,7 +31,7 @@ from . import (
     ReuseInfo,
     SourceType,
 )
-from ._licenses import EXCEPTION_MAP, LICENSE_MAP
+from ._licenses import EXCEPTION_MAP, LICENSE_MAP, REF_RE
 from ._util import (
     _HEADER_BYTES,
     GIT_EXE,
@@ -304,7 +306,7 @@ class Project:
             raise IdentifierNotFound(f"{path} has no file extension")
         if path.stem in self.license_map:
             return path.stem
-        if path.stem.startswith("LicenseRef-"):
+        if re.match(REF_RE, path.stem):
             return path.stem
 
         raise IdentifierNotFound(
@@ -395,10 +397,7 @@ class Project:
                 raise RuntimeError(f"Multiple licenses resolve to {identifier}")
             # Add the identifiers
             license_files[identifier] = path
-            if (
-                identifier.startswith("LicenseRef-")
-                and "Unknown" not in identifier
-            ):
+            if re.match(REF_RE, identifier) and "Unknown" not in identifier:
                 self.license_map[identifier] = {
                     "reference": str(path),
                     "isDeprecatedLicenseId": False,

--- a/src/reuse/project.py
+++ b/src/reuse/project.py
@@ -11,9 +11,8 @@ import contextlib
 import glob
 import logging
 import os
-import warnings
 import re
-
+import warnings
 from gettext import gettext as _
 from pathlib import Path
 from typing import Dict, Iterator, List, Optional, Union, cast

--- a/src/reuse/project.py
+++ b/src/reuse/project.py
@@ -11,7 +11,6 @@ import contextlib
 import glob
 import logging
 import os
-import re
 import warnings
 from gettext import gettext as _
 from pathlib import Path
@@ -30,9 +29,10 @@ from . import (
     ReuseInfo,
     SourceType,
 )
-from ._licenses import EXCEPTION_MAP, LICENSE_MAP, REF_RE
+from ._licenses import EXCEPTION_MAP, LICENSE_MAP
 from ._util import (
     _HEADER_BYTES,
+    _LICENSEREF_PATTERN,
     GIT_EXE,
     HG_EXE,
     StrPath,
@@ -305,7 +305,7 @@ class Project:
             raise IdentifierNotFound(f"{path} has no file extension")
         if path.stem in self.license_map:
             return path.stem
-        if re.match(REF_RE, path.stem):
+        if _LICENSEREF_PATTERN.match(path.stem):
             return path.stem
 
         raise IdentifierNotFound(
@@ -396,7 +396,10 @@ class Project:
                 raise RuntimeError(f"Multiple licenses resolve to {identifier}")
             # Add the identifiers
             license_files[identifier] = path
-            if re.match(REF_RE, identifier) and "Unknown" not in identifier:
+            if (
+                _LICENSEREF_PATTERN.match(identifier)
+                and "Unknown" not in identifier
+            ):
                 self.license_map[identifier] = {
                     "reference": str(path),
                     "isDeprecatedLicenseId": False,

--- a/src/reuse/report.py
+++ b/src/reuse/report.py
@@ -12,7 +12,6 @@ import datetime
 import logging
 import multiprocessing as mp
 import random
-import re
 from gettext import gettext as _
 from hashlib import md5
 from io import StringIO
@@ -22,8 +21,7 @@ from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Set, cast
 from uuid import uuid4
 
 from . import __REUSE_version__, __version__
-from ._licenses import REF_RE
-from ._util import _LICENSING, StrPath, _checksum
+from ._util import _LICENSEREF_PATTERN, _LICENSING, StrPath, _checksum
 from .project import Project, ReuseInfo
 
 _LOGGER = logging.getLogger(__name__)
@@ -228,7 +226,7 @@ class ProjectReport:  # pylint: disable=too-many-instance-attributes
 
         # Licenses
         for lic, path in sorted(self.licenses.items()):
-            if re.match(REF_RE, lic):
+            if _LICENSEREF_PATTERN.match(lic):
                 out.write("\n")
                 out.write(f"LicenseID: {lic}\n")
                 out.write("LicenseName: NOASSERTION\n")

--- a/src/reuse/report.py
+++ b/src/reuse/report.py
@@ -12,6 +12,7 @@ import datetime
 import logging
 import multiprocessing as mp
 import random
+import re
 from gettext import gettext as _
 from hashlib import md5
 from io import StringIO
@@ -21,6 +22,7 @@ from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Set, cast
 from uuid import uuid4
 
 from . import __REUSE_version__, __version__
+from ._licenses import REF_RE
 from ._util import _LICENSING, StrPath, _checksum
 from .project import Project, ReuseInfo
 
@@ -226,7 +228,7 @@ class ProjectReport:  # pylint: disable=too-many-instance-attributes
 
         # Licenses
         for lic, path in sorted(self.licenses.items()):
-            if lic.startswith("LicenseRef-"):
+            if re.match(REF_RE, lic):
                 out.write("\n")
                 out.write(f"LicenseID: {lic}\n")
                 out.write("LicenseName: NOASSERTION\n")


### PR DESCRIPTION
When initializing a new project that will use a custom license, the first step will fail because it currently handles only the list of supported license.

This pull request implements the handling for `LicenseRef-` so that it can also be used from the start.

The implementation will request a path to the license file so it can be copied over to the project.

Fixes #677