### PR TITLE
feat: Jakarte Server Page (.jsp) comment style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ CLI command and its behaviour. There are no guarantees of stability for the
   - Visual Studio Code workspace (`.code-workspace`) (#747)
   - Application Resource Bundle (`.arb`) (#749)
   - Svelte components (`.svelte`)
+  - Jakarte Server Page (`.jsp`) (#757)
 - More files are recognised:
   - Clang format (`.clang-format`) (#632)
   - Browserslist config (`.browserslist`)

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -578,6 +578,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".jinja2": JinjaCommentStyle,
     ".js": CCommentStyle,
     ".json": UncommentableCommentStyle,
+    ".jsp": AspxCommentStyle,
     ".jsx": CCommentStyle,
     ".jy": PythonCommentStyle,
     ".ksh": PythonCommentStyle,


### PR DESCRIPTION
Add comment style for Jakarta Server Page (.jsp) files. The comment syntax is
`<%-- comment --%>` as observed in real code and found described in this
tutorial
https://www.digitalocean.com/community/tutorials/jsp-example-tutorial-for-beginners#jsp-comments

Signed-off-by: Nico Rikken <nico@nicorikken.eu>
