### PR TITLE
Ignore .sl directory the same way as .hg.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ CLI command and its behaviour. There are no guarantees of stability for the
   currently exits early. To automatically create a .license file for
   unrecognised files, `--fallback-dot-license` has been added. (#823, #851,
   #853, #859; this took a while to get right.)
+- Ignore `.sl` directory as used by [Sapling SCM](https://sapling-scm.com/).
+  (#867)
 
 ### Changed
 

--- a/src/reuse/__init__.py
+++ b/src/reuse/__init__.py
@@ -54,6 +54,7 @@ else:
 _IGNORE_DIR_PATTERNS = [
     re.compile(r"^\.git$"),
     re.compile(r"^\.hg$"),
+    re.compile(r"^\.sl$"),  # Used by Sapling SCM
     re.compile(r"^LICENSES$"),
     re.compile(r"^\.reuse$"),
 ]


### PR DESCRIPTION
The .sl directory is used by Sapling (https://sapling-scm.com/) so
it should be handled like the other SCM directories.
