### PR TITLE
Add Julia comment style

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -62,6 +62,8 @@ Contributors
 
 - roberto-red <roberto@redradix.com>
 
+- Shun Sakai
+
 Translators
 -----------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ CLI command and its behaviour. There are no guarantees of stability for the
 
 ### Added
 
+- More file types are recognised:
+  - Julia (`.jl`) (#815)
+
 ### Changed
 
 ### Deprecated

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -131,9 +131,13 @@ class CommentStyle:
         :raises CommentParseError: if *text* could not be parsed.
         """
         try:
-            return cls._parse_comment_single(text)
-        except CommentParseError:
+            # Attempt to parse multi-line comments first, in case of comment
+            # styles like Julia, where '#=' starts a multi-line comment, and '#'
+            # starts a single-line comment. If we parsed single-line comments
+            # first, '#=' would be a valid single-line comment.
             return cls._parse_comment_multi(text)
+        except CommentParseError:
+            return cls._parse_comment_single(text)
 
     @classmethod
     def _parse_comment_single(cls, text: str) -> str:
@@ -396,13 +400,6 @@ class JuliaCommentStyle(CommentStyle):
     INDENT_AFTER_SINGLE = " "
     MULTI_LINE = MultiLineSegments("#=", "", "=#")
     SHEBANGS = ["#!"]
-
-    @classmethod
-    def parse_comment(cls, text: str) -> str:
-        try:
-            return cls._parse_comment_multi(text)
-        except CommentParseError:
-            return cls._parse_comment_single(text)
 
 
 class LispCommentStyle(CommentStyle):

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -13,6 +13,7 @@
 # SPDX-FileCopyrightText: 2023 Redradix S.L. <info@redradix.com>
 # SPDX-FileCopyrightText: 2023 Kevin Meagher
 # SPDX-FileCopyrightText: 2023 Mathias Dannesbo <md@magenta.dk>
+# SPDX-FileCopyrightText: 2023 Shun Sakai <sorairolake@protonmail.ch>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -386,6 +387,24 @@ class JinjaCommentStyle(CommentStyle):
     MULTI_LINE = MultiLineSegments("{#", "", "#}")
 
 
+class JuliaCommentStyle(CommentStyle):
+    """Julia comment style."""
+
+    SHORTHAND = "julia"
+
+    SINGLE_LINE = "#"
+    INDENT_AFTER_SINGLE = " "
+    MULTI_LINE = MultiLineSegments("#=", "", "=#")
+    SHEBANGS = ["#!"]
+
+    @classmethod
+    def parse_comment(cls, text: str) -> str:
+        try:
+            return cls._parse_comment_multi(text)
+        except CommentParseError:
+            return cls._parse_comment_single(text)
+
+
 class LispCommentStyle(CommentStyle):
     """Lisp comment style."""
 
@@ -580,6 +599,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".java": CCommentStyle,
     ".jinja": JinjaCommentStyle,
     ".jinja2": JinjaCommentStyle,
+    ".jl": JuliaCommentStyle,
     ".js": CCommentStyle,
     ".json": UncommentableCommentStyle,
     ".jsp": AspxCommentStyle,


### PR DESCRIPTION
Add the comment style for Julia.[^1] This supports both single-line comments and multi-line comments.

Also, single-line multi-line comments cannot be parsed with `CommentStyle.parse_comment()`, so I changed this to run `CommentStyle._parse_comment_multi()` first.

[^1]: https://docs.julialang.org/en/v1/base/punctuation/