### PR TITLE
Add support for flutter Application Resource Bundle file ".arb"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ CLI command and its behaviour. There are no guarantees of stability for the
   - Qt .pro (`.pro`) (#632)
   - Textile (`.textile`) (#712)
   - Visual Studio Code workspace (`.code-workspace`) (#746)
+  - Application Resource Bundle (`.arb`) (#748)
   - Svelte components (`.svelte`)
 - More files are recognised:
   - Clang format (`.clang-format`) (#632)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,8 +48,8 @@ CLI command and its behaviour. There are no guarantees of stability for the
   - CommonJS (`.cjs`) (#632)
   - Qt .pro (`.pro`) (#632)
   - Textile (`.textile`) (#712)
-  - Visual Studio Code workspace (`.code-workspace`) (#746)
-  - Application Resource Bundle (`.arb`) (#748)
+  - Visual Studio Code workspace (`.code-workspace`) (#747)
+  - Application Resource Bundle (`.arb`) (#749)
   - Svelte components (`.svelte`)
 - More files are recognised:
   - Clang format (`.clang-format`) (#632)

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -497,6 +497,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".ahkl": LispCommentStyle,
     ".aidl": CCommentStyle,
     ".applescript": AppleScriptCommentStyle,
+    ".arb": UncommentableCommentStyle,
     ".asax": AspxCommentStyle,
     ".asc": CCommentStyle,
     ".asciidoc": CCommentStyle,


### PR DESCRIPTION
Add support for the Application Resource Bundle (.arb) files mostly used in Flutter to generate localisation.

Fixes https://github.com/fsfe/reuse-tool/issues/748