### PR TITLE
Make translations available in Docker images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ The versions follow [semantic versioning](https://semver.org).
 
 - Fixed automatic generation of Sphinx documentation via readthedocs.io by
   adding a `.readthedocs.yaml` configuration file (#648)
+- Translations are available in Docker images. (#701)
 
 ### Security
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,7 @@ RUN apk --no-cache add git mercurial python3
 # Build reuse into a virtualenv
 FROM base AS build
 
-RUN apk --no-cache add poetry
+RUN apk --no-cache add poetry gettext
 
 WORKDIR /reuse-tool
 COPY . /reuse-tool/

--- a/docker/Dockerfile-debian
+++ b/docker/Dockerfile-debian
@@ -15,7 +15,7 @@ RUN apt-get update \
 FROM base AS build
 
 RUN apt-get update \
-    && apt-get install -y python3-dev python3-pip \
+    && apt-get install -y python3-dev python3-pip gettext \
     && rm -rf /var/lib/apt/lists/*
 
 RUN pip install poetry

--- a/docker/Dockerfile-extra
+++ b/docker/Dockerfile-extra
@@ -12,7 +12,7 @@ RUN apk --no-cache add git mercurial python3 openssh-client
 # Build reuse into a virtualenv
 FROM base AS build
 
-RUN apk --no-cache add poetry
+RUN apk --no-cache add poetry gettext
 
 WORKDIR /reuse-tool
 COPY . /reuse-tool/


### PR DESCRIPTION
Fix #693 

gettext (msgfmt) was missing from the Docker images during build. This PR adds gettext during the setup phase. The actual Docker image size will not significantly be impacted as it's a multistage build.