### PR TITLE
Adds mapping for Textile (`.textile`) files #712

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The versions follow [semantic versioning](https://semver.org).
   - Fennel (`.fnl`) (#638)
   - CommonJS (`.cjs`) (#632)
   - Qt .pro (`.pro`) (#632)
+  - Textile (`.textile`) (#712)
 - More files are recognised:
   - Clang format (`.clang-format`) (#632)
 - Added loglevel argument to pytest and skip one test if loglevel is too high

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -663,6 +663,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".svg": UncommentableCommentStyle,
     ".swift": CCommentStyle,
     ".tex": TexCommentStyle,
+    ".textile": HtmlCommentStyle,
     ".thy": MlCommentStyle,
     ".toc": TexCommentStyle,
     ".toml": PythonCommentStyle,


### PR DESCRIPTION
This adds one of the three supported comments styles for this format:

https://textile-lang.com/doc/textile-comments

If this is ever an issue for someone in the future, they would have to add support for the two native, custom types of comments.