### PR TITLE
Add modern Fortran comment style

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -66,6 +66,8 @@ Contributors
 
 - Shun Sakai
 
+-  Dirk Brömmel
+
 Translators
 -----------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ CLI command and its behaviour. There are no guarantees of stability for the
 
 - More file types are recognised:
   - Julia (`.jl`) (#815)
+  - Modern Fortran (`.f90`) (#836)
 
 ### Changed
 

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -14,6 +14,7 @@
 # SPDX-FileCopyrightText: 2023 Kevin Meagher
 # SPDX-FileCopyrightText: 2023 Mathias Dannesbo <md@magenta.dk>
 # SPDX-FileCopyrightText: 2023 Shun Sakai <sorairolake@protonmail.ch>
+# SPDX-FileCopyrightText: 2023 Juelich Supercomputing Centre, Forschungszentrum Juelich GmbH
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -341,11 +342,20 @@ class EmptyCommentStyle(CommentStyle):
 
 
 class FortranCommentStyle(CommentStyle):
-    """Fortran comment style."""
+    """Fortran (fixed form) comment style."""
 
     SHORTHAND = "f"
 
     SINGLE_LINE = "c"
+    INDENT_AFTER_SINGLE = " "
+
+
+class ModernFortranCommentStyle(CommentStyle):
+    """Fortran (free form) comment style."""
+
+    SHORTHAND = "f90"
+
+    SINGLE_LINE = "!"
     INDENT_AFTER_SINGLE = " "
 
 
@@ -562,15 +572,18 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".ex": PythonCommentStyle,
     ".exs": PythonCommentStyle,
     ".f": FortranCommentStyle,
-    ".f03": FortranCommentStyle,
-    ".f90": FortranCommentStyle,
-    ".f95": FortranCommentStyle,
+    ".f03": ModernFortranCommentStyle,
+    ".f08": ModernFortranCommentStyle,
+    ".f90": ModernFortranCommentStyle,
+    ".f95": ModernFortranCommentStyle,
     ".fish": PythonCommentStyle,
     ".fnl": LispCommentStyle,
     ".fodp": UncommentableCommentStyle,
     ".fods": UncommentableCommentStyle,
     ".fodt": UncommentableCommentStyle,
     ".for": FortranCommentStyle,
+    ".ftn": FortranCommentStyle,
+    ".fpp": FortranCommentStyle,
     ".fs": CCommentStyle,
     ".ftl": FtlCommentStyle,
     ".gemspec": PythonCommentStyle,


### PR DESCRIPTION
The current comment style for Fortran seems to target fixed form source code, where any character in col.1 would start a comment. The character usually is "c" or ''C".  
Free form source code, on the other hand, requires an "!" to start comments. Adding comments with a leading "c" is not supported if I'm not mistaken, sources would no longer compile, `reuse` would thus break the code.

This PR adds an additional comment style for modern free form Fortran and adjusts the selection to commonly used file extensions. While the easiest fix would have been to replace
```python
    SINGLE_LINE = "c"
```
with
```python
    SINGLE_LINE = "!"
```
I think it is more customary to have 'c' with fixed form source code, hence the additional style block.

Since the changes are minimal at best, I did not add a line to "AUTHORS.rst" or the copyright headers at the top of the file. If you prefer to add anything, it should be my employer "Juelich Supercomputing Centre, Forschungszentrum Juelich GmbH", possibly including my name. But I don't think any of this is necessary.