### PR TITLE
Do not scan uncommentable files

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -66,7 +66,9 @@ Contributors
 
 - Shun Sakai
 
--  Dirk Brömmel
+- Dirk Brömmel
+
+- Robin Vobruba
 
 Translators
 -----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@ CLI command and its behaviour. There are no guarantees of stability for the
 
 - Alpine Docker image now uses 3.18 as base. (#846)
 
+- No longer scan binary or uncommentable files for their contents in search of
+  REUSE information. (#825)
+
 ### Deprecated
 
 ### Removed

--- a/src/reuse/project.py
+++ b/src/reuse/project.py
@@ -185,7 +185,15 @@ class Project:
                     _("'{path}' covered by .reuse/dep5").format(path=path)
                 )
 
-        if path != Path(original_path) or _is_commentable(path):
+        if not _is_commentable(path):
+            _LOGGER.info(
+                _(
+                    "'{path}' was detected as a binary file or its extension is"
+                    " marked as uncommentable; not searching its contents for"
+                    " REUSE information."
+                ).format(path=path)
+            )
+        else:
             # Search the file for REUSE information.
             with path.open("rb") as fp:
                 try:

--- a/src/reuse/project.py
+++ b/src/reuse/project.py
@@ -197,6 +197,7 @@ class Project:
             # Search the file for REUSE information.
             with path.open("rb") as fp:
                 try:
+                    read_limit: Optional[int] = _HEADER_BYTES
                     # Completely read the file once
                     # to search for possible snippets
                     if _contains_snippet(fp):
@@ -204,8 +205,6 @@ class Project:
                             f"'{path}' seems to contain an SPDX Snippet"
                         )
                         read_limit = None
-                    else:
-                        read_limit = _HEADER_BYTES
                     # Reset read position
                     fp.seek(0)
                     # Scan the file for REUSE info, possibly limiting the read
@@ -214,10 +213,9 @@ class Project:
                         decoded_text_from_binary(fp, size=read_limit)
                     )
                     if file_result.contains_copyright_or_licensing():
+                        source_type = SourceType.FILE_HEADER
                         if path.suffix == ".license":
                             source_type = SourceType.DOT_LICENSE
-                        else:
-                            source_type = SourceType.FILE_HEADER
                         file_result = file_result.copy(
                             path=self.relative_from_root(
                                 original_path


### PR DESCRIPTION
This prevents incidents of falsely detected copyright info
in binary files (and other uncommentable file types),
if they contain the word "Copyright" as plain-text.
This happened to me in the case of some JPG files, for example.

This also saves us from reading binary file contents unnecessarily.

... or are there ever cases where we want to detect plain-text in binary or uncommentable files?