### PR TITLE
.pre-commit-hooks.yaml: remove the language_version

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -10,4 +10,3 @@
   pass_filenames: false
   description:
     "Lint the project directory for compliance with the REUSE Specification"
-  language_version: python3


### PR DESCRIPTION
Reuse specifying `language_version: python3` means that the hook is executed using the system `python3` version and it takes priority over the top level language configuration of the project unlesss the project added explicit override for the reuse hook.

E.g. with:

```yaml
default_language_version:
  python: pypy3
```

all other Python3 `pre-commit` hooks I have would be running with `pypy3` with the exception of `reuse` enforcing `python3`.

Based on https://github.com/fsfe/reuse-tool/pull/132, reuse would support pypy outside of pre-commit.