### PR TITLE
Add support for flutter pubspec.lock file "pubspec.lock" and flutter ".metadata" file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ CLI command and its behaviour. There are no guarantees of stability for the
   - Clang format (`.clang-format`) (#632)
   - Browserslist config (`.browserslist`)
   - Prettier config (`.prettierrc`) and ignored files (`.prettierignore`)
+  - Flutter pubspec.lock (`pubspec.lock`) (#)
+  - Flutter .metadata (`.metadata`) (#)
 - Added loglevel argument to pytest and skip one test if loglevel is too high
   (#645).
 - `--add-license-concluded`, `--creator-person`, and `--creator-organization`

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -713,6 +713,7 @@ FILENAME_COMMENT_STYLE_MAP = {
     ".gitignore": PythonCommentStyle,
     ".gitmodules": PythonCommentStyle,
     ".mailmap": PythonCommentStyle,
+    ".metadata": UncommentableCommentStyle,
     ".mdlrc": PythonCommentStyle,  # Markdown-linter config
     ".npmignore": PythonCommentStyle,
     ".prettierrc": UncommentableCommentStyle,  # could either be JSON or YAML
@@ -742,6 +743,7 @@ FILENAME_COMMENT_STYLE_MAP = {
     "manifest": PythonCommentStyle,  # used by cdist
     "meson.build": PythonCommentStyle,
     "meson_options.txt": PythonCommentStyle,
+    "pubspec.lock": UncommentableCommentStyle,
     "Rakefile": PythonCommentStyle,
     "requirements.txt": PythonCommentStyle,
     "ROOT": MlCommentStyle,


### PR DESCRIPTION
Add support for the pubspec.lock files used in Flutter to manage project dependencies.

Also support `.metadata` file which is used in Flutter to track project properties. The file can also be used by other libraries or in different context (but mostly as extension: `*.metadata` type instead of file).

Fixes https://github.com/fsfe/reuse-tool/issues/750