### PR TITLE
Add support for Visual Studio Code workspace file ".code-workspace"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ CLI command and its behaviour. There are no guarantees of stability for the
   - CommonJS (`.cjs`) (#632)
   - Qt .pro (`.pro`) (#632)
   - Textile (`.textile`) (#712)
+  - Visual Studio Code workspace (`.code-workspace`) (#746)
   - Svelte components (`.svelte`)
 - More files are recognised:
   - Clang format (`.clang-format`) (#632)

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -520,7 +520,6 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".cljc": LispCommentStyle,
     ".cljs": LispCommentStyle,
     ".cmake": PythonCommentStyle,  # TODO: Bracket comments not supported.
-    # Visual Studio Code workspace file (JSON with Comments based)
     ".code-workspace": CCommentStyle,
     ".coffee": PythonCommentStyle,
     ".cpp": CCommentStyle,

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -520,6 +520,8 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".cljc": LispCommentStyle,
     ".cljs": LispCommentStyle,
     ".cmake": PythonCommentStyle,  # TODO: Bracket comments not supported.
+    # Visual Studio Code workspace file (JSON with Comments based)
+    ".code-workspace": CCommentStyle,
     ".coffee": PythonCommentStyle,
     ".cpp": CCommentStyle,
     ".cs": CCommentStyle,


### PR DESCRIPTION
Add support of Visual Studio Code workspace files (which is based on JSON with Comment files)

Fixes #746 