### PR TITLE
Ignore the LICENCE file

### DIFF
--- a/src/reuse/__init__.py
+++ b/src/reuse/__init__.py
@@ -63,6 +63,7 @@ _IGNORE_MESON_PARENT_DIR_PATTERNS = [
 ]
 
 _IGNORE_FILE_PATTERNS = [
+    re.compile(r"^LICENCE"),
     re.compile(r"^LICENSE"),
     re.compile(r"^COPYING"),
     # ".git" as file happens in submodules


### PR DESCRIPTION
`reuse lint` complains that my licence file is missing a licence header:

    The following files have no licensing information:
    * LICENCE

Obviously this file doesn't need a licence header, so ignore it entirely.