### PR TITLE
Add support for CUDA-C++

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ CLI command and its behaviour. There are no guarantees of stability for the
 
 ### Added
 
+- More file types are recognised:
+  - CUDA-C++ (`.cu`, `.cuh`)
+
 ### Changed
 
 ### Deprecated

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -604,6 +604,8 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".csl": HtmlCommentStyle,  # Bibliography (XML based)
     ".css": CssCommentStyle,
     ".csv": UncommentableCommentStyle,
+    ".cu": CCommentStyle,
+    ".cuh": CCommentStyle,
     ".cxx": CCommentStyle,
     ".d": CCommentStyle,
     ".dart": CCommentStyle,


### PR DESCRIPTION
This PR adds ´.cu´ and ´.cuh´ to the list of supported files. As an extension to C/C++, CUDA-C++ uses the same comment style as C/C++.