### PR TITLE
Fix the link to spdx/tools-python in _license.py

### DIFF
--- a/src/reuse/_licenses.py
+++ b/src/reuse/_licenses.py
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 # load_license_list was copied and altered from its original location
-# at <https://github.com/spdx/tools-python/blob/master/spdx/config.py>.
+# at <https://github.com/spdx/tools-python/blob/462e986/spdx/config.py>.
 
 """A list with all SPDX licenses."""
 


### PR DESCRIPTION
There was a breaking change v0.7 -> v0.8 in `spdx/tools-python`, causing the link to the original location to be broken.

Replace the master branch with the actual commit at the time when the file was copied.

The chosen commit is 462e986, based on Github history (2017-06-15) and the commit date of the `_license.py` file (2019-04-14).

The commit can be verified using https://github.com/spdx/tools-python/commits/main/spdx/config.py, in case I got it wrong.