### PR TITLE
Explicitly state deprecation instead of trying to suppress it

### DIFF
--- a/src/reuse/_main.py
+++ b/src/reuse/_main.py
@@ -150,7 +150,7 @@ def parser() -> argparse.ArgumentParser:
         "addheader",
         header.add_arguments,
         header.run,
-        help=argparse.SUPPRESS,
+        help=_("deprecated in favor of annotate"),
     )
 
     add_command(


### PR DESCRIPTION
Apparently, argparse does not support suppression of help for subcommands and this will likely not change:
https://github.com/python/cpython/issues/67037
The simple, even if not quite as pretty solution is to just make the deprecation explicit instead of trying to suppress it.

Closes #739.