### PR TITLE
feat: uncommentable AES encrypted files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ CLI command and its behaviour. There are no guarantees of stability for the
   - Visual Studio Code workspace (`.code-workspace`) (#747)
   - Application Resource Bundle (`.arb`) (#749)
   - Svelte components (`.svelte`)
+  - AES encrypted files (`.aes`) (#758)
 - More files are recognised:
   - Clang format (`.clang-format`) (#632)
   - Browserslist config (`.browserslist`)

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -494,6 +494,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".adb": HaskellCommentStyle,
     ".adoc": CCommentStyle,
     ".ads": HaskellCommentStyle,
+    ".aes": UncommentableCommentStyle,
     ".ahk": LispCommentStyle,
     ".ahkl": LispCommentStyle,
     ".aidl": CCommentStyle,


### PR DESCRIPTION
Support for `.aes` files which is a typical extension for AES-encrypted files.
Commenting is not possible for these files.

Signed-off-by: Nico Rikken <nico@nicorikken.eu>
