### PR TITLE
Ignore COPYING and LICENSE as exact matches or with extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,10 @@ CLI command and its behaviour. There are no guarantees of stability for the
 ### Changed
 
 - `.s` files now use the Python comment style as per GNU Assembler (gas). (#928)
+- Previously, any file that begins with `COPYING` or `LICENSE` was ignored. This
+  has been changed. Now, files like `COPYING_README` are no longer ignored, but
+  `COPYING` and `COPYING.txt` are still ignored (in other words: exact matches,
+  or `COPYING` + a file extension). Idem ditto for `LICENSE`. (#886)
 
 ### Deprecated
 

--- a/src/reuse/__init__.py
+++ b/src/reuse/__init__.py
@@ -64,8 +64,8 @@ _IGNORE_MESON_PARENT_DIR_PATTERNS = [
 ]
 
 _IGNORE_FILE_PATTERNS = [
-    re.compile(r"^LICENSE"),
-    re.compile(r"^COPYING"),
+    re.compile(r"^LICENSE(\..*)?$"),
+    re.compile(r"^COPYING(\..*)?$"),
     # ".git" as file happens in submodules
     re.compile(r"^\.git$"),
     re.compile(r"^\.gitkeep$"),

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -101,10 +101,34 @@ def test_all_files_ignore_git(empty_directory):
 def test_all_files_ignore_hg(empty_directory):
     """When the hg directory is present, ignore it."""
     (empty_directory / ".hg").mkdir()
-    (empty_directory / ".hg/config").touch()
+    (empty_directory / ".hg/config").write_text("foo")
 
     project = Project.from_directory(empty_directory)
     assert not list(project.all_files())
+
+
+def test_all_files_ignore_license_copying(empty_directory):
+    """When there are files names LICENSE, LICENSE.ext, COPYING, or COPYING.ext,
+    ignore them.
+    """
+    (empty_directory / "LICENSE").write_text("foo")
+    (empty_directory / "LICENSE.txt").write_text("foo")
+    (empty_directory / "COPYING").write_text("foo")
+    (empty_directory / "COPYING.txt").write_text("foo")
+
+    project = Project.from_directory(empty_directory)
+    assert not list(project.all_files())
+
+
+def test_all_files_not_ignore_license_copying_no_ext(empty_directory):
+    """Do not ignore files that start with LICENSE or COPYING and are followed
+    by some non-extension text.
+    """
+    (empty_directory / "LICENSE_README.md").write_text("foo")
+    (empty_directory / "COPYING2").write_text("foo")
+
+    project = Project.from_directory(empty_directory)
+    assert len(list(project.all_files())) == 2
 
 
 @posix


### PR DESCRIPTION
Related to #881 and https://github.com/fsfe/reuse-docs/issues/139