### PR TITLE
Add support for Zig and fix Hare comment style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ CLI command and its behaviour. There are no guarantees of stability for the
   - ShellCheck configuration (`.shellcheckrc`) (#862)
   - Pylint in-project configuration (`pylintrc`) (#862)
   - Lisp schemes (`.sld`, `.sls`, `.sps`) (#875)
+- Added comment styles:
+  - `csingle` for Zig (`.zig`) and Hare (`.ha`) (#889)
 - Display recommendations for steps to fix found issues during a lint. (#698)
 - Add support for Pijul VCS. Pijul support is not added to the Docker image.
   (#858)

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -524,6 +524,15 @@ class XQueryCommentStyle(CommentStyle):
     INDENT_BEFORE_END = " "
 
 
+class CSingleCommentStyle(CommentStyle):
+    """C single-only comment style."""
+
+    SHORTHAND = "csingle"
+
+    SINGLE_LINE = "//"
+    INDENT_AFTER_SINGLE = " "
+
+
 #: A map of (common) file extensions against comment types.
 EXTENSION_COMMENT_STYLE_MAP = {
     ".adb": HaskellCommentStyle,
@@ -600,7 +609,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".graphql": PythonCommentStyle,
     ".groovy": CCommentStyle,
     ".h": CCommentStyle,
-    ".ha": CCommentStyle,
+    ".ha": CSingleCommentStyle,
     ".hbs": HandlebarsCommentStyle,
     ".hcl": PythonCommentStyle,
     ".hh": CCommentStyle,
@@ -712,11 +721,11 @@ EXTENSION_COMMENT_STYLE_MAP = {
     # SuperCollider synth definition (binary)
     ".scsyndef": UncommentableCommentStyle,
     ".sh": PythonCommentStyle,
-    ".sld": LispCommentStyle,   # Scheme Library Definition (R7RS)
-    ".sls": LispCommentStyle,   # Scheme Library Source (R6RS)
+    ".sld": LispCommentStyle,  # Scheme Library Definition (R7RS)
+    ".sls": LispCommentStyle,  # Scheme Library Source (R6RS)
     ".sml": MlCommentStyle,
     ".soy": CCommentStyle,
-    ".sps": LispCommentStyle,   # Scheme Program Source (R6RS)
+    ".sps": LispCommentStyle,  # Scheme Program Source (R6RS)
     ".sql": HaskellCommentStyle,
     ".sty": TexCommentStyle,
     ".svg": UncommentableCommentStyle,
@@ -756,6 +765,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".xsl": HtmlCommentStyle,
     ".yaml": PythonCommentStyle,
     ".yml": PythonCommentStyle,
+    ".zig": CSingleCommentStyle,
     ".zsh": PythonCommentStyle,
 }
 


### PR DESCRIPTION
Zig supports C99 single line comments, but not C multi-line comments.

Fix the comment style for Hare by using ZigCommentStyle, instead of CCommentStyle.

I avoided adding support for zon (Zig Object Notation) files used by the Zig package manager, since it is still in its early stages.

Closes #837
Closes #888