### PR TITLE
Revert the mandatory order of precedence; display PendingDeprecationWarning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ CLI command and its behaviour. There are no guarantees of stability for the
 - Added `--json` flag to `lint` command (#654).
 - `reuse.ReuseInfo` now has `copy` and `union` methods. (#759)
 - Added Ukrainian and Czech translations (#767)
+- Added `--suppress-deprecation` to hide (verbose) deprecation warnings. (#778)
 
 ### Changed
 
@@ -86,11 +87,16 @@ CLI command and its behaviour. There are no guarantees of stability for the
   version of reuse. (#724)
 - Bumped SPDX license list to v3.21. (#763)
 - Bumped REUSE Spec version to 3.1. (#768)
-- Introduce an order of precedence. The copyright and licensing information from
-  different sources (e.g. `.license` or `.reuse/dep5` file) is no longer merged.
-  (#654)
 
 ### Deprecated
+
+- Pending deprecation of aggregation of file sources. Presently, when copyright
+  and licensing information is defined both within e.g. the file itself and in
+  the DEP5 file, then the information is merged or aggregated for the purposes
+  of linting and BOM generation. In the future, this will no longer be the case
+  unless explicitly defined. The exact mechanism for this is not yet concrete,
+  but a `PendingDeprecationWarning` will be shown to the user to make them aware
+  of this. (#778)
 
 ### Removed
 

--- a/src/reuse/_main.py
+++ b/src/reuse/_main.py
@@ -9,6 +9,7 @@
 import argparse
 import logging
 import sys
+import warnings
 from gettext import gettext as _
 from typing import IO, Callable, List, Optional, Type, cast
 
@@ -67,6 +68,11 @@ def parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--debug", action="store_true", help=_("enable debug statements")
+    )
+    parser.add_argument(
+        "--suppress-deprecation",
+        action="store_true",
+        help=_("hide deprecation warnings"),
     )
     parser.add_argument(
         "--include-submodules",
@@ -271,6 +277,9 @@ def main(args: Optional[List[str]] = None, out: IO[str] = sys.stdout) -> int:
     parsed_args = main_parser.parse_args(args)
 
     setup_logging(level=logging.DEBUG if parsed_args.debug else logging.WARNING)
+    # Show all warnings raised by ourselves.
+    if not parsed_args.suppress_deprecation:
+        warnings.filterwarnings("default", module="reuse")
 
     if parsed_args.version:
         out.write(f"reuse {__version__}\n")

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -191,33 +191,4 @@ def test_lint_json_output(fake_repository):
             )
 
 
-def test_lint_json_output_precedence(fake_repository):
-    """Test for lint with JSON output with focus on precedence."""
-    (fake_repository / "doc/differently_licensed_docs.rst").write_text(
-        "SPDX-License-Identifier: MIT"
-    )
-    project = Project(fake_repository)
-    report = ProjectReport.generate(project)
-
-    json_result = report.to_dict_lint()
-
-    assert json_result
-    # Test result
-    assert json_result["summary"]["compliant"] is False
-    # Test license path precedence
-    for test_file in json_result["files"]:
-        if test_file["path"].startswith(
-            str(fake_repository / "doc/differently_licensed_docs.rst")
-        ):
-            assert test_file["licenses"][0]["value"] == "MIT"
-            assert test_file["licenses"][0]["source"] == str(
-                fake_repository / "doc/differently_licensed_docs.rst"
-            )
-        if test_file["path"].startswith(str(fake_repository / "doc/index.rst")):
-            assert test_file["licenses"][0]["value"] == "CC0-1.0"
-            assert test_file["licenses"][0]["source"] == str(
-                fake_repository / ".reuse/dep5"
-            )
-
-
 # REUSE-IgnoreEnd

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -8,6 +8,7 @@
 
 import os
 import shutil
+import warnings
 from importlib import import_module
 from inspect import cleandoc
 from pathlib import Path
@@ -246,24 +247,10 @@ def test_reuse_info_of_only_copyright(fake_repository):
     )
 
 
-def test_reuse_info_of_only_copyright_also_covered_by_debian(fake_repository):
-    """A file contains only a copyright line, but debian/copyright also has
-    information on this file. Use only the information from file header.
-    """
-    (fake_repository / "doc/foo.py").write_text(
-        "SPDX-FileCopyrightText: in file"
-    )
-    project = Project(fake_repository)
-    reuse_info = project.reuse_info_of("doc/foo.py")
-
-    assert len(reuse_info.copyright_lines) == 1
-    assert "SPDX-FileCopyrightText: in file" in reuse_info.copyright_lines
-
-
 def test_reuse_info_of_also_covered_by_dep5(fake_repository):
     """A file contains all REUSE information, but .reuse/dep5 also
-    provides information on this file. Use only the information
-    from the file header.
+    provides information on this file. Aggregate the information (for now), and
+    expect a PendingDeprecationWarning.
     """
     (fake_repository / "doc/foo.py").write_text(
         dedent(
@@ -273,11 +260,17 @@ def test_reuse_info_of_also_covered_by_dep5(fake_repository):
         )
     )
     project = Project(fake_repository)
-    reuse_info = project.reuse_info_of("doc/foo.py")
-    assert LicenseSymbol("MIT") in reuse_info.spdx_expressions
-    assert LicenseSymbol("CC0-1.0") not in reuse_info.spdx_expressions
-    assert "SPDX-FileCopyrightText: in file" in reuse_info.copyright_lines
-    assert "2017 Jane Doe" not in reuse_info.copyright_lines
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        reuse_info = project.reuse_info_of("doc/foo.py")
+        assert LicenseSymbol("MIT") in reuse_info.spdx_expressions
+        assert LicenseSymbol("CC0-1.0") in reuse_info.spdx_expressions
+        assert "SPDX-FileCopyrightText: in file" in reuse_info.copyright_lines
+        assert "2017 Jane Doe" in reuse_info.copyright_lines
+
+        assert len(caught_warnings) == 1
+        assert issubclass(
+            caught_warnings[0].category, PendingDeprecationWarning
+        )
 
 
 def test_reuse_info_of_no_duplicates(empty_directory):


### PR DESCRIPTION
See rationale in #779 for reverting this behaviour.