### PR TITLE
Fix `Created` field format in bill of materials

### DIFF
--- a/src/reuse/report.py
+++ b/src/reuse/report.py
@@ -228,7 +228,7 @@ class ProjectReport:  # pylint: disable=too-many-instance-attributes
         out.write(f"Creator: Tool: reuse-{__version__}\n")
 
         now = datetime.datetime.now(tz=datetime.timezone.utc)
-        now = now.replace(microsecond=0)
+        now = now.replace(microsecond=0, tzinfo=None)
         out.write(f"Created: {now.isoformat()}Z\n")
         out.write(
             "CreatorComment: <text>This document was created automatically"

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -8,6 +8,7 @@
 
 
 import os
+import re
 import sys
 from importlib import import_module
 from textwrap import dedent
@@ -451,7 +452,10 @@ def test_bill_of_materials(fake_repository, multiprocessing):
     project = Project.from_directory(fake_repository)
     report = ProjectReport.generate(project, multiprocessing=multiprocessing)
     # TODO: Actually do something
-    report.bill_of_materials()
+    bom = report.bill_of_materials()
+    created_re = re.compile(r"^Created: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$",
+        re.MULTILINE)
+    assert created_re.search(bom) is not None
 
 
 # REUSE-IgnoreEnd


### PR DESCRIPTION
When generating a Bill Of Materials, the SPDX specification for the
[Created field] expect the date with format `YYYY-MM-DDThh:mm:ssZ`.

The current implementation does the transformation to express the
current time in UTC, but this has the side effect to add `+00:00` at the
end of the date when formatting it.  The resulting date
`YYYY-MM-DDThh:mm:ss+00:00Z` does not match the SPDX specification and
validation using the SPDX online tools fail because of this invalid
format.

Make sure to remove `tzinfo` from the date so that time zone information
is not output when formatting the date, so that we can safely append a
`Z` at the end to indicate UTC time-zone.

Other formats for the time-zone (e.g. `+00:00`) is not allowed by the
SPDX specification.

Fixes: #918

[Created field]: https://spdx.github.io/spdx-spec/v2.3/document-creation-information/#69-created-field
