### PR TITLE
add option to exclude hidden dirs and files

### DIFF
--- a/src/reuse/__init__.py
+++ b/src/reuse/__init__.py
@@ -58,6 +58,8 @@ _IGNORE_DIR_PATTERNS = [
     re.compile(r"^\.reuse$"),
 ]
 
+_IGNORE_HIDDEN_PATTERN = re.compile(r"^\..+$")
+
 _IGNORE_MESON_PARENT_DIR_PATTERNS = [
     re.compile(r"^subprojects$"),
 ]

--- a/src/reuse/_main.py
+++ b/src/reuse/_main.py
@@ -85,6 +85,16 @@ def parser() -> argparse.ArgumentParser:
         help=_("do not skip over Meson subprojects"),
     )
     parser.add_argument(
+        "--exclude-hidden-dirs",
+        action="store_true",
+        help=_("skip hidden directories"),
+    )
+    parser.add_argument(
+        "--exclude-hidden-files",
+        action="store_true",
+        help=_("skip hidden files"),
+    )
+    parser.add_argument(
         "--no-multiprocessing",
         action="store_true",
         help=_("do not use multiprocessing"),
@@ -291,6 +301,8 @@ def main(args: Optional[List[str]] = None, out: IO[str] = sys.stdout) -> int:
         project = create_project()
     project.include_submodules = parsed_args.include_submodules
     project.include_meson_subprojects = parsed_args.include_meson_subprojects
+    project.exclude_hidden_dirs = parsed_args.exclude_hidden_dirs
+    project.exclude_hidden_files = parsed_args.exclude_hidden_files
 
     return parsed_args.func(parsed_args, project, out)
 

--- a/src/reuse/lint.py
+++ b/src/reuse/lint.py
@@ -30,6 +30,9 @@ def add_arguments(parser: ArgumentParser) -> None:
         "-j", "--json", action="store_true", help=_("formats output as JSON")
     )
     mutex_group.add_argument(
+        "--ignore-hidden-files", action="store_true", help=_("ignore hidden files")
+    )
+    mutex_group.add_argument(
         "-p",
         "--plain",
         action="store_true",

--- a/src/reuse/lint.py
+++ b/src/reuse/lint.py
@@ -30,7 +30,9 @@ def add_arguments(parser: ArgumentParser) -> None:
         "-j", "--json", action="store_true", help=_("formats output as JSON")
     )
     mutex_group.add_argument(
-        "--ignore-hidden-files", action="store_true", help=_("ignore hidden files")
+        "--ignore-hidden-files",
+        action="store_true",
+        help=_("ignore hidden files"),
     )
     mutex_group.add_argument(
         "-p",

--- a/src/reuse/project.py
+++ b/src/reuse/project.py
@@ -24,6 +24,7 @@ from license_expression import ExpressionError
 from . import (
     _IGNORE_DIR_PATTERNS,
     _IGNORE_FILE_PATTERNS,
+    _IGNORE_HIDDEN_PATTERN,
     _IGNORE_MESON_PARENT_DIR_PATTERNS,
     IdentifierNotFound,
     ReuseInfo,
@@ -62,6 +63,8 @@ class Project:
         root: StrPath,
         include_submodules: bool = False,
         include_meson_subprojects: bool = False,
+        exclude_hidden_files: bool = False,
+        exclude_hidden_dirs: bool = False,
     ):
         self._root = Path(root)
         if not self._root.is_dir():
@@ -265,9 +268,15 @@ class Project:
             for pattern in _IGNORE_FILE_PATTERNS:
                 if pattern.match(name):
                     return True
+            if self.exclude_hidden_files:
+                if _IGNORE_HIDDEN_PATTERN.match(name):
+                    return True
         elif path.is_dir():
             for pattern in _IGNORE_DIR_PATTERNS:
                 if pattern.match(name):
+                    return True
+            if self.exclude_hidden_dirs:
+                if _IGNORE_HIDDEN_PATTERN.match(name):
                     return True
             if not self.include_meson_subprojects:
                 for pattern in _IGNORE_MESON_PARENT_DIR_PATTERNS:


### PR DESCRIPTION
Reasoning : In our CI, the build artifact contains dependencies in a hidden directory. Because of this, reuse fails to validate using lint because its detecting issues in the dependencies directory.

By adding this option, we are able to explicitly tell reuse to exclude hidden directories, which contains dependencies in our case.