### PR TITLE
Add `lint --only <files...>` option

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,8 +5,8 @@
 - id: reuse
   name: reuse
   entry: reuse
-  args: ["lint"]
+  args: ["lint", "--only"]
   language: python
-  pass_filenames: false
+  require_serial: true
   description:
     "Lint the project directory for compliance with the REUSE Specification"

--- a/src/reuse/lint.py
+++ b/src/reuse/lint.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
 # SPDX-FileCopyrightText: 2022 Florian Snow <florian@familysnow.net>
 # SPDX-FileCopyrightText: 2023 DB Systel GmbH
+# SPDX-FileCopyrightText: 2024 Martin Lehmann <lemmi59612@gmail.com>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -36,6 +37,15 @@ def add_arguments(parser: ArgumentParser) -> None:
         "--plain",
         action="store_true",
         help=_("formats output as plain text"),
+    )
+
+    parser.add_argument(
+        "--only",
+        action="extend",
+        type=Path,
+        nargs="*",
+        default=[],
+        help=_("only report issues for these files"),
     )
 
 
@@ -260,7 +270,10 @@ def format_json(report: ProjectReport) -> str:
 def run(args: Namespace, project: Project, out: IO[str] = sys.stdout) -> int:
     """List all non-compliant files."""
     report = ProjectReport.generate(
-        project, do_checksum=False, multiprocessing=not args.no_multiprocessing
+        project,
+        do_checksum=False,
+        multiprocessing=not args.no_multiprocessing,
+        only=args.only,
     )
 
     if args.quiet:

--- a/src/reuse/report.py
+++ b/src/reuse/report.py
@@ -336,14 +336,14 @@ class ProjectReport:  # pylint: disable=too-many-instance-attributes
             project_report.file_reports.add(file_report)
 
             # Missing licenses.
-            for missing_license in file_report.missing_licenses:
+            for license_name in file_report.missing_licenses:
                 project_report.missing_licenses.setdefault(
-                    missing_license, set()
+                    license_name, set()
                 ).add(file_report.path)
 
             # Bad licenses
-            for bad_license in file_report.bad_licenses:
-                project_report.bad_licenses.setdefault(bad_license, set()).add(
+            for license_name in file_report.bad_licenses:
+                project_report.bad_licenses.setdefault(license_name, set()).add(
                     file_report.path
                 )
 

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V. <https://fsfe.org>
 # SPDX-FileCopyrightText: 2022 Florian Snow <florian@familysnow.net>
+# SPDX-FileCopyrightText: 2024 Martin Lehmann <lemmi59612@gmail.com>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -63,6 +64,23 @@ def test_lint_submodule_included(submodule_repository):
     report = ProjectReport.generate(project)
     result = format_plain(report)
     assert ":-(" in result
+
+
+def test_lint_only(fake_repository):
+    """Test that ``only=...`` ignores errors in excluded files."""
+    (fake_repository / "main.py").write_text(
+        "SPDX-License-Identifier: GPL-3.0-or-later\n"
+        "SPDX-FileCopyrightText: Jane Doe"
+    )
+    (fake_repository / "ignored.py").write_text(
+        "SPDX-License-Identifier: Proprietary"
+    )
+
+    project = Project.from_directory(fake_repository)
+    report = ProjectReport.generate(project, only=["main.py"])
+    result = format_plain(report)
+
+    assert ":-)" in result
 
 
 def test_lint_empty_directory(empty_directory):


### PR DESCRIPTION
Here's my second shot at #578. I went with the `--only` option that @stephanlachnit proposed, as I found it a bit easier to implement than a new subcommand. It should also be fairly simple to extend it with an `--exclude` option later.

---

This option restricts the generated report to only the files listed on the command line. It is useful for example in the pre-commit hook, in order to not fail the entire commit if there are some issues in files that aren't supposed to be committed yet anyways.

This option is implemented by checking all files that we know about as usual, but only reporting on (and failing for) issues in files listed.

We have to check all files, otherwise we wouldn't be able to catch certain types of errors reliably or at all. Specifically, the "unused licenses" check would often raise false-positive errors: If we only look at the *to-be-committed* files, and those don't use a particular license, we would fail the check even if another file uses it (which was already committed before, but not touched during the new commit).

This does however mean that untracked files could cause false-negatives, but this was already the case before, and will (still) be caught by CI.

One alternative to this approach is to not check for unused licenses at all if doing such a partial check, but this would mean that downstream CI scripts would have to be adjusted to explicitly run a full `reuse lint` instead of running the pre-commit hook over all repo files. However, this would only lead to a lot of complications without any meaningful benefit.

---

Annoyingly pylint now complains about "too many locals", because I introduced a new argument to `ProjectReport.generate`, which ruins the otherwise perfect score. To avoid this, I have renamed the `missing_license` and `bad_license` loop variables to `license_name`, because they're both just strings anyways (from a type checker's perspective), and IMO license_name is still explicit enough. It's a separate commit, so if you don't want that, we can just force-push it away and do something else instead :)