### PR TITLE
lint: help beginners to figure out what MISSING LICENSES means

### DIFF
--- a/src/reuse/lint.py
+++ b/src/reuse/lint.py
@@ -78,7 +78,13 @@ def format_plain(report: ProjectReport) -> str:
 
         # Missing licenses
         if report.missing_licenses:
-            output.write("# " + _("MISSING LICENSES") + "\n\n")
+            output.write("# " + _("MISSING LICENSES") + "\n")
+            output.write(
+               _(
+                    "The corresponding license txt files "
+                    "were not found in the directory LICENSES"
+               ) + "\n\n"
+            )
             for lic, files in sorted(report.missing_licenses.items()):
                 output.write(_("'{}' found in:").format(lic) + "\n")
                 for file in sorted(files):


### PR DESCRIPTION
I spent around 50minutes debugging and reading the source codes to find out that you the reuse tool expects texts of licenses in the directory LICENSES.

This commit adds a hint message for slower people like me.

From:
```
 # MISSING LICENSES

'CC-BY-4.0' found in:
* CONTRIBUTING.md
* README.md

 # SUMMARY

* Bad licenses: 0
* Deprecated licenses: 0
* Licenses without file extension: 0
* Missing licenses: CC-BY-4.0
* Unused licenses: 0
* Used licenses: CC-BY-4.0
* Read errors: 0
* files with copyright information: 2 / 2
* files with license information: 2 / 2

Unfortunately, your project is not compliant with version 3.0 of the REUSE Specification :-(
```

To:
```
 # MISSING LICENSES
The corresponding license txt files were not found in the directory LICENSES

'CC-BY-4.0' found in:
* CONTRIBUTING.md
* README.md

 # SUMMARY

* Bad licenses: 0
* Deprecated licenses: 0
* Licenses without file extension: 0
* Missing licenses: CC-BY-4.0
* Unused licenses: 0
* Used licenses: CC-BY-4.0
* Read errors: 0
* files with copyright information: 2 / 2
* files with license information: 2 / 2

Unfortunately, your project is not compliant with version 3.0 of the REUSE Specification :-(
```