### PR TITLE
util: fix parsing of copyrights without year

### DIFF
--- a/src/reuse/_util.py
+++ b/src/reuse/_util.py
@@ -295,9 +295,9 @@ def _parse_copyright_year(year: str) -> list:
     """Parse copyright years and return list."""
     if not year:
         ret = []
-    if re.match(r"\d{4}$", year):
+    elif re.match(r"\d{4}$", year):
         ret = [int(year)]
-    if re.match(r"\d{4} ?- ?\d{4}$", year):
+    elif re.match(r"\d{4} ?- ?\d{4}$", year):
         ret = [int(year[:4]), int(year[-4:])]
     return ret
 
@@ -393,7 +393,9 @@ def merge_copyright_lines(copyright_lines: Set[str]) -> Set[str]:
             years += copy["year"]
 
         year: Optional[str] = None
-        if min(years) == max(years):
+        if not years:
+            year = None
+        elif min(years) == max(years):
             year = min(years)
         else:
             year = f"{min(years)} - {max(years)}"


### PR DESCRIPTION
Fixes a crash when reuse tries to parse an older Copyright line which has no year token. This resulted in a None dereference when a string was expected.