### PR TITLE
annotate: add --fallback-dot-license option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ CLI command and its behaviour. There are no guarantees of stability for the
 
 ### Added
 
+- `--fallback-dot-license` option added to `annotate` command. (#)
+
 ### Changed
 
 ### Deprecated


### PR DESCRIPTION
`reuse annotate` defaults to fail when it reaches unrecognized files, and to ignore them when `--skip-unrecognised` option is given. When annotating a large set of files at once, creating a .license file for unrecognized files can be handy instead.

This PR creates a new `--fallback-dot-license` option for this case, making it easier to annotate a large repository with various file kinds.

This new option creates a .license file for any non-binary file whose extension is unknown to reuse. Known or binary files are handled as usual. Reminder: files detected as binary are automatically supported with a .license file.