### PR TITLE
Add support to .graphqls in addition to .graphql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ CLI command and its behaviour. There are no guarantees of stability for the
 
 - More file types are recognised:
   - Assembler (`.asm`) (#928)
+  - GraphQL (`.graphqls`, `.gqls`) (#930)
   - CUDA-C++ (`.cu`, `.cuh`) (#938)
   - Various .NET files (`.csproj`, `.fsproj`, `.fsx`, `.props`, `.sln`,
     `.vbproj`) (#940)

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -653,6 +653,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".gradle": CCommentStyle,
     ".graphql": PythonCommentStyle,
     ".graphqls": PythonCommentStyle,
+    ".gqls": PythonCommentStyle,
     ".groovy": CCommentStyle,
     ".h": CCommentStyle,
     ".ha": CSingleCommentStyle,

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -652,6 +652,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".go": CCommentStyle,
     ".gradle": CCommentStyle,
     ".graphql": PythonCommentStyle,
+    ".graphqls": PythonCommentStyle,
     ".groovy": CCommentStyle,
     ".h": CCommentStyle,
     ".ha": CSingleCommentStyle,


### PR DESCRIPTION
From https://docs.spring.io/spring-graphql/reference/request-execution.html#execution.graphqlsource.schema-resources

> By default, the Boot starter [looks for schema files](https://docs.spring.io/spring-boot/docs/3.1.5/reference/html/web.html#web.graphql.schema) with extensions ".graphqls" or ".gqls" under the location classpath:graphql/**, which is typically src/main/resources/graphql.

This PR adds ´.graphqls´ and ´.gqls´ to the list of supported files. 