### PR TITLE
Add support for certain files from .NET ecosystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ CLI command and its behaviour. There are no guarantees of stability for the
 - More file types are recognised:
   - Assembler (`.asm`) (#928)
   - CUDA-C++ (`.cu`, `.cuh`) (#938)
+  - Various .NET files (`.csproj`, `.fsproj`, `.fsx`, `.props`, `.sln`,
+    `.vbproj`) (#940)
 
 ### Changed
 

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -604,6 +604,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".cs": CCommentStyle,
     ".csl": HtmlCommentStyle,  # Bibliography (XML based)
     ".css": CssCommentStyle,
+    ".csproj": HtmlCommentStyle,
     ".csv": UncommentableCommentStyle,
     ".cu": CCommentStyle,
     ".cuh": CCommentStyle,
@@ -621,6 +622,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".ex": PythonCommentStyle,
     ".exs": PythonCommentStyle,
     ".f": FortranCommentStyle,
+    ".fsproj": HtmlCommentStyle,
     ".f03": ModernFortranCommentStyle,
     ".f08": ModernFortranCommentStyle,
     ".f90": ModernFortranCommentStyle,
@@ -634,6 +636,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".ftn": FortranCommentStyle,
     ".fpp": FortranCommentStyle,
     ".fs": CCommentStyle,
+    ".fsx": CCommentStyle,
     ".ftl": FtlCommentStyle,
     ".gemspec": PythonCommentStyle,
     ".go": CCommentStyle,
@@ -716,6 +719,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".pptx": UncommentableCommentStyle,
     ".pri": PythonCommentStyle,
     ".pro": PythonCommentStyle,
+    ".props": HtmlCommentStyle,  # MSBuild files
     ".proto": CCommentStyle,
     ".ps1": PythonCommentStyle,  # TODO: Multiline comments
     ".psm1": PythonCommentStyle,  # TODO: Multiline comments
@@ -754,6 +758,8 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".scsyndef": UncommentableCommentStyle,
     ".sh": PythonCommentStyle,
     ".sld": LispCommentStyle,  # Scheme Library Definition (R7RS)
+    # Visual Studio solution file, officially uncommentable:
+    ".sln": UncommentableCommentStyle,
     ".sls": LispCommentStyle,  # Scheme Library Source (R6RS)
     ".sml": MlCommentStyle,
     ".soy": CCommentStyle,
@@ -778,6 +784,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".ui": HtmlCommentStyle,
     ".v": CCommentStyle,  # V-Lang source code
     ".vala": CCommentStyle,
+    ".vbproj": HtmlCommentStyle,
     ".vim": VimCommentStyle,
     ".vm": VelocityCommentStyle,
     ".vsh": CCommentStyle,  # V-Lang script


### PR DESCRIPTION
- Visual Studio solution file, `.sln`
- .NET project files: `.csproj`, `.fsproj`, `.vbproj`
- F# script files, `.fsx`
- MSBuild files, `.props` (such as `Directory.Build.props`)

While working with the tool, I've also noted that it can sometimes break files if they include UTF-8 BOM (which is, while not mandatory, pretty common in .NET ecosystem). This is a separate issue #384, though.