### PR TITLE
fix(docker): add git safe dir to data dir

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,6 +31,7 @@ COPY --from=build /opt/venv /opt/venv
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
+RUN git config --global --add safe.directory /data
 WORKDIR /data
 
 ENTRYPOINT ["reuse"]

--- a/docker/Dockerfile-debian
+++ b/docker/Dockerfile-debian
@@ -38,6 +38,7 @@ COPY --from=build /opt/venv /opt/venv
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
+RUN git config --global --add safe.directory /data
 WORKDIR /data
 
 ENTRYPOINT ["reuse"]

--- a/docker/Dockerfile-extra
+++ b/docker/Dockerfile-extra
@@ -32,6 +32,7 @@ COPY --from=build /opt/venv /opt/venv
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
+RUN git config --global --add safe.directory /data
 WORKDIR /data
 
 ENTRYPOINT ["reuse"]


### PR DESCRIPTION
Fixes the requirement that: Newer versions of git needs the 'git config --global --add safe.directory /data' setting to work in a container.

Here is an example to verify both the problem and the fix: 

Problem:
1) .Build an reuse image from latest main code, official branch:

` docker build -f docker/Dockerfile-debian -t reusetest_default .`
 
2). Run the code in reuse compliant project, I used my script project (https://github.com/janderssonse/janderscripts)

` docker run --rm --volume $(pwd):/data reusetest_default lint`
 
 **Result**: Fails respecting .gitignore etc as the git config will fail and show warning '---no VCS'' etc.
 
 Fix:
3). Now try the same dockerfile but with the added fix in this pr:

` docker build -f docker/Dockerfile-debian -t reusetest_with_git_add_data_safe .`
 
4).  Run on same example repo as before (https://github.com/janderssonse/janderscripts)

` docker run --rm --volume $(pwd):/data reusetest_with_git_add_data_safe lint`
  
 ` Result`: success - git (vcs) accepted, .gitignore respected etc.