### PR TITLE
feat: no strict dep5 parsing

### DIFF
--- a/src/reuse/project.py
+++ b/src/reuse/project.py
@@ -306,7 +306,7 @@ class Project:
             copyright_path = self.root / ".reuse/dep5"
             try:
                 with copyright_path.open(encoding="utf-8") as fp:
-                    self._copyright_val = Copyright(fp)
+                    self._copyright_val = Copyright(fp, strict=False)
             except OSError:
                 _LOGGER.debug("no .reuse/dep5 file, or could not read it")
             except DebianError:

--- a/src/reuse/report.py
+++ b/src/reuse/report.py
@@ -19,9 +19,9 @@ from pathlib import Path, PurePath
 from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Set, cast
 from uuid import uuid4
 
-from . import __REUSE_version__, __version__
+from . import ReuseInfo, __REUSE_version__, __version__
 from ._util import _LICENSING, StrPath, _checksum
-from .project import Project, ReuseInfo
+from .project import Project
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -298,7 +298,7 @@ def dep5_copyright():
     with (RESOURCES_DIRECTORY / "fake_repository/.reuse/dep5").open(
         encoding="utf-8"
     ) as fp:
-        return Copyright(fp)
+        return Copyright(fp, strict=False)
 
 
 @pytest.fixture()

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -269,10 +269,11 @@ def test_generate_file_report_to_dict_lint_source_information(fake_repository):
 
 
 def test_strict_dep5_in_file_report(fake_repository):
-    """All copyright information of a strictly formatted dep5 file should be taken
-    into account in the file report. Strictly formatted meaning that there is a
-    single Copyright entry with indentend values.
+    """All copyright information of a strictly formatted dep5 file should be
+    taken into account in the file report. Strictly formatted meaning that there
+    is a single Copyright entry with indentend values.
     """
+    # pylint: disable=line-too-long
     (fake_repository / ".reuse/dep5").write_text(
         dedent(
             """
@@ -316,14 +317,15 @@ def test_strict_dep5_in_file_report(fake_repository):
 
 
 def test_non_strict_dep5_in_file_report(fake_repository):
-    """Copyright information of a non-strictly formatted dep5 file should be taken
-    into account in the file report. Non-strictly formatted meaning that there
-    are multiple Copyright entries.
+    """Copyright information of a non-strictly formatted dep5 file should be
+    taken into account in the file report. Non-strictly formatted meaning that
+    there are multiple Copyright entries.
 
     Note that in the non-strict mode only the first Copyright entry is taken
     into account and the rest is silently ignored. This is undesireable but
     reflects the current state of reuse-tool.
     """
+    # pylint: disable=line-too-long
     (fake_repository / ".reuse/dep5").write_text(
         dedent(
             """

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -316,9 +316,13 @@ def test_strict_dep5_in_file_report(fake_repository):
 
 
 def test_non_strict_dep5_in_file_report(fake_repository):
-    """All copyright information of a non-strictly formatted dep5 file should be
-    taken into account in the file report. Non-strictly formatted meaning that
-    there are multiple Copyright entries.
+    """Copyright information of a non-strictly formatted dep5 file should be taken
+    into account in the file report. Non-strictly formatted meaning that there
+    are multiple Copyright entries.
+
+    Note that in the non-strict mode only the first Copyright entry is taken
+    into account and the rest is silently ignored. This is undesireable but
+    reflects the current state of reuse-tool.
     """
     (fake_repository / ".reuse/dep5").write_text(
         dedent(
@@ -348,16 +352,6 @@ def test_non_strict_dep5_in_file_report(fake_repository):
             "source": ".reuse/dep5",
             "source_type": "dep5",
             "value": "2017 Jane Doe",
-        },
-        {
-            "source": ".reuse/dep5",
-            "source_type": "dep5",
-            "value": "2018 John Doe",
-        },
-        {
-            "source": ".reuse/dep5",
-            "source_type": "dep5",
-            "value": "2019 Joey Doe",
         },
     ]
 


### PR DESCRIPTION
Since version 0.1.47 of python-debian the dep5 parsing is strict. This is causing issues for certain users that have multiple Copyright statements in their Dep5 file. Disablng strictness removes the issue for those users.

Closes #803