### PR TITLE
Better error handling for DEP5 parse errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!--
 SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
-SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 SPDX-FileCopyrightText: 2023 DB Systel GmbH
+SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 
 SPDX-License-Identifier: CC-BY-SA-4.0
 -->
@@ -80,6 +80,7 @@ CLI command and its behaviour. There are no guarantees of stability for the
 
 ### Fixed
 
+- Syntax errors in .reuse/dep5 now have better error handling. (#841)
 - Reduced python-debian minimum version to 0.1.34. (#808)
 - Fix issue in `annotate` where `--single-line` and `--multi-line` would not
   correctly raise an error with an incompatible comment style. (#853)

--- a/src/reuse/_main.py
+++ b/src/reuse/_main.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
-# SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 # SPDX-FileCopyrightText: 2022 Florian Snow <florian@familysnow.net>
+# SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -278,7 +278,7 @@ def main(args: Optional[List[str]] = None, out: IO[str] = sys.stdout) -> int:
         return 0
 
     if parsed_args.root:
-        project = Project(parsed_args.root)
+        project = Project.from_directory(parsed_args.root)
     else:
         project = create_project()
     project.include_submodules = parsed_args.include_submodules

--- a/src/reuse/_main.py
+++ b/src/reuse/_main.py
@@ -11,7 +11,10 @@ import logging
 import sys
 import warnings
 from gettext import gettext as _
+from pathlib import Path
 from typing import IO, Callable, List, Optional, Type, cast
+
+from debian.copyright import Error as DebianError
 
 from . import (
     __REUSE_version__,
@@ -25,7 +28,8 @@ from . import (
 )
 from ._format import INDENT, fill_all, fill_paragraph
 from ._util import PathType, setup_logging
-from .project import Project, create_project
+from .project import Project
+from .vcs import find_root
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -277,10 +281,29 @@ def main(args: Optional[List[str]] = None, out: IO[str] = sys.stdout) -> int:
         out.write(f"reuse {__version__}\n")
         return 0
 
-    if parsed_args.root:
-        project = Project.from_directory(parsed_args.root)
-    else:
-        project = create_project()
+    root = parsed_args.root
+    if root is None:
+        root = find_root()
+    if root is None:
+        root = Path.cwd()
+    try:
+        project = Project.from_directory(root)
+    # FileNotFoundError and NotADirectoryError don't need to be caught because
+    # argparse already made sure of these things.
+    except UnicodeDecodeError:
+        main_parser.error(
+            _("'{dep5}' could not be decoded as UTF-8.").format(
+                dep5=root / ".reuse/dep5"
+            )
+        )
+    except DebianError as error:
+        main_parser.error(
+            _(
+                "'{dep5}' could not be parsed. We received the following error"
+                " message: {message}"
+            ).format(dep5=root / ".reuse/dep5", message=str(error))
+        )
+
     project.include_submodules = parsed_args.include_submodules
     project.include_meson_subprojects = parsed_args.include_meson_subprojects
 

--- a/src/reuse/_util.py
+++ b/src/reuse/_util.py
@@ -249,33 +249,23 @@ def _parse_dep5(path: StrPath) -> Copyright:
     """Parse the dep5 file and create a dep5 Copyright object.
 
     Raises:
-        OSError: file doesn't exist or could not read it.
+        FileNotFoundError: file doesn't exist.
         DebianError: file could not be parsed.
-        UnicodeError: could not decode file as UTF-8.
-        ValueError: file could not be parsed.
+        UnicodeDecodeError: could not decode file as UTF-8.
     """
     path = Path(path)
     try:
         with path.open(encoding="utf-8") as fp:
             return Copyright(fp)
-    except OSError:
+    except FileNotFoundError:
         _LOGGER.debug(_("no '{}' file, or could not read it").format(path))
-        raise
-    except UnicodeError:
-        _LOGGER.error(_("'{}' could not be parsed as utf-8").format(path))
         raise
     # TODO: Remove ValueError once
     # <https://salsa.debian.org/python-debian-team/python-debian/-/merge_requests/123>
     # is closed
     except (DebianError, ValueError) as error:
-        _LOGGER.error(
-            _(
-                "'{path}' has syntax errors and could not be parsed as dep5"
-                " file. We received the following error message:\n"
-                "\n"
-                "{message}"
-            ).format(path=path, message=str(error))
-        )
+        if error.__class__ == ValueError:
+            raise DebianError(str(error)) from error
         raise
 
 

--- a/src/reuse/_util.py
+++ b/src/reuse/_util.py
@@ -262,15 +262,19 @@ def _parse_dep5(path: StrPath) -> Copyright:
         _LOGGER.debug(_("no '{}' file, or could not read it").format(path))
         raise
     except UnicodeError:
-        _LOGGER.exception(_("'{}' could not be parsed as utf-8").format(path))
+        _LOGGER.error(_("'{}' could not be parsed as utf-8").format(path))
         raise
-    # FIXME: I don't really expect the ValueError as a parsing error here. Let's
-    # make an upstream fix.
-    except (DebianError, ValueError):
-        _LOGGER.exception(
+    # TODO: Remove ValueError once
+    # <https://salsa.debian.org/python-debian-team/python-debian/-/merge_requests/123>
+    # is closed
+    except (DebianError, ValueError) as error:
+        _LOGGER.error(
             _(
-                "'{}' has syntax errors and could not be parsed as dep5 file"
-            ).format(path)
+                "'{path}' has syntax errors and could not be parsed as dep5"
+                " file. We received the following error message:\n"
+                "\n"
+                "{message}"
+            ).format(path=path, message=str(error))
         )
         raise
 

--- a/src/reuse/_util.py
+++ b/src/reuse/_util.py
@@ -1,12 +1,12 @@
 # SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
-# SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 # SPDX-FileCopyrightText: 2020 Tuomas Siipola <tuomas@zpl.fi>
-# SPDX-FileCopyrightText: 2022 Nico Rikken <nico.rikken@fsfe.org>
-# SPDX-FileCopyrightText: 2022 Florian Snow <florian@familysnow.net>
 # SPDX-FileCopyrightText: 2022 Carmen Bianca Bakker <carmenbianca@fsfe.org>
+# SPDX-FileCopyrightText: 2022 Florian Snow <florian@familysnow.net>
+# SPDX-FileCopyrightText: 2022 Nico Rikken <nico.rikken@fsfe.org>
 # SPDX-FileCopyrightText: 2022 Pietro Albini <pietro.albini@ferrous-systems.com>
 # SPDX-FileCopyrightText: 2023 DB Systel GmbH
 # SPDX-FileCopyrightText: 2023 Johannes Zarl-Zierl <johannes@zarl-zierl.at>
+# SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -44,6 +44,7 @@ from typing import (
 from binaryornot.check import is_binary
 from boolean.boolean import Expression, ParseError
 from debian.copyright import Copyright
+from debian.copyright import Error as DebianError
 from license_expression import ExpressionError, Licensing
 
 from . import ReuseInfo, SourceType
@@ -242,6 +243,36 @@ def _determine_license_suffix_path(path: StrPath) -> Path:
     if path.suffix == ".license":
         return path
     return Path(f"{path}.license")
+
+
+def _parse_dep5(path: StrPath) -> Copyright:
+    """Parse the dep5 file and create a dep5 Copyright object.
+
+    Raises:
+        OSError: file doesn't exist or could not read it.
+        DebianError: file could not be parsed.
+        UnicodeError: could not decode file as UTF-8.
+        ValueError: file could not be parsed.
+    """
+    path = Path(path)
+    try:
+        with path.open(encoding="utf-8") as fp:
+            return Copyright(fp)
+    except OSError:
+        _LOGGER.debug(_("no '{}' file, or could not read it").format(path))
+        raise
+    except UnicodeError:
+        _LOGGER.exception(_("'{}' could not be parsed as utf-8").format(path))
+        raise
+    # FIXME: I don't really expect the ValueError as a parsing error here. Let's
+    # make an upstream fix.
+    except (DebianError, ValueError):
+        _LOGGER.exception(
+            _(
+                "'{}' has syntax errors and could not be parsed as dep5 file"
+            ).format(path)
+        )
+        raise
 
 
 def _copyright_from_dep5(path: StrPath, dep5_copyright: Copyright) -> ReuseInfo:

--- a/src/reuse/project.py
+++ b/src/reuse/project.py
@@ -102,8 +102,6 @@ class Project:
             root: The root of the project.
             include_submodules: Whether to also lint VCS submodules.
             include_meson_subprojects: Whether to also lint Meson subprojects.
-                If the provided value is True, but 'meson.build' does not exist,
-                then it is set as False on the created object.
 
         Raises:
             FileNotFoundError: if root does not exist.
@@ -132,10 +130,6 @@ class Project:
             )
         except FileNotFoundError:
             dep5_copyright = None
-
-        meson_build_path = root / "meson.build"
-        uses_meson = meson_build_path.is_file()
-        include_meson_subprojects = include_meson_subprojects and uses_meson
 
         project = cls(
             root,

--- a/src/reuse/project.py
+++ b/src/reuse/project.py
@@ -120,8 +120,11 @@ class Project:
             dep5_copyright: Optional[Copyright] = _parse_dep5(
                 root / ".reuse/dep5"
             )
-        except (OSError, DebianError, UnicodeError, ValueError):
+        except OSError:
             dep5_copyright = None
+        except (DebianError, UnicodeError, ValueError):
+            dep5_copyright = None
+            _LOGGER.warning(_("Proceeding as if no DEP5 file existed."))
 
         meson_build_path = root / "meson.build"
         uses_meson = meson_build_path.is_file()

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -31,7 +31,7 @@ posix = pytest.mark.skipif(not IS_POSIX, reason="Windows not supported")
 
 def test_lint_simple(fake_repository):
     """Extremely simple test for lint."""
-    project = Project(fake_repository)
+    project = Project.from_directory(fake_repository)
     report = ProjectReport.generate(project)
     result = format_plain(report)
     assert result
@@ -39,7 +39,7 @@ def test_lint_simple(fake_repository):
 
 def test_lint_git(git_repository):
     """Extremely simple test for lint with a git repository."""
-    project = Project(git_repository)
+    project = Project.from_directory(git_repository)
     report = ProjectReport.generate(project)
     result = format_plain(report)
     assert result
@@ -47,7 +47,7 @@ def test_lint_git(git_repository):
 
 def test_lint_submodule(submodule_repository):
     """Extremely simple test for lint with an ignored submodule."""
-    project = Project(submodule_repository)
+    project = Project.from_directory(submodule_repository)
     (submodule_repository / "submodule/foo.c").write_text("foo")
     report = ProjectReport.generate(project)
     result = format_plain(report)
@@ -56,7 +56,9 @@ def test_lint_submodule(submodule_repository):
 
 def test_lint_submodule_included(submodule_repository):
     """Extremely simple test for lint with an included submodule."""
-    project = Project(submodule_repository, include_submodules=True)
+    project = Project.from_directory(
+        submodule_repository, include_submodules=True
+    )
     (submodule_repository / "submodule/foo.c").write_text("foo")
     report = ProjectReport.generate(project)
     result = format_plain(report)
@@ -65,7 +67,7 @@ def test_lint_submodule_included(submodule_repository):
 
 def test_lint_empty_directory(empty_directory):
     """An empty directory is compliant."""
-    project = Project(empty_directory)
+    project = Project.from_directory(empty_directory)
     report = ProjectReport.generate(project)
     result = format_plain(report)
     assert result
@@ -81,7 +83,7 @@ def test_lint_deprecated(fake_repository):
         "SPDX-License-Identifier: GPL-3.0\nSPDX-FileCopyrightText: Jane Doe"
     )
 
-    project = Project(fake_repository)
+    project = Project.from_directory(fake_repository)
     report = ProjectReport.generate(project)
     result = format_plain(report)
 
@@ -97,7 +99,7 @@ def test_lint_bad_license(fake_repository):
     (fake_repository / "foo.py").write_text(
         "SPDX-License-Identifier: bad-license"
     )
-    project = Project(fake_repository)
+    project = Project.from_directory(fake_repository)
     report = ProjectReport.generate(project)
     result = format_plain(report)
 
@@ -127,7 +129,7 @@ def test_lint_licenses_without_extension(fake_repository):
 def test_lint_missing_licenses(fake_repository):
     """A missing license is detected."""
     (fake_repository / "foo.py").write_text("SPDX-License-Identifier: MIT")
-    project = Project(fake_repository)
+    project = Project.from_directory(fake_repository)
     report = ProjectReport.generate(project)
     result = format_plain(report)
 
@@ -141,7 +143,7 @@ def test_lint_missing_licenses(fake_repository):
 def test_lint_unused_licenses(fake_repository):
     """An unused license is detected."""
     (fake_repository / "LICENSES/MIT.txt").write_text("foo")
-    project = Project(fake_repository)
+    project = Project.from_directory(fake_repository)
     report = ProjectReport.generate(project)
     result = format_plain(report)
 
@@ -157,7 +159,7 @@ def test_lint_read_errors(fake_repository):
     """A read error is detected."""
     (fake_repository / "foo.py").write_text("foo")
     (fake_repository / "foo.py").chmod(0o000)
-    project = Project(fake_repository)
+    project = Project.from_directory(fake_repository)
     report = ProjectReport.generate(project)
     result = format_plain(report)
 
@@ -171,7 +173,7 @@ def test_lint_read_errors(fake_repository):
 def test_lint_files_without_copyright_and_licensing(fake_repository):
     """A file without copyright and licensing is detected."""
     (fake_repository / "foo.py").write_text("foo")
-    project = Project(fake_repository)
+    project = Project.from_directory(fake_repository)
     report = ProjectReport.generate(project)
     result = format_plain(report)
 
@@ -189,7 +191,7 @@ def test_lint_files_without_copyright_and_licensing(fake_repository):
 def test_lint_json_output(fake_repository):
     """Test for lint with JSON output."""
     (fake_repository / "foo.py").write_text("SPDX-License-Identifier: MIT")
-    project = Project(fake_repository)
+    project = Project.from_directory(fake_repository)
     report = ProjectReport.generate(project)
 
     json_result = report.to_dict_lint()

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -116,7 +116,7 @@ def test_lint_licenses_without_extension(fake_repository):
     (fake_repository / "LICENSES/GPL-3.0-or-later.txt").rename(
         fake_repository / "LICENSES/GPL-3.0-or-later"
     )
-    project = Project(fake_repository)
+    project = Project.from_directory(fake_repository)
     report = ProjectReport.generate(project)
     result = format_plain(report)
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from textwrap import dedent
 
 import pytest
+from debian.copyright import Error as DebianError
 from license_expression import LicenseSymbol
 
 from reuse import SourceType
@@ -40,6 +41,12 @@ def test_project_not_a_directory(empty_directory):
     (empty_directory / "foo.py").write_text("foo")
     with pytest.raises(NotADirectoryError):
         Project.from_directory(empty_directory / "foo.py")
+
+
+def test_project_not_exists(empty_directory):
+    """Cannot create a Project with a directory that doesn't exist."""
+    with pytest.raises(FileNotFoundError):
+        Project.from_directory(empty_directory / "foo")
 
 
 def test_all_files(empty_directory):
@@ -397,7 +404,7 @@ def test_relative_from_root_no_shared_base_path(empty_directory):
     ) == Path("src/hello.py")
 
 
-def test_duplicate_field_dep5(empty_directory, caplog):
+def test_duplicate_field_dep5(empty_directory):
     """When a duplicate field is in a dep5 file, correctly handle errors."""
     dep5_text = cleandoc(
         """
@@ -415,10 +422,8 @@ def test_duplicate_field_dep5(empty_directory, caplog):
     (empty_directory / ".reuse").mkdir()
     (empty_directory / ".reuse/dep5").write_text(dep5_text)
 
-    project = Project.from_directory(empty_directory)
-    assert project.dep5_copyright is None
-    assert "syntax errors" in caplog.text
-    assert 'Duplicate field "Copyright"' in caplog.text
+    with pytest.raises(DebianError):
+        Project.from_directory(empty_directory)
 
 
 # REUSE-IgnoreEnd

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -397,4 +397,28 @@ def test_relative_from_root_no_shared_base_path(empty_directory):
     ) == Path("src/hello.py")
 
 
+def test_duplicate_field_dep5(empty_directory, caplog):
+    """When a duplicate field is in a dep5 file, correctly handle errors."""
+    dep5_text = cleandoc(
+        """
+        Format: https://example.com/format/1.0
+        Upstream-Name: Some project
+        Upstream-Contact: Jane Doe
+        Source: https://example.com/
+
+        Files: foo.py
+        Copyright: 2017 Jane Doe
+        Copyright: 2017 John Doe
+        License: GPL-3.0-or-later
+        """
+    )
+    (empty_directory / ".reuse").mkdir()
+    (empty_directory / ".reuse/dep5").write_text(dep5_text)
+
+    project = Project.from_directory(empty_directory)
+    assert project.dep5_copyright is None
+    assert "syntax errors" in caplog.text
+    assert 'Duplicate field "Copyright"' in caplog.text
+
+
 # REUSE-IgnoreEnd

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
-# SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 # SPDX-FileCopyrightText: 2022 Florian Snow <florian@familysnow.net>
 # SPDX-FileCopyrightText: 2023 Carmen Bianca BAKKER <carmenbianca@fsfe.org>
+# SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -39,7 +39,7 @@ def test_project_not_a_directory(empty_directory):
     """Cannot create a Project without a valid directory."""
     (empty_directory / "foo.py").write_text("foo")
     with pytest.raises(NotADirectoryError):
-        Project(empty_directory / "foo.py")
+        Project.from_directory(empty_directory / "foo.py")
 
 
 def test_all_files(empty_directory):
@@ -47,7 +47,7 @@ def test_all_files(empty_directory):
     (empty_directory / "foo").write_text("foo")
     (empty_directory / "bar").write_text("foo")
 
-    project = Project(empty_directory)
+    project = Project.from_directory(empty_directory)
     assert {file_.name for file_ in project.all_files()} == {"foo", "bar"}
 
 
@@ -56,7 +56,7 @@ def test_all_files_ignore_dot_license(empty_directory):
     (empty_directory / "foo").write_text("foo")
     (empty_directory / "foo.license").write_text("foo")
 
-    project = Project(empty_directory)
+    project = Project.from_directory(empty_directory)
     assert {file_.name for file_ in project.all_files()} == {"foo"}
 
 
@@ -69,7 +69,7 @@ def test_all_files_ignore_cal_license(empty_directory):
     (empty_directory / "CAL-1.0-Combined-Work-Exception").write_text("foo")
     (empty_directory / "CAL-1.0-Combined-Work-Exception.txt").write_text("foo")
 
-    project = Project(empty_directory)
+    project = Project.from_directory(empty_directory)
     assert not list(project.all_files())
 
 
@@ -78,7 +78,7 @@ def test_all_files_ignore_shl_license(empty_directory):
     (empty_directory / "SHL-2.1").write_text("foo")
     (empty_directory / "SHL-2.1.txt").write_text("foo")
 
-    project = Project(empty_directory)
+    project = Project.from_directory(empty_directory)
     assert not list(project.all_files())
 
 
@@ -87,7 +87,7 @@ def test_all_files_ignore_git(empty_directory):
     (empty_directory / ".git").mkdir()
     (empty_directory / ".git/config").write_text("foo")
 
-    project = Project(empty_directory)
+    project = Project.from_directory(empty_directory)
     assert not list(project.all_files())
 
 
@@ -96,7 +96,7 @@ def test_all_files_ignore_hg(empty_directory):
     (empty_directory / ".hg").mkdir()
     (empty_directory / ".hg/config").touch()
 
-    project = Project(empty_directory)
+    project = Project.from_directory(empty_directory)
     assert not list(project.all_files())
 
 
@@ -114,7 +114,7 @@ def test_all_files_symlinks(empty_directory):
         )
     )
     (empty_directory / "symlink").symlink_to("blob")
-    project = Project(empty_directory)
+    project = Project.from_directory(empty_directory)
     assert Path("symlink").absolute() not in project.all_files()
 
 
@@ -122,7 +122,7 @@ def test_all_files_ignore_zero_sized(empty_directory):
     """Empty files should be skipped."""
     (empty_directory / "foo").touch()
 
-    project = Project(empty_directory)
+    project = Project.from_directory(empty_directory)
     assert Path("foo").absolute() not in project.all_files()
 
 
@@ -130,7 +130,7 @@ def test_all_files_git_ignored(git_repository):
     """Given a Git repository where some files are ignored, do not yield those
     files.
     """
-    project = Project(git_repository)
+    project = Project.from_directory(git_repository)
     assert Path("build/hello.py").absolute() not in project.all_files()
 
 
@@ -141,14 +141,14 @@ def test_all_files_git_ignored_different_cwd(git_repository):
     Be in a different CWD during the above.
     """
     os.chdir(git_repository / "LICENSES")
-    project = Project(git_repository)
+    project = Project.from_directory(git_repository)
     assert Path("build/hello.py").absolute() not in project.all_files()
 
 
 def test_all_files_git_ignored_contains_space(git_repository):
     """Files that contain spaces are also ignored."""
     (git_repository / "I contain spaces.pyc").write_text("foo")
-    project = Project(git_repository)
+    project = Project.from_directory(git_repository)
     assert Path("I contain spaces.pyc").absolute() not in project.all_files()
 
 
@@ -156,7 +156,7 @@ def test_all_files_git_ignored_contains_space(git_repository):
 def test_all_files_git_ignored_contains_newline(git_repository):
     """Files that contain newlines are also ignored."""
     (git_repository / "hello\nworld.pyc").write_text("foo")
-    project = Project(git_repository)
+    project = Project.from_directory(git_repository)
     assert Path("hello\nworld.pyc").absolute() not in project.all_files()
 
 
@@ -167,7 +167,7 @@ def test_all_files_submodule_is_ignored(submodule_repository):
     contents = gitignore.read_text()
     contents += "\nsubmodule/\n"
     gitignore.write_text(contents)
-    project = Project(submodule_repository)
+    project = Project.from_directory(submodule_repository)
     assert Path("submodule/foo.py").absolute() not in project.all_files()
 
 
@@ -175,7 +175,7 @@ def test_all_files_hg_ignored(hg_repository):
     """Given a mercurial repository where some files are ignored, do not yield
     those files.
     """
-    project = Project(hg_repository)
+    project = Project.from_directory(hg_repository)
     assert Path("build/hello.py").absolute() not in project.all_files()
 
 
@@ -186,14 +186,14 @@ def test_all_files_hg_ignored_different_cwd(hg_repository):
     Be in a different CWD during the above.
     """
     os.chdir(hg_repository / "LICENSES")
-    project = Project(hg_repository)
+    project = Project.from_directory(hg_repository)
     assert Path("build/hello.py").absolute() not in project.all_files()
 
 
 def test_all_files_hg_ignored_contains_space(hg_repository):
     """File names that contain spaces are also ignored."""
     (hg_repository / "I contain spaces.pyc").touch()
-    project = Project(hg_repository)
+    project = Project.from_directory(hg_repository)
     assert Path("I contain spaces.pyc").absolute() not in project.all_files()
 
 
@@ -201,7 +201,7 @@ def test_all_files_hg_ignored_contains_space(hg_repository):
 def test_all_files_hg_ignored_contains_newline(hg_repository):
     """File names that contain newlines are also ignored."""
     (hg_repository / "hello\nworld.pyc").touch()
-    project = Project(hg_repository)
+    project = Project.from_directory(hg_repository)
     assert Path("hello\nworld.pyc").absolute() not in project.all_files()
 
 
@@ -209,7 +209,7 @@ def test_reuse_info_of_file_does_not_exist(fake_repository):
     """Raise FileNotFoundError when asking for the REUSE info of a file that
     does not exist.
     """
-    project = Project(fake_repository)
+    project = Project.from_directory(fake_repository)
     with pytest.raises(FileNotFoundError):
         project.reuse_info_of(fake_repository / "does_not_exist")
 
@@ -218,7 +218,7 @@ def test_reuse_info_of_directory(empty_directory):
     """Raise IsADirectoryError when calling reuse_info_of on a directory."""
     (empty_directory / "src").mkdir()
 
-    project = Project(empty_directory)
+    project = Project.from_directory(empty_directory)
     with pytest.raises((IsADirectoryError, PermissionError)):
         project.reuse_info_of(empty_directory / "src")
 
@@ -229,7 +229,7 @@ def test_reuse_info_of_unlicensed_file(fake_repository):
 
     """
     (fake_repository / "foo.py").write_text("foo")
-    project = Project(fake_repository)
+    project = Project.from_directory(fake_repository)
     assert not bool(project.reuse_info_of("foo.py"))
 
 
@@ -240,7 +240,7 @@ def test_reuse_info_of_only_copyright(fake_repository):
     (fake_repository / "foo.py").write_text(
         "SPDX-FileCopyrightText: 2017 Jane Doe"
     )
-    project = Project(fake_repository)
+    project = Project.from_directory(fake_repository)
     reuse_info = project.reuse_info_of("foo.py")[0]
     assert not any(reuse_info.spdx_expressions)
     assert len(reuse_info.copyright_lines) == 1
@@ -265,7 +265,7 @@ def test_reuse_info_of_also_covered_by_dep5(fake_repository):
             SPDX-FileCopyrightText: in file"""
         )
     )
-    project = Project(fake_repository)
+    project = Project.from_directory(fake_repository)
     with warnings.catch_warnings(record=True) as caught_warnings:
         reuse_infos = project.reuse_info_of("doc/foo.py")
         assert len(reuse_infos) == 2
@@ -302,7 +302,7 @@ def test_reuse_info_of_no_duplicates(empty_directory):
     text = spdx_line + copyright_line
 
     (empty_directory / "foo.py").write_text(text * 2)
-    project = Project(empty_directory)
+    project = Project.from_directory(empty_directory)
     reuse_info = project.reuse_info_of("foo.py")[0]
     assert len(reuse_info.spdx_expressions) == 1
     assert LicenseSymbol("GPL-3.0-or-later") in reuse_info.spdx_expressions
@@ -319,7 +319,7 @@ def test_reuse_info_of_binary_succeeds(fake_repository):
         RESOURCES_DIRECTORY / "fsfe.png", fake_repository / "doc/fsfe.png"
     )
 
-    project = Project(fake_repository)
+    project = Project.from_directory(fake_repository)
     reuse_info = project.reuse_info_of("doc/fsfe.png")[0]
     assert LicenseSymbol("CC0-1.0") in reuse_info.spdx_expressions
     assert reuse_info.source_type == SourceType.DEP5
@@ -335,7 +335,7 @@ def test_license_file_detected(empty_directory):
         "SPDX-FileCopyrightText: 2017 Jane Doe\nSPDX-License-Identifier: MIT\n"
     )
 
-    project = Project(empty_directory)
+    project = Project.from_directory(empty_directory)
     reuse_info = project.reuse_info_of("foo.py")[0]
 
     assert "SPDX-FileCopyrightText: 2017 Jane Doe" in reuse_info.copyright_lines
@@ -349,7 +349,7 @@ def test_licenses_filename(empty_directory):
     """Detect the license identifier of a license from its stem."""
     (empty_directory / "LICENSES").mkdir()
     (empty_directory / "LICENSES/foo.txt").write_text("foo")
-    project = Project(empty_directory)
+    project = Project.from_directory(empty_directory)
     assert "foo" in project.licenses
 
 
@@ -360,7 +360,7 @@ def test_licenses_no_extension(empty_directory):
     (empty_directory / "LICENSES").mkdir()
     (empty_directory / "LICENSES/GPL-3.0-or-later").write_text("foo")
     (empty_directory / "LICENSES/MIT-3.0-or-later").write_text("foo")
-    project = Project(empty_directory)
+    project = Project.from_directory(empty_directory)
     assert "GPL-3.0-or-later" in project.licenses
     assert "MIT-3" in project.licenses
 
@@ -369,13 +369,13 @@ def test_licenses_subdirectory(empty_directory):
     """Find a license in a subdirectory of LICENSES/."""
     (empty_directory / "LICENSES/sub").mkdir(parents=True)
     (empty_directory / "LICENSES/sub/MIT.txt").write_text("foo")
-    project = Project(empty_directory)
+    project = Project.from_directory(empty_directory)
     assert "MIT" in project.licenses
 
 
 def test_relative_from_root(empty_directory):
     """A simple test. Given /path/to/root/src/hello.py, return src/hello.py."""
-    project = Project(empty_directory)
+    project = Project.from_directory(empty_directory)
     assert project.relative_from_root(project.root / "src/hello.py") == Path(
         "src/hello.py"
     )
@@ -389,7 +389,7 @@ def test_relative_from_root_no_shared_base_path(empty_directory):
     directory /path/to, return src/hello.py. This is a bit involved, but works
     out.
     """
-    project = Project(empty_directory)
+    project = Project.from_directory(empty_directory)
     parent = empty_directory.parent
     os.chdir(parent)
     assert project.relative_from_root(

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -38,7 +38,7 @@ def test_generate_file_report_file_simple(
     """An extremely simple generate test, just to see if the function doesn't
     crash.
     """
-    project = Project(fake_repository)
+    project = Project.from_directory(fake_repository)
     result = FileReport.generate(
         project,
         "src/source_code.py",
@@ -61,7 +61,7 @@ def test_generate_file_report_file_from_different_cwd(
 ):
     """Another simple generate test, but from a different CWD."""
     os.chdir("/")
-    project = Project(fake_repository)
+    project = Project.from_directory(fake_repository)
     result = FileReport.generate(
         project,
         fake_repository / "src/source_code.py",
@@ -85,7 +85,7 @@ def test_generate_file_report_file_missing_license(
     (fake_repository / "foo.py").write_text(
         "SPDX-License-Identifier: BSD-3-Clause"
     )
-    project = Project(fake_repository)
+    project = Project.from_directory(fake_repository)
     result = FileReport.generate(
         project, "foo.py", add_license_concluded=add_license_concluded
     )
@@ -108,7 +108,7 @@ def test_generate_file_report_file_bad_license(
     (fake_repository / "foo.py").write_text(
         "SPDX-License-Identifier: fakelicense"
     )
-    project = Project(fake_repository)
+    project = Project.from_directory(fake_repository)
     result = FileReport.generate(
         project, "foo.py", add_license_concluded=add_license_concluded
     )
@@ -134,7 +134,7 @@ def test_generate_file_report_license_contains_plus(
         "SPDX-License-Identifier: Apache-1.0+"
     )
     (fake_repository / "LICENSES/Apache-1.0.txt").touch()
-    project = Project(fake_repository)
+    project = Project.from_directory(fake_repository)
     result = FileReport.generate(
         project, "foo.py", add_license_concluded=add_license_concluded
     )
@@ -152,7 +152,7 @@ def test_generate_file_report_license_contains_plus(
 
 def test_generate_file_report_exception(fake_repository, add_license_concluded):
     """Simple generate test to test if the exception is detected."""
-    project = Project(fake_repository)
+    project = Project.from_directory(fake_repository)
     result = FileReport.generate(
         project, "src/exception.py", add_license_concluded=add_license_concluded
     )
@@ -177,7 +177,7 @@ def test_generate_file_report_no_licenses(
 ):
     """Test behavior when no license information is present in the file"""
     (fake_repository / "foo.py").write_text("")
-    project = Project(fake_repository)
+    project = Project.from_directory(fake_repository)
     result = FileReport.generate(
         project, "foo.py", add_license_concluded=add_license_concluded
     )
@@ -197,7 +197,7 @@ def test_generate_file_report_multiple_licenses(
     fake_repository, add_license_concluded
 ):
     """Test that all licenses are included in LicenseConcluded"""
-    project = Project(fake_repository)
+    project = Project.from_directory(fake_repository)
     result = FileReport.generate(
         project,
         "src/multiple_licenses.rs",
@@ -233,7 +233,7 @@ def test_generate_file_report_to_dict_lint_source_information(fake_repository):
             SPDX-FileCopyrightText: in file"""
         )
     )
-    project = Project(fake_repository)
+    project = Project.from_directory(fake_repository)
     report = FileReport.generate(
         project,
         "doc/foo.py",
@@ -269,7 +269,7 @@ def test_generate_file_report_to_dict_lint_source_information(fake_repository):
 
 def test_generate_project_report_simple(fake_repository, multiprocessing):
     """Simple generate test, just to see if it sort of works."""
-    project = Project(fake_repository)
+    project = Project.from_directory(fake_repository)
     result = ProjectReport.generate(project, multiprocessing=multiprocessing)
 
     assert not result.bad_licenses
@@ -289,7 +289,7 @@ def test_generate_project_report_licenses_without_extension(
         fake_repository / "LICENSES/CC0-1.0"
     )
 
-    project = Project(fake_repository)
+    project = Project.from_directory(fake_repository)
     result = ProjectReport.generate(project, multiprocessing=multiprocessing)
 
     assert "CC0-1.0" in result.licenses_without_extension
@@ -301,7 +301,7 @@ def test_generate_project_report_missing_license(
     """Missing licenses are detected."""
     (fake_repository / "LICENSES/GPL-3.0-or-later.txt").unlink()
 
-    project = Project(fake_repository)
+    project = Project.from_directory(fake_repository)
     result = ProjectReport.generate(project, multiprocessing=multiprocessing)
 
     assert "GPL-3.0-or-later" in result.missing_licenses
@@ -312,7 +312,7 @@ def test_generate_project_report_bad_license(fake_repository, multiprocessing):
     """Bad licenses are detected."""
     (fake_repository / "LICENSES/bad.txt").write_text("foo")
 
-    project = Project(fake_repository)
+    project = Project.from_directory(fake_repository)
     result = ProjectReport.generate(project, multiprocessing=multiprocessing)
 
     assert result.bad_licenses
@@ -325,7 +325,7 @@ def test_generate_project_report_unused_license(
     """Unused licenses are detected."""
     (fake_repository / "LICENSES/MIT.txt").write_text("foo")
 
-    project = Project(fake_repository)
+    project = Project.from_directory(fake_repository)
     result = ProjectReport.generate(project, multiprocessing=multiprocessing)
 
     assert result.unused_licenses == {"MIT"}
@@ -347,7 +347,7 @@ def test_generate_project_report_unused_license_plus(
     )
     (fake_repository / "LICENSES/Apache-1.0.txt").touch()
 
-    project = Project(fake_repository)
+    project = Project.from_directory(fake_repository)
     result = ProjectReport.generate(project, multiprocessing=multiprocessing)
 
     assert not result.unused_licenses
@@ -365,7 +365,7 @@ def test_generate_project_report_unused_license_plus_only_plus(
     )
     (fake_repository / "LICENSES/Apache-1.0.txt").touch()
 
-    project = Project(fake_repository)
+    project = Project.from_directory(fake_repository)
     result = ProjectReport.generate(project, multiprocessing=multiprocessing)
 
     assert not result.unused_licenses
@@ -379,7 +379,7 @@ def test_generate_project_report_bad_license_in_file(
     """Bad licenses in files are detected."""
     (fake_repository / "foo.py").write_text("SPDX-License-Identifier: bad")
 
-    project = Project(fake_repository)
+    project = Project.from_directory(fake_repository)
     result = ProjectReport.generate(project, multiprocessing=multiprocessing)
 
     assert "bad" in result.bad_licenses
@@ -391,7 +391,7 @@ def test_generate_project_report_bad_license_can_also_be_missing(
     """Bad licenses can also be missing licenses."""
     (fake_repository / "foo.py").write_text("SPDX-License-Identifier: bad")
 
-    project = Project(fake_repository)
+    project = Project.from_directory(fake_repository)
     result = ProjectReport.generate(project, multiprocessing=multiprocessing)
 
     assert "bad" in result.bad_licenses
@@ -406,7 +406,7 @@ def test_generate_project_report_deprecated_license(
         fake_repository / "LICENSES/GPL-3.0.txt"
     )
 
-    project = Project(fake_repository)
+    project = Project.from_directory(fake_repository)
     result = ProjectReport.generate(project, multiprocessing=multiprocessing)
 
     assert "GPL-3.0" in result.deprecated_licenses
@@ -419,7 +419,7 @@ def test_generate_project_report_read_error(fake_repository, multiprocessing):
     (fake_repository / "bad").write_text("foo")
     (fake_repository / "bad").chmod(0o000)
 
-    project = Project(fake_repository)
+    project = Project.from_directory(fake_repository)
     result = ProjectReport.generate(project, multiprocessing=multiprocessing)
 
     # pylint: disable=superfluous-parens
@@ -428,7 +428,7 @@ def test_generate_project_report_read_error(fake_repository, multiprocessing):
 
 def test_generate_project_report_to_dict_lint(fake_repository, multiprocessing):
     """Generate dictionary output and verify correct ordering."""
-    project = Project(fake_repository)
+    project = Project.from_directory(fake_repository)
     report = ProjectReport.generate(project, multiprocessing=multiprocessing)
     result = report.to_dict_lint()
 
@@ -448,7 +448,7 @@ def test_generate_project_report_to_dict_lint(fake_repository, multiprocessing):
 
 def test_bill_of_materials(fake_repository, multiprocessing):
     """Generate a bill of materials."""
-    project = Project(fake_repository)
+    project = Project.from_directory(fake_repository)
     report = ProjectReport.generate(project, multiprocessing=multiprocessing)
     # TODO: Actually do something
     report.bill_of_materials()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -12,6 +12,7 @@
 # pylint: disable=protected-access,invalid-name
 
 import os
+import shutil
 from argparse import ArgumentTypeError
 from inspect import cleandoc
 from io import BytesIO
@@ -19,6 +20,8 @@ from pathlib import Path
 
 import pytest
 from boolean.boolean import ParseError
+from debian.copyright import Copyright
+from debian.copyright import Error as DebianError
 from license_expression import LicenseSymbol
 
 from reuse import _util
@@ -37,6 +40,10 @@ except ImportError:
 git = pytest.mark.skipif(not _util.GIT_EXE, reason="requires git")
 no_root = pytest.mark.xfail(is_root, reason="fails when user is root")
 posix = pytest.mark.skipif(not is_posix, reason="Windows not supported")
+
+
+TESTS_DIRECTORY = Path(__file__).parent.resolve()
+RESOURCES_DIRECTORY = TESTS_DIRECTORY / "resources"
 
 
 # REUSE-IgnoreStart
@@ -383,6 +390,53 @@ def test_filter_ignore_block_with_multiple_ignore_blocks():
 
     result = _util.filter_ignore_block(text)
     assert result == expected
+
+
+def test_parse_dep5_simple(fake_repository):
+    """No error if everything is good."""
+    result = _util._parse_dep5(fake_repository / ".reuse/dep5")
+    assert result.__class__ == Copyright
+
+
+def test_parse_dep5_not_exists(empty_directory):
+    """Raise FileNotFoundError if .reuse/dep5 doesn't exist."""
+    with pytest.raises(FileNotFoundError):
+        _util._parse_dep5(empty_directory / "foo")
+
+
+def test_parse_dep5_unicode_decode_error(fake_repository):
+    """Raise UnicodeDecodeError if file can't be decoded as utf-8."""
+    shutil.copy(RESOURCES_DIRECTORY / "fsfe.png", fake_repository / "fsfe.png")
+    with pytest.raises(UnicodeDecodeError):
+        _util._parse_dep5(fake_repository / "fsfe.png")
+
+
+def test_parse_dep5_parse_error(empty_directory):
+    """Raise DebianError on parse error."""
+    (empty_directory / "foo").write_text("foo")
+    with pytest.raises(DebianError):
+        _util._parse_dep5(empty_directory / "foo")
+
+
+def test_parse_dep5_double_copyright_parse_error(empty_directory):
+    """Raise DebianError on double Copyright lines."""
+    (empty_directory / "foo").write_text(
+        cleandoc(
+            """
+            Format: something
+            Upstream-Name: example
+            Upstream-Contact: Jane Doe
+            Source: https://example.com
+
+            Files: *
+            Copyright: Jane Doe
+            Copyright: John Doe
+            License: MIT
+            """
+        )
+    )
+    with pytest.raises(DebianError):
+        _util._parse_dep5(empty_directory / "foo")
 
 
 def test_copyright_from_dep5(dep5_copyright):


### PR DESCRIPTION
Fixes #803 by having better error handling.

Upstream PR to improve some exception catching: https://salsa.debian.org/python-debian-team/python-debian/-/merge_requests/123

After adding a duplicate Copyright field, the lint output looks like this:

```
$ reuse lint
usage: reuse [-h] [--debug] [--suppress-deprecation] [--include-submodules] [--include-meson-subprojects] [--no-multiprocessing] [--root PATH] [--version]
             {annotate,download,init,lint,spdx,supported-licenses,supported-licences} ...
reuse: error: '.reuse/dep5' could not be parsed. We received the following error message: Duplicate field "Copyright" in paragraph number 1
```
