### PR TITLE
Add a "Recommendations" section in lint output based on found issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ CLI command and its behaviour. There are no guarantees of stability for the
 - More file types are recognised:
   - Julia (`.jl`) (#815)
   - Modern Fortran (`.f90`) (#836)
+- Display recommendations for steps to fix found issues during a lint. (#698)
 
 ### Changed
 

--- a/src/reuse/lint.py
+++ b/src/reuse/lint.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
 # SPDX-FileCopyrightText: 2022 Florian Snow <florian@familysnow.net>
+# SPDX-FileCopyrightText: 2023 DB Systel GmbH
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -13,6 +14,7 @@ from argparse import ArgumentParser, Namespace
 from gettext import gettext as _
 from io import StringIO
 from pathlib import Path
+from textwrap import TextWrapper
 from typing import IO, Any
 
 from . import __REUSE_version__
@@ -37,7 +39,7 @@ def add_arguments(parser: ArgumentParser) -> None:
     )
 
 
-# pylint: disable=too-many-branches, too-many-statements
+# pylint: disable=too-many-branches,too-many-statements,too-many-locals
 def format_plain(report: ProjectReport) -> str:
     """Formats data dictionary as plaintext string to be printed to sys.stdout
 
@@ -201,6 +203,23 @@ def format_plain(report: ProjectReport) -> str:
                 "{} of the REUSE Specification :-("
             ).format(__REUSE_version__)
         )
+
+        # Write recommendations in a nicely wrapped format
+        output.write("\n\n\n# ")
+        output.write(_("RECOMMENDATIONS"))
+        output.write("\n\n")
+
+        wrapper = TextWrapper(
+            width=80,
+            drop_whitespace=True,
+            break_long_words=False,
+            initial_indent="* ",
+            subsequent_indent="  ",
+        )
+        for help_text in report.recommendations:
+            output.write("\n".join(wrapper.wrap(help_text)))
+            output.write("\n")
+
     output.write("\n")
 
     return output.getvalue()

--- a/src/reuse/lint.py
+++ b/src/reuse/lint.py
@@ -120,7 +120,7 @@ def format_plain(report: ProjectReport) -> str:
             files_without_licenses_excl
         )
 
-        if files_without_either:
+        if files_without_either or files_without_both:
             header = (
                 "# " + _("MISSING COPYRIGHT AND LICENSING INFORMATION") + "\n\n"
             )

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -86,7 +86,10 @@ def test_lint_deprecated(fake_repository):
     result = format_plain(report)
 
     assert ":-(" in result
+    assert "# DEPRECATED LICENSES" in result
     assert "GPL-3.0" in result
+    assert "Fix deprecated licenses:" in result
+    assert "spdx.org/licenses/#deprecated" in result
 
 
 def test_lint_bad_license(fake_repository):
@@ -99,8 +102,26 @@ def test_lint_bad_license(fake_repository):
     result = format_plain(report)
 
     assert ":-(" in result
+    assert "# BAD LICENSES" in result
     assert "foo.py" in result
     assert "bad-license" in result
+    assert "Fix bad licenses:" in result
+    assert "reuse.software/faq/#custom-license" in result
+
+
+def test_lint_licenses_without_extension(fake_repository):
+    """A license without file extension is detected."""
+    (fake_repository / "LICENSES/GPL-3.0-or-later.txt").rename(
+        fake_repository / "LICENSES/GPL-3.0-or-later"
+    )
+    project = Project(fake_repository)
+    report = ProjectReport.generate(project)
+    result = format_plain(report)
+
+    assert ":-(" in result
+    assert "# LICENSES WITHOUT FILE EXTENSION" in result
+    assert "GPL-3.0-or-later" in result
+    assert "Fix licenses without file extension:" in result
 
 
 def test_lint_missing_licenses(fake_repository):
@@ -111,8 +132,10 @@ def test_lint_missing_licenses(fake_repository):
     result = format_plain(report)
 
     assert ":-(" in result
+    assert "# MISSING LICENSES" in result
     assert "foo.py" in result
     assert "MIT" in result
+    assert "Fix missing licenses:" in result
 
 
 def test_lint_unused_licenses(fake_repository):
@@ -123,7 +146,9 @@ def test_lint_unused_licenses(fake_repository):
     result = format_plain(report)
 
     assert ":-(" in result
+    assert "# UNUSED LICENSES" in result
     assert "Unused licenses: MIT" in result
+    assert "Fix unused licenses:" in result
 
 
 @cpython
@@ -137,8 +162,10 @@ def test_lint_read_errors(fake_repository):
     result = format_plain(report)
 
     assert ":-(" in result
+    assert "# READ ERRORS" in result
     assert "Could not read:" in result
     assert "foo.py" in result
+    assert "Fix read errors:" in result
 
 
 def test_lint_files_without_copyright_and_licensing(fake_repository):
@@ -149,11 +176,14 @@ def test_lint_files_without_copyright_and_licensing(fake_repository):
     result = format_plain(report)
 
     assert ":-(" in result
+    assert "# MISSING COPYRIGHT AND LICENSING INFORMATION" in result
     assert (
         "The following files have no copyright and licensing information:"
         in result
     )
     assert "foo.py" in result
+    assert "Fix missing copyright/licensing information:" in result
+    assert "reuse.software/tutorial" in result
 
 
 def test_lint_json_output(fake_repository):
@@ -172,9 +202,11 @@ def test_lint_json_output(fake_repository):
     assert "non_compliant" in json_result
     assert "files" in json_result
     assert "summary" in json_result
+    assert "recommendations" in json_result
     # Test length of resulting list values
     assert len(json_result["files"]) == 9
     assert len(json_result["summary"]) == 5
+    assert len(json_result["recommendations"]) == 2
     # Test result
     assert json_result["summary"]["compliant"] is False
     # Test license path

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -439,8 +439,11 @@ def test_generate_project_report_to_dict_lint(fake_repository, multiprocessing):
         "reuse_tool_version",
     ]
 
+    # Check if the recommendation key is at the bottom of the dictionary
+    assert list(result.keys())[-1] == "recommendations"
+
     # Check if the rest of the keys are sorted alphabetically
-    assert list(result.keys())[3:] == sorted(list(result.keys())[3:])
+    assert list(result.keys())[3:-1] == sorted(list(result.keys())[3:-1])
 
 
 def test_bill_of_materials(fake_repository, multiprocessing):


### PR DESCRIPTION
Fix #672

As noted in the referenced issue, some error messages of `reuse lint` are not really helpful if your experience with REUSE and/or licensing is limited.

This PR attempts to improve the situation by adding a "Recommendations" section after the linting result, explaining the occured issues and how to best solve them (if there is an easy solution).

I'm not sure whether the position I implemented this in the code is ideal, but I liked that I could derive everything from the `report` object. Depending on what other issues we might want to explain, there might be better solutions, but I didn't invest many thoughts on this yet.

Possible blockers:
* The help texts should probably also go into the future JSON output. So #654 might need to be adapted, or this PR if JSON is added before.

Please find the output below in a repo in which basically everything is broken:

<details><summary>New output of `reuse lint` on a very problematic repo</summary>
<p>

```
$ reuse lint
reuse.project - WARNING - Could not resolve SPDX License Identifier of LICENSES/InVaLiD.txt, resolving to InVaLiD. Make sure the license is in the license list found at <https://spdx.org/licenses/> or that it starts with 'LicenseRef-', and that it has a file extension.
reuse.report - ERROR - Could not read 'README.md'
PermissionError: [Errno 13] Permission denied: 'README.md'
# BAD LICENSES

'InVaLiD' found in:
* LICENSES/InVaLiD.txt


# DEPRECATED LICENSES

The following licenses are deprecated by SPDX:
* GPL-2.0+


# LICENSES WITHOUT FILE EXTENSION

The following licenses have no file extension:
* LICENSES/Apache-2.0


# MISSING LICENSES

'MIT' found in:
* Makefile
* img/cat.jpg
* img/dog.jpg


# UNUSED LICENSES

The following licenses are not used:
* Apache-2.0
* CC-BY-SA-4.0
* GPL-2.0+
* InVaLiD


# READ ERRORS

Could not read:
* README.md


# MISSING COPYRIGHT AND LICENSING INFORMATION

The following files have no copyright and licensing information:
* src/main.c

The following files have no copyright information:
* Makefile

The following files have no licensing information:
* .gitignore


# SUMMARY

* Bad licenses: InVaLiD
* Deprecated licenses: GPL-2.0+
* Licenses without file extension: Apache-2.0
* Missing licenses: MIT
* Unused licenses: Apache-2.0, CC-BY-SA-4.0, GPL-2.0+, InVaLiD
* Used licenses: MIT
* Read errors: 1
* Files with copyright information: 3 / 5
* Files with license information: 3 / 5

Unfortunately, your project is not compliant with version 3.0 of the REUSE Specification :-(


# RECOMMENDATIONS

* Fix bad licenses: At least one license in the LICENSES directory and/or
  provided by 'SPDX-License-Identifier' tags is invalid. They are either not
  valid SPDX license identifiers or do not start with 'LicenseRef-'. FAQ about
  custom licenses: https://reuse.software/faq/#custom-license
* Fix deprecated licenses: At least one of the licenses in the LICENSES
  directory and/or provided by an 'SPDX-License-Identifier' tag or in
  '.reuse/dep5' has been deprecated by SPDX. The current list and their
  respective recommended  new identifiers can be found here:
  https://spdx.org/licenses/#deprecated
* Fix licenses without file extension: At least one license text file in the
  'LICENSES' directory does not have a '.txt' file extension. Please rename the
  file(s) accordingly.
* Fix missing licenses: For at least one of the license identifiers provided by
  the 'SPDX-LicenseIdentifier' tags, there is no corresponding license text file
  in the 'LICENSES' directory. For SPDX license identifiers, you can simply run
  'reuse download --all' to get any missing ones. For custom licenses (starting
  with 'LicenseRef-'), you need to add these files yourself.
* Fix unused licenses: At least one of the license text files in 'LICENSES' is
  not referenced for any file, e.g. by an 'SPDX-License-Identifier' tag. Please
  make sure that you either tag the accordingly licensed files properly, or
  delete the unused license text if you are sure that no file or code snippet is
  licensed as such.
* Fix read errors: At least one of the files in your directory cannot be read by
  the tool. Please check the file permissions. You will find the affected files
  at the top of the output as part of the logged error messages.
* Fix missing copyright/license information: For one or more files, the tool
  cannot find copyright and/or license information. Please add it as a comment
  in the file header, ideally using the 'SPDX-FileCopyrightText' tag. If that's
  not possible, you can use adjacent '.license' files or the '.reuse/dep5' file.
```
</p>
</details>