### PR TITLE
Allow year ranges to contain space around the dash

### DIFF
--- a/src/reuse/_util.py
+++ b/src/reuse/_util.py
@@ -6,6 +6,7 @@
 # SPDX-FileCopyrightText: 2022 Carmen Bianca Bakker <carmenbianca@fsfe.org>
 # SPDX-FileCopyrightText: 2022 Pietro Albini <pietro.albini@ferrous-systems.com>
 # SPDX-FileCopyrightText: 2023 DB Systel GmbH
+# SPDX-FileCopyrightText: 2023 Johannes Zarl-Zierl <johannes@zarl-zierl.at>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -81,17 +82,17 @@ _IDENTIFIER_PATTERN = re.compile(
 _COPYRIGHT_PATTERNS = [
     re.compile(
         r"(?P<copyright>(?P<prefix>SPDX-(File|Snippet)CopyrightText:)\s+"
-        r"((?P<year>\d{4} - \d{4}|\d{4}),?\s+)?"
+        r"((?P<year>\d{4} *- *\d{4}|\d{4}),?\s+)?"
         r"(?P<statement>.*?))" + _END_PATTERN
     ),
     re.compile(
         r"(?P<copyright>(?P<prefix>Copyright(\s?\([cC]\))?)\s+"
-        r"((?P<year>\d{4} - \d{4}|\d{4}),?\s+)?"
+        r"((?P<year>\d{4} *- *\d{4}|\d{4}),?\s+)?"
         r"(?P<statement>.*?))" + _END_PATTERN
     ),
     re.compile(
         r"(?P<copyright>(?P<prefix>©)\s+"
-        r"((?P<year>\d{4} - \d{4}|\d{4}),?\s+)?"
+        r"((?P<year>\d{4} *- *\d{4}|\d{4}),?\s+)?"
         r"(?P<statement>.*?))" + _END_PATTERN
     ),
 ]
@@ -222,7 +223,7 @@ def _parse_copyright_year(year: str) -> list:
         ret = []
     if re.match(r"\d{4}$", year):
         ret = [int(year)]
-    if re.match(r"\d{4} - \d{4}$", year):
+    if re.match(r"\d{4} *- *\d{4}$", year):
         ret = [int(year[:4]), int(year[-4:])]
     return ret
 

--- a/src/reuse/_util.py
+++ b/src/reuse/_util.py
@@ -82,17 +82,17 @@ _IDENTIFIER_PATTERN = re.compile(
 _COPYRIGHT_PATTERNS = [
     re.compile(
         r"(?P<copyright>(?P<prefix>SPDX-(File|Snippet)CopyrightText:)\s+"
-        r"((?P<year>\d{4} *- *\d{4}|\d{4}),?\s+)?"
+        r"((?P<year>\d{4} ?- ?\d{4}|\d{4}),?\s+)?"
         r"(?P<statement>.*?))" + _END_PATTERN
     ),
     re.compile(
         r"(?P<copyright>(?P<prefix>Copyright(\s?\([cC]\))?)\s+"
-        r"((?P<year>\d{4} *- *\d{4}|\d{4}),?\s+)?"
+        r"((?P<year>\d{4} ?- ?\d{4}|\d{4}),?\s+)?"
         r"(?P<statement>.*?))" + _END_PATTERN
     ),
     re.compile(
         r"(?P<copyright>(?P<prefix>©)\s+"
-        r"((?P<year>\d{4} *- *\d{4}|\d{4}),?\s+)?"
+        r"((?P<year>\d{4} ?- ?\d{4}|\d{4}),?\s+)?"
         r"(?P<statement>.*?))" + _END_PATTERN
     ),
 ]
@@ -223,7 +223,7 @@ def _parse_copyright_year(year: str) -> list:
         ret = []
     if re.match(r"\d{4}$", year):
         ret = [int(year)]
-    if re.match(r"\d{4} *- *\d{4}$", year):
+    if re.match(r"\d{4} ?- ?\d{4}$", year):
         ret = [int(year[:4]), int(year[-4:])]
     return ret
 


### PR DESCRIPTION
As shown in the examples of the SPDX specification (https://spdx.github.io/spdx-spec/v2.3/file-information/#8.8), the a copyright year range is not required to contain spaces around the dash character.

This patch allows zero or more spaces on each side of the dash, making all of the following year ranges being accepted by reuse: "2023"
"2022-2023"
"2022 - 2023"
"2022-  2023"
"2022  -2023"

Reuse still writes the copyright in a normalized "yyyy - yyyy" format.

Closes #647