### PR TITLE
Release 2.1.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.0
+current_version = 2.1.0
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?P<release>(a|b|rc)?)(?P<releasenumber>\d*)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,47 @@ CLI command and its behaviour. There are no guarantees of stability for the
 
 ### Added
 
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## 2.1.0 - 2023-07-18
+
+After the yanked 2.0.0 release, we're excited to announce our latest major
+version packed with new features and improvements! We've expanded our file type
+recognition, now including Fennel, CommonJS, Qt .pro, .pri, .qrc, .qss, .ui,
+Textile, Visual Studio Code workspace, Application Resource Bundle, Svelte
+components, AES encrypted files, Jakarta Server Page, Clang format, Browserslist
+config, Prettier config and ignored files, Flutter pubspec.lock, .metadata,
+Terraform and HCL, Typst and more.
+
+We've also added the ability to detect SPDX snippet tags in files and introduced
+additional license metadata for the Python package. A new `--json` flag has been
+added to the `lint` command, marking the first step towards better integration
+of REUSE output with other tools.
+
+Notably, `reuse.ReuseInfo` has been enhanced with `copy` and `union` methods and
+now stores information about the source from which the information was gathered.
+
+On the changes front, we've bumped the SPDX license list to v3.21 and made
+significant updates to our Sphinx documentation. Please note that Python 3.6 and
+3.7 support has been dropped in this release.
+
+We've fixed several issues including automatic generation of Sphinx
+documentation via readthedocs.io and a compatibility issue where reuse could not
+be installed if gettext is not installed.
+
+This update is all about making your experience better. Enjoy adding copyright
+and licensing information to your code!
+
+### Added
+
 - Detect SPDX snippet tags in files. (#699)
 - More file types are recognised:
   - Fennel (`.fnl`) (#638)
@@ -90,7 +131,6 @@ CLI command and its behaviour. There are no guarantees of stability for the
 - Removed dependency on setuptools' `pkg_resources` to determine the installed
   version of reuse. (#724)
 - Bumped SPDX license list to v3.21. (#763)
-- Bumped REUSE Spec version to 3.1. (#768)
 - `Project.reuse_info_of` now returns a list of `ReuseInfo` objects instead of a
   single one. This is because the source information is now stored alongside the
   REUSE information. (#787)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,9 +67,6 @@ additional license metadata for the Python package. A new `--json` flag has been
 added to the `lint` command, marking the first step towards better integration
 of REUSE output with other tools.
 
-Notably, `reuse.ReuseInfo` has been enhanced with `copy` and `union` methods and
-now stores information about the source from which the information was gathered.
-
 On the changes front, we've bumped the SPDX license list to v3.21 and made
 significant updates to our Sphinx documentation. Please note that Python 3.6 and
 3.7 support has been dropped in this release.

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Git. This uses [pre-commit](https://pre-commit.com/). Once you
 ```yaml
 repos:
   - repo: https://github.com/fsfe/reuse-tool
-    rev: v2.0.0
+    rev: v2.1.0
     hooks:
       - id: reuse
 ```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,8 @@
 #
 import os
 import sys
-from importlib.metadata import PackageNotFoundError, version as get_version
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as get_version
 from shutil import copyfile
 
 sys.path.insert(0, os.path.abspath("../src/"))

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -76,7 +76,7 @@ try:
     # The full version, including alpha/beta/rc tags.
     release = get_version("reuse")
 except PackageNotFoundError:
-    release = "2.0.0"
+    release = "2.1.0"
 
 # The short X.Y.Z version.
 version = ".".join(release.split(".")[:3])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@
 
 [tool.poetry]
 name = "reuse"
-version = "2.0.0"
+version = "2.1.0"
 description = "reuse is a tool for compliance with the REUSE recommendations."
 authors = [
     "Free Software Foundation Europe <contact@fsfe.org>",

--- a/src/reuse/__init__.py
+++ b/src/reuse/__init__.py
@@ -31,7 +31,7 @@ try:
     __version__ = version("reuse")
 except PackageNotFoundError:
     # package is not installed
-    __version__ = "2.0.0"
+    __version__ = "2.1.0"
 
 __author__ = "Carmen Bianca Bakker"
 __email__ = "carmenbianca@fsfe.org"

--- a/src/reuse/__init__.py
+++ b/src/reuse/__init__.py
@@ -36,7 +36,7 @@ except PackageNotFoundError:
 __author__ = "Carmen Bianca Bakker"
 __email__ = "carmenbianca@fsfe.org"
 __license__ = "Apache-2.0 AND CC0-1.0 AND CC-BY-SA-4.0 AND GPL-3.0-or-later"
-__REUSE_version__ = "3.1"
+__REUSE_version__ = "3.0"
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
After the yanked 2.0.0 release, we're excited to announce our latest major version packed with new features and improvements! We've expanded our file type recognition, now including Fennel, CommonJS, Qt .pro, .pri, .qrc, .qss, .ui, Textile, Visual Studio Code workspace, Application Resource Bundle, Svelte components, AES encrypted files, Jakarta Server Page, Clang format, Browserslist config, Prettier config and ignored files, Flutter pubspec.lock, .metadata, Terraform and HCL, Typst and more.

We've also added the ability to detect SPDX snippet tags in files and introduced additional license metadata for the Python package. A new `--json` flag has been added to the `lint` command, marking the first step towards better integration of REUSE output with other tools.

Notably, `reuse.ReuseInfo` has been enhanced with `copy` and `union` methods and now stores information about the source from which the information was gathered.

On the changes front, we've bumped the SPDX license list to v3.21 and made significant updates to our Sphinx documentation. Please note that Python 3.6 and 3.7 support has been dropped in this release.

We've fixed several issues including automatic generation of Sphinx documentation via readthedocs.io and a compatibility issue where reuse could not be installed if gettext is not installed.

This update is all about making your experience better. Enjoy adding copyright and licensing information to your code!