### PR TITLE
Add Typst file support (.typ)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ CLI command and its behaviour. There are no guarantees of stability for the
   - Flutter pubspec.lock (`pubspec.lock`) (#751)
   - Flutter .metadata (`.metadata`) (#751)
   - Terraform (`.tf`, `tfvars`) and HCL (`.hcl`). (#756)
+  - Typst (`.typ`)
 - Added loglevel argument to pytest and skip one test if loglevel is too high
   (#645).
 - `--add-license-concluded`, `--creator-person`, and `--creator-organization`

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -686,7 +686,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".ts": CCommentStyle,
     ".tsx": CCommentStyle,
     ".ttl": PythonCommentStyle,  # Turtle/RDF
-    ".typ": CCommentStyle, # typst files
+    ".typ": CCommentStyle,  # typst files
     ".ui": UncommentableCommentStyle,
     ".v": CCommentStyle,  # V-Lang source code
     ".vala": CCommentStyle,

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -686,6 +686,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".ts": CCommentStyle,
     ".tsx": CCommentStyle,
     ".ttl": PythonCommentStyle,  # Turtle/RDF
+    ".typ": CCommentStyle, # typst files
     ".ui": UncommentableCommentStyle,
     ".v": CCommentStyle,  # V-Lang source code
     ".vala": CCommentStyle,


### PR DESCRIPTION
Typst is a typesetting program created in rust in the same vein of LaTeX.

the syntax for comments is [here](https://typst.app/docs/reference/syntax/#comments) and uses the same style as the C programming language for both single and multi-line comments, so a new style is not needed.