### PR TITLE
Update REUSE spec version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ recommendations.
 - Documentation: <https://reuse.readthedocs.io> and <https://reuse.software>
 - Source code: <https://github.com/fsfe/reuse-tool>
 - PyPI: <https://pypi.python.org/pypi/reuse>
-- REUSE: 3.0
+- REUSE: 3.1
 - Python: 3.8+
 
 ## Table of contents


### PR DESCRIPTION
We missed that in the 2.0.0 release.