### PR TITLE
comment: C, Cpp and Css styles reorganization (big)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,12 +70,13 @@ CLI command and its behaviour. There are no guarantees of stability for the
 
 ### Deprecated
 
+- `csingle` and `css` style shorthands (see changes). (#941)
+
 ### Removed
 
 - The PendingDeprecationWarning for the aggregation of information between DEP5
   and the contents of a file has been removed. This behaviour is now explicitly
   specified in REUSE Specification v3.2. (#1017, related to #779)
-- `csingle` and `css` style shorthands (see changes). (#941)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,8 +55,18 @@ CLI command and its behaviour. There are no guarantees of stability for the
 - Support alternate spelling `--skip-unrecognized`. (#974)
 - In `annotate`, rename `--copyright-style` to `--copyright-prefix`. The former
   parameter is still supported. (#973)
+- Support alternate spelling `--skip-unrecognized` (#974)
+- `cpp` and `cppsingle` style shorthands (see changes). (#941)
 
 ### Changed
+
+- Reorganised the way that `c`, `css`, and `csingle` styles work. (#941)
+  - `c` used to support multi-line comments; it now only supports multi-line
+    `/* */` comments. This is identical to the old `css` style.
+  - `cpp` has been added, which supports multi-line `/* */` comments and
+    single-line `//` comments. This is identical to the old `c` style.
+  - `csingle` has been renamed to `cppsingle`, and it supports only single-line
+    `//` comments.
 
 ### Deprecated
 
@@ -65,6 +75,7 @@ CLI command and its behaviour. There are no guarantees of stability for the
 - The PendingDeprecationWarning for the aggregation of information between DEP5
   and the contents of a file has been removed. This behaviour is now explicitly
   specified in REUSE Specification v3.2. (#1017, related to #779)
+- `csingle` and `css` style shorthands (see changes). (#941)
 
 ### Fixed
 

--- a/docs/man/reuse-annotate.rst
+++ b/docs/man/reuse-annotate.rst
@@ -39,7 +39,7 @@ The tool tries to auto-detect the comment style to use from the file extension
 of a file, and use that comment style.
 
 Normally, the tool uses a single-line comment style when one is available (e.g.,
-``//`` is used instead of ``/* ... */`` for C comment styles). If no single-line
+``//`` is used instead of ``/* ... */`` for C++ comment styles). If no single-line
 comment style is available, a multi-line style is used.
 
 Mandatory options

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -916,3 +916,6 @@ _result.remove(UncommentableCommentStyle)
 
 #: A map of human-friendly names against style classes.
 NAME_STYLE_MAP = {style.SHORTHAND: style for style in _result}
+# TODO: Remove this for next major 4.0 release.
+NAME_STYLE_MAP["csingle"] = CppSingleCommentStyle
+NAME_STYLE_MAP["css"] = CCommentStyle

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -329,6 +329,17 @@ class CCommentStyle(CommentStyle):
 
     SHORTHAND = "c"
 
+    MULTI_LINE = MultiLineSegments("/*", "*", "*/")
+    INDENT_BEFORE_MIDDLE = " "
+    INDENT_AFTER_MIDDLE = " "
+    INDENT_BEFORE_END = " "
+
+
+class CppCommentStyle(CommentStyle):
+    """C++ comment style."""
+
+    SHORTHAND = "cpp"
+
     SINGLE_LINE = "//"
     INDENT_AFTER_SINGLE = " "
     MULTI_LINE = MultiLineSegments("/*", "*", "*/")
@@ -341,24 +352,13 @@ class CCommentStyle(CommentStyle):
     ]
 
 
-class CSingleCommentStyle(CommentStyle):
-    """C single-only comment style."""
+class CppSingleCommentStyle(CommentStyle):
+    """C++ single-only comment style."""
 
-    SHORTHAND = "csingle"
+    SHORTHAND = "cppsingle"
 
     SINGLE_LINE = "//"
     INDENT_AFTER_SINGLE = " "
-
-
-class CssCommentStyle(CommentStyle):
-    """CSS comment style."""
-
-    SHORTHAND = "css"
-
-    MULTI_LINE = MultiLineSegments("/*", "*", "*/")
-    INDENT_BEFORE_MIDDLE = " "
-    INDENT_AFTER_MIDDLE = " "
-    INDENT_BEFORE_END = " "
 
 
 class EmptyCommentStyle(CommentStyle):
@@ -577,17 +577,17 @@ class XQueryCommentStyle(CommentStyle):
 #: A map of (common) file extensions against comment types.
 EXTENSION_COMMENT_STYLE_MAP = {
     ".adb": HaskellCommentStyle,
-    ".adoc": CCommentStyle,
+    ".adoc": CppCommentStyle,
     ".ads": HaskellCommentStyle,
     ".aes": UncommentableCommentStyle,
     ".ahk": SemicolonCommentStyle,
     ".ahkl": SemicolonCommentStyle,
-    ".aidl": CCommentStyle,
+    ".aidl": CppCommentStyle,
     ".applescript": AppleScriptCommentStyle,
     ".arb": UncommentableCommentStyle,
     ".asax": AspxCommentStyle,
-    ".asc": CCommentStyle,
-    ".asciidoc": CCommentStyle,
+    ".asc": CppCommentStyle,
+    ".asciidoc": CppCommentStyle,
     ".ashx": AspxCommentStyle,
     ".asm": LispCommentStyle,  # ASM assembler
     ".asmx": AspxCommentStyle,
@@ -604,34 +604,34 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".bib": BibTexCommentStyle,
     ".bzl": PythonCommentStyle,
     ".c": CCommentStyle,
-    ".cc": CCommentStyle,
-    ".cjs": CCommentStyle,
+    ".cc": CppCommentStyle,
+    ".cjs": CppCommentStyle,
     ".cl": LispCommentStyle,
     ".clj": LispCommentStyle,
     ".cljc": LispCommentStyle,
     ".cljs": LispCommentStyle,
     ".cls": TexCommentStyle,
     ".cmake": PythonCommentStyle,  # TODO: Bracket comments not supported.
-    ".code-workspace": CCommentStyle,
+    ".code-workspace": CppCommentStyle,
     ".coffee": PythonCommentStyle,
-    ".cpp": CCommentStyle,
-    ".cs": CCommentStyle,
+    ".cpp": CppCommentStyle,
+    ".cs": CppCommentStyle,
     ".csl": HtmlCommentStyle,  # Bibliography (XML based)
     ".cson": PythonCommentStyle,
-    ".css": CssCommentStyle,
+    ".css": CCommentStyle,
     ".csproj": HtmlCommentStyle,
     ".csv": UncommentableCommentStyle,
-    ".cu": CCommentStyle,
-    ".cuh": CCommentStyle,
-    ".cxx": CCommentStyle,
-    ".d": CCommentStyle,
-    ".dart": CCommentStyle,
-    ".di": CCommentStyle,
+    ".cu": CppCommentStyle,
+    ".cuh": CppCommentStyle,
+    ".cxx": CppCommentStyle,
+    ".d": CppCommentStyle,
+    ".dart": CppCommentStyle,
+    ".di": CppCommentStyle,
     ".doc": UncommentableCommentStyle,
     ".docx": UncommentableCommentStyle,
     ".dotx": UncommentableCommentStyle,
-    ".dts": CCommentStyle,
-    ".dtsi": CCommentStyle,
+    ".dts": CppCommentStyle,
+    ".dtsi": CppCommentStyle,
     ".el": LispCommentStyle,
     ".erl": TexCommentStyle,
     ".ex": PythonCommentStyle,
@@ -650,52 +650,52 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".for": FortranCommentStyle,
     ".ftn": FortranCommentStyle,
     ".fpp": FortranCommentStyle,
-    ".fs": CCommentStyle,
-    ".fsx": CCommentStyle,
+    ".fs": CppCommentStyle,
+    ".fsx": CppCommentStyle,
     ".ftl": FtlCommentStyle,
     ".gemspec": PythonCommentStyle,
-    ".go": CCommentStyle,
-    ".gradle": CCommentStyle,
+    ".go": CppCommentStyle,
+    ".gradle": CppCommentStyle,
     ".graphql": PythonCommentStyle,
     ".graphqls": PythonCommentStyle,
     ".gqls": PythonCommentStyle,
-    ".groovy": CCommentStyle,
+    ".groovy": CppCommentStyle,
     ".h": CCommentStyle,
-    ".ha": CSingleCommentStyle,
+    ".ha": CppSingleCommentStyle,
     ".hbs": HandlebarsCommentStyle,
     ".hcl": PythonCommentStyle,
-    ".hh": CCommentStyle,
-    ".hjson": CCommentStyle,
-    ".hpp": CCommentStyle,
+    ".hh": CppCommentStyle,
+    ".hjson": CppCommentStyle,
+    ".hpp": CppCommentStyle,
     ".hrl": TexCommentStyle,
     ".hs": HaskellCommentStyle,
     ".html": HtmlCommentStyle,
-    ".hx": CCommentStyle,
-    ".hxsl": CCommentStyle,
+    ".hx": CppCommentStyle,
+    ".hxsl": CppCommentStyle,
     ".ini": SemicolonCommentStyle,
-    ".ino": CCommentStyle,
+    ".ino": CppCommentStyle,
     ".ipynb": UncommentableCommentStyle,
     ".iuml": PlantUmlCommentStyle,
-    ".java": CCommentStyle,
+    ".java": CppCommentStyle,
     ".jinja": JinjaCommentStyle,
     ".jinja2": JinjaCommentStyle,
     ".jl": JuliaCommentStyle,
     ".jpg": UncommentableCommentStyle,
     ".jpeg": UncommentableCommentStyle,
-    ".js": CCommentStyle,
+    ".js": CppCommentStyle,
     ".json": UncommentableCommentStyle,
-    ".json5": CCommentStyle,
-    ".jsonc": CCommentStyle,
+    ".json5": CppCommentStyle,
+    ".jsonc": CppCommentStyle,
     ".jsp": AspxCommentStyle,
-    ".jsx": CCommentStyle,
+    ".jsx": CppCommentStyle,
     ".jy": PythonCommentStyle,
     ".ksh": PythonCommentStyle,
-    ".kt": CCommentStyle,
-    ".kts": CCommentStyle,
+    ".kt": CppCommentStyle,
+    ".kts": CppCommentStyle,
     ".l": LispCommentStyle,
     ".latex": TexCommentStyle,
-    ".ld": CCommentStyle,
-    ".less": CssCommentStyle,
+    ".ld": CppCommentStyle,
+    ".less": CCommentStyle,
     ".license": EmptyCommentStyle,
     ".lisp": LispCommentStyle,
     ".lsp": LispCommentStyle,
@@ -704,7 +704,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".man": UnixManCommentStyle,
     ".markdown": HtmlCommentStyle,
     ".md": HtmlCommentStyle,
-    ".mjs": CCommentStyle,
+    ".mjs": CppCommentStyle,
     ".mk": PythonCommentStyle,
     ".ml": MlCommentStyle,
     ".mli": MlCommentStyle,
@@ -726,10 +726,10 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".ott": UncommentableCommentStyle,
     ".pdf": UncommentableCommentStyle,
     ".pem": UncommentableCommentStyle,
-    ".php": CCommentStyle,
-    ".php3": CCommentStyle,
-    ".php4": CCommentStyle,
-    ".php5": CCommentStyle,
+    ".php": CppCommentStyle,
+    ".php3": CppCommentStyle,
+    ".php4": CppCommentStyle,
+    ".php5": CppCommentStyle,
     ".pl": PythonCommentStyle,
     ".plantuml": PlantUmlCommentStyle,
     ".png": UncommentableCommentStyle,
@@ -742,7 +742,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".pro": PythonCommentStyle,
     ".props": HtmlCommentStyle,  # MSBuild files
     ".properties": PythonCommentStyle,
-    ".proto": CCommentStyle,
+    ".proto": CppCommentStyle,
     ".ps1": PythonCommentStyle,  # TODO: Multiline comments
     ".psm1": PythonCommentStyle,  # TODO: Multiline comments
     ".pu": PlantUmlCommentStyle,
@@ -752,10 +752,10 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".pyi": PythonCommentStyle,
     ".pyw": PythonCommentStyle,
     ".pyx": PythonCommentStyle,
-    ".qbs": CCommentStyle,
-    ".qml": CCommentStyle,
+    ".qbs": CppCommentStyle,
+    ".qml": CppCommentStyle,
     ".qrc": HtmlCommentStyle,
-    ".qss": CssCommentStyle,
+    ".qss": CCommentStyle,
     ".R": PythonCommentStyle,
     ".rake": PythonCommentStyle,
     ".rb": PythonCommentStyle,
@@ -763,19 +763,19 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".rbx": PythonCommentStyle,
     ".rkt": LispCommentStyle,
     ".Rmd": HtmlCommentStyle,
-    ".rs": CCommentStyle,
+    ".rs": CppCommentStyle,
     ".rss": HtmlCommentStyle,
     ".rst": ReStructedTextCommentStyle,
     ".s": PythonCommentStyle,  # Assume GNU Assembler for x86
-    ".sass": CssCommentStyle,
-    ".sbt": CCommentStyle,
-    ".sc": CCommentStyle,  # SuperCollider source file
-    ".scad": CCommentStyle,
-    ".scala": CCommentStyle,
+    ".sass": CCommentStyle,
+    ".sbt": CppCommentStyle,
+    ".sc": CppCommentStyle,  # SuperCollider source file
+    ".scad": CppCommentStyle,
+    ".scala": CppCommentStyle,
     ".scm": LispCommentStyle,
     ".scpt": AppleScriptCommentStyle,
     ".scptd": AppleScriptCommentStyle,
-    ".scss": CssCommentStyle,
+    ".scss": CCommentStyle,
     # SuperCollider synth definition (binary)
     ".scsyndef": UncommentableCommentStyle,
     ".sh": PythonCommentStyle,
@@ -784,13 +784,13 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".sln": UncommentableCommentStyle,
     ".sls": LispCommentStyle,  # Scheme Library Source (R6RS)
     ".sml": MlCommentStyle,
-    ".soy": CCommentStyle,
+    ".soy": CppCommentStyle,
     ".sps": LispCommentStyle,  # Scheme Program Source (R6RS)
     ".sql": HaskellCommentStyle,
     ".sty": TexCommentStyle,
     ".svg": UncommentableCommentStyle,
     ".svelte": HtmlCommentStyle,
-    ".swift": CCommentStyle,
+    ".swift": CppCommentStyle,
     ".t": PythonCommentStyle,
     ".tcl": PythonCommentStyle,
     ".tex": TexCommentStyle,
@@ -800,17 +800,17 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".thy": MlCommentStyle,
     ".toc": TexCommentStyle,
     ".toml": PythonCommentStyle,
-    ".ts": CCommentStyle,
-    ".tsx": CCommentStyle,
+    ".ts": CppCommentStyle,
+    ".tsx": CppCommentStyle,
     ".ttl": PythonCommentStyle,  # Turtle/RDF
-    ".typ": CCommentStyle,  # typst files
+    ".typ": CppCommentStyle,  # typst files
     ".ui": HtmlCommentStyle,
-    ".v": CCommentStyle,  # V-Lang source code
-    ".vala": CCommentStyle,
+    ".v": CppCommentStyle,  # V-Lang source code
+    ".vala": CppCommentStyle,
     ".vbproj": HtmlCommentStyle,
     ".vim": VimCommentStyle,
     ".vm": VelocityCommentStyle,
-    ".vsh": CCommentStyle,  # V-Lang script
+    ".vsh": CppCommentStyle,  # V-Lang script
     ".vtl": VelocityCommentStyle,
     ".vue": HtmlCommentStyle,
     ".webp": UncommentableCommentStyle,
@@ -827,7 +827,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".xsl": HtmlCommentStyle,
     ".yaml": PythonCommentStyle,
     ".yml": PythonCommentStyle,
-    ".zig": CSingleCommentStyle,
+    ".zig": CppSingleCommentStyle,
     ".zsh": PythonCommentStyle,
 }
 
@@ -877,10 +877,10 @@ FILENAME_COMMENT_STYLE_MAP = {
     "Dockerfile": PythonCommentStyle,
     "Doxyfile": PythonCommentStyle,
     "Gemfile": PythonCommentStyle,
-    "go.mod": CCommentStyle,
+    "go.mod": CppCommentStyle,
     "go.sum": UncommentableCommentStyle,
     "gradlew": PythonCommentStyle,
-    "Jenkinsfile": CCommentStyle,
+    "Jenkinsfile": CppCommentStyle,
     "Makefile.am": PythonCommentStyle,
     "Makefile": PythonCommentStyle,
     "MANIFEST.in": PythonCommentStyle,

--- a/tests/test_comment.py
+++ b/tests/test_comment.py
@@ -13,10 +13,10 @@ from textwrap import dedent
 import pytest
 
 from reuse.comment import (
-    CCommentStyle,
     CommentCreateError,
     CommentParseError,
     CommentStyle,
+    CppCommentStyle,
     HtmlCommentStyle,
     LispCommentStyle,
     PythonCommentStyle,
@@ -236,8 +236,8 @@ def test_parse_comment_python_multi_error():
         PythonCommentStyle._parse_comment_multi("Hello world")
 
 
-def test_create_comment_c_single():
-    """Create a C comment with single-line comments."""
+def test_create_comment_cpp_single():
+    """Create a C++ comment with single-line comments."""
     text = cleandoc(
         """
         Hello
@@ -251,11 +251,11 @@ def test_create_comment_c_single():
         """
     )
 
-    assert CCommentStyle.create_comment(text) == expected
+    assert CppCommentStyle.create_comment(text) == expected
 
 
-def test_parse_comment_c_single():
-    """Parse a C comment with single-line comments."""
+def test_parse_comment_cpp_single():
+    """Parse a C++ comment with single-line comments."""
     text = cleandoc(
         """
         // Hello
@@ -269,11 +269,11 @@ def test_parse_comment_c_single():
         """
     )
 
-    assert CCommentStyle.parse_comment(text) == expected
+    assert CppCommentStyle.parse_comment(text) == expected
 
 
-def test_create_comment_c_multi():
-    """Create a C comment with multi-line comments."""
+def test_create_comment_cpp_multi():
+    """Create a C++ comment with multi-line comments."""
     text = cleandoc(
         """
         Hello
@@ -289,11 +289,11 @@ def test_create_comment_c_multi():
         """
     )
 
-    assert CCommentStyle.create_comment(text, force_multi=True) == expected
+    assert CppCommentStyle.create_comment(text, force_multi=True) == expected
 
 
-def test_create_comment_c_multi_empty_newlines():
-    """Create a C comment that contains empty lines."""
+def test_create_comment_cpp_multi_empty_newlines():
+    """Create a C++ comment that contains empty lines."""
     text = cleandoc(
         """
         Hello
@@ -311,11 +311,11 @@ def test_create_comment_c_multi_empty_newlines():
         """
     )
 
-    assert CCommentStyle.create_comment(text, force_multi=True) == expected
+    assert CppCommentStyle.create_comment(text, force_multi=True) == expected
 
 
-def test_create_comment_c_multi_surrounded_by_newlines():
-    """Create a C comment that is surrounded by empty lines."""
+def test_create_comment_cpp_multi_surrounded_by_newlines():
+    """Create a C++ comment that is surrounded by empty lines."""
     text = "\nHello\nworld\n"
     expected = cleandoc(
         """
@@ -328,10 +328,10 @@ def test_create_comment_c_multi_surrounded_by_newlines():
         """
     )
 
-    assert CCommentStyle.create_comment(text, force_multi=True) == expected
+    assert CppCommentStyle.create_comment(text, force_multi=True) == expected
 
 
-def test_create_comment_c_multi_contains_ending():
+def test_create_comment_cpp_multi_contains_ending():
     """Raise CommentCreateError when the text contains a comment ending."""
     text = cleandoc(
         """
@@ -342,11 +342,11 @@ def test_create_comment_c_multi_contains_ending():
     )
 
     with pytest.raises(CommentCreateError):
-        CCommentStyle.create_comment(text, force_multi=True)
+        CppCommentStyle.create_comment(text, force_multi=True)
 
 
-def test_parse_comment_c_multi():
-    """Parse a C comment with multi-line comments."""
+def test_parse_comment_cpp_multi():
+    """Parse a C++ comment with multi-line comments."""
     text = cleandoc(
         """
         /*
@@ -361,11 +361,11 @@ def test_parse_comment_c_multi():
         world
         """
     )
-    assert CCommentStyle.parse_comment(text) == expected
+    assert CppCommentStyle.parse_comment(text) == expected
 
 
-def test_parse_comment_c_multi_missing_middle():
-    """Parse a C comment even though the middle markers are missing."""
+def test_parse_comment_cpp_multi_missing_middle():
+    """Parse a C++ comment even though the middle markers are missing."""
     text = cleandoc(
         """
         /*
@@ -381,11 +381,11 @@ def test_parse_comment_c_multi_missing_middle():
         """
     )
 
-    assert CCommentStyle.parse_comment(text) == expected
+    assert CppCommentStyle.parse_comment(text) == expected
 
 
-def test_parse_comment_c_multi_misaligned_end():
-    """Parse a C comment even though the end is misaligned."""
+def test_parse_comment_cpp_multi_misaligned_end():
+    """Parse a C++ comment even though the end is misaligned."""
     text = cleandoc(
         """
         /*
@@ -401,7 +401,7 @@ def test_parse_comment_c_multi_misaligned_end():
         """
     )
 
-    assert CCommentStyle.parse_comment(text) == expected
+    assert CppCommentStyle.parse_comment(text) == expected
 
     text = cleandoc(
         """
@@ -418,11 +418,11 @@ def test_parse_comment_c_multi_misaligned_end():
         """
     )
 
-    assert CCommentStyle.parse_comment(text) == expected
+    assert CppCommentStyle.parse_comment(text) == expected
 
 
-def test_parse_comment_c_multi_no_middle():
-    """Parse a C comment that has no middle whatsoever."""
+def test_parse_comment_cpp_multi_no_middle():
+    """Parse a C++ comment that has no middle whatsoever."""
     text = cleandoc(
         """
         /* Hello
@@ -436,11 +436,11 @@ def test_parse_comment_c_multi_no_middle():
         """
     )
 
-    assert CCommentStyle.parse_comment(text) == expected
+    assert CppCommentStyle.parse_comment(text) == expected
 
 
-def test_parse_comment_c_multi_ends_at_last():
-    """Parse a C comment that treats the last line like a regular line."""
+def test_parse_comment_cpp_multi_ends_at_last():
+    """Parse a C++ comment that treats the last line like a regular line."""
     text = cleandoc(
         """
         /*
@@ -455,11 +455,11 @@ def test_parse_comment_c_multi_ends_at_last():
         """
     )
 
-    assert CCommentStyle.parse_comment(text) == expected
+    assert CppCommentStyle.parse_comment(text) == expected
 
 
-def test_parse_comment_c_multi_starts_at_first():
-    """Parse a C comment that treats the first line like a regular line."""
+def test_parse_comment_cpp_multi_starts_at_first():
+    """Parse a C++ comment that treats the first line like a regular line."""
     text = cleandoc(
         """
         /* Hello
@@ -474,11 +474,11 @@ def test_parse_comment_c_multi_starts_at_first():
         """
     )
 
-    assert CCommentStyle.parse_comment(text) == expected
+    assert CppCommentStyle.parse_comment(text) == expected
 
 
-def test_parse_comment_c_multi_indented():
-    """Preserve indentations in C comments."""
+def test_parse_comment_cpp_multi_indented():
+    """Preserve indentations in C++ comments."""
     text = cleandoc(
         """
         /*
@@ -494,37 +494,37 @@ def test_parse_comment_c_multi_indented():
         """
     )
 
-    assert CCommentStyle.parse_comment(text) == expected
+    assert CppCommentStyle.parse_comment(text) == expected
 
 
-def test_parse_comment_c_multi_single_line():
+def test_parse_comment_cpp_multi_single_line():
     """Parse a single-line multi-line comment."""
     text = "/* Hello world */"
     expected = "Hello world"
 
-    assert CCommentStyle.parse_comment(text) == expected
+    assert CppCommentStyle.parse_comment(text) == expected
 
 
-def test_parse_comment_c_multi_no_start():
+def test_parse_comment_cpp_multi_no_start():
     """Raise CommentParseError when there is no comment starter."""
     text = "Hello world */"
 
     with pytest.raises(CommentParseError):
-        CCommentStyle.parse_comment(text)
+        CppCommentStyle.parse_comment(text)
 
     with pytest.raises(CommentParseError):
-        CCommentStyle._parse_comment_multi(text)
+        CppCommentStyle._parse_comment_multi(text)
 
 
-def test_parse_comment_c_multi_no_end():
+def test_parse_comment_cpp_multi_no_end():
     """Raise CommentParseError when there is no comment end."""
     text = "/* Hello world"
 
     with pytest.raises(CommentParseError):
-        CCommentStyle.parse_comment(text)
+        CppCommentStyle.parse_comment(text)
 
 
-def test_parse_comment_c_multi_text_after_end():
+def test_parse_comment_cpp_multi_text_after_end():
     """Raise CommentParseError when there is stuff after the comment
     delimiter.
     """
@@ -538,7 +538,7 @@ def test_parse_comment_c_multi_text_after_end():
     )
 
     with pytest.raises(CommentParseError):
-        CCommentStyle.parse_comment(text)
+        CppCommentStyle.parse_comment(text)
 
 
 def test_create_comment_html():
@@ -633,8 +633,8 @@ def test_comment_at_first_character_python_indented_comments():
     assert PythonCommentStyle.comment_at_first_character(text) == expected
 
 
-def test_comment_at_first_character_c_multi():
-    """Simple test for a multi-line C comment."""
+def test_comment_at_first_character_cpp_multi():
+    """Simple test for a multi-line C++ comment."""
     text = cleandoc(
         """
         /*
@@ -653,10 +653,10 @@ def test_comment_at_first_character_c_multi():
         """
     )
 
-    assert CCommentStyle.comment_at_first_character(text) == expected
+    assert CppCommentStyle.comment_at_first_character(text) == expected
 
 
-def test_comment_at_first_character_c_multi_never_ends():
+def test_comment_at_first_character_cpp_multi_never_ends():
     """Expect CommentParseError if the comment never ends."""
     text = cleandoc(
         """
@@ -668,7 +668,7 @@ def test_comment_at_first_character_c_multi_never_ends():
     )
 
     with pytest.raises(CommentParseError):
-        CCommentStyle.comment_at_first_character(text)
+        CppCommentStyle.comment_at_first_character(text)
 
 
 def test_parse_comment_lisp():

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -11,7 +11,7 @@ from inspect import cleandoc
 import pytest
 
 from reuse import ReuseInfo
-from reuse.comment import CCommentStyle, CommentCreateError
+from reuse.comment import CommentCreateError, CppCommentStyle
 from reuse.header import (
     MissingReuseInfo,
     add_new_header,
@@ -95,7 +95,7 @@ def test_create_header_template_commented(template_commented):
             info,
             template=template_commented,
             template_is_commented=True,
-            style=CCommentStyle,
+            style=CppCommentStyle,
         ).strip()
         == expected
     )

--- a/tests/test_main_annotate.py
+++ b/tests/test_main_annotate.py
@@ -482,7 +482,7 @@ def test_annotate_specify_style(fake_repository, stringio, mock_date_today):
             "--copyright",
             "Jane Doe",
             "--style",
-            "c",
+            "cpp",
             "foo.py",
         ],
         out=stringio,

--- a/tests/test_main_annotate.py
+++ b/tests/test_main_annotate.py
@@ -1574,4 +1574,54 @@ def test_annotate_exit_if_unrecognised(
     assert "Jane Doe" not in (fake_repository / "baz/foo.py").read_text()
 
 
+def test_annotate_csingle(fake_repository, stringio, mock_date_today):
+    """Old csingle style is identical to new cppsingle style.
+
+    Remove this in the 4.0 major release.
+    """
+    (fake_repository / "csingle.py").write_text("pass")
+    (fake_repository / "cppsingle.py").write_text("pass")
+
+    for style in ["csingle", "cppsingle"]:
+        main(
+            [
+                "annotate",
+                "--copyright",
+                "Jane Doe",
+                "--style",
+                style,
+                f"{style}.py",
+            ]
+        )
+
+    assert (fake_repository / "csingle.py").read_text() == (
+        fake_repository / "cppsingle.py"
+    ).read_text()
+
+
+def test_annotate_css(fake_repository, stringio, mock_date_today):
+    """Old css style is identical to new c style.
+
+    Remove this in the 4.0 major release.
+    """
+    (fake_repository / "css.py").write_text("pass")
+    (fake_repository / "c.py").write_text("pass")
+
+    for style in ["css", "c"]:
+        main(
+            [
+                "annotate",
+                "--copyright",
+                "Jane Doe",
+                "--style",
+                style,
+                f"{style}.py",
+            ]
+        )
+
+    assert (fake_repository / "css.py").read_text() == (
+        fake_repository / "c.py"
+    ).read_text()
+
+
 # REUSE-IgnoreEnd


### PR DESCRIPTION
C and C++ features different comment styles:
- only multi-line `/* */` comment is valid in traditional C89
- C++ also supports `// ` single line comments from its beginning
- C started to support C++-style `// ` comments in C99

For this reason, multi-line `/* */` is often named C-style comment and single-line `// ` is often named C++-style comment.

In current implementation, there were only a "CCommentStyle" with `/* */` and `// ` support, used for both C and C++ files (also used by quite many other file types). 

Therefore:
- Rename CCommentStyle as CppCommentStyle
- Create a new CCommentStyle with only `/* */` support
- Remove redundant CssCommentStyle (same as new CCommentStyle)
- Associate *.c and *.h with CCommentStyle

Caution:
- this (slightly) changes *.c and *.h comments (by removing their multi-line support)
   - despite *.h files being often used also for C++, which is a minor issue in my opinion since C comments is a subset of C++ comment
- this changes the list of known style shorthands:
   - "c" style shorthand meaning changes
   - "css" style shorthand is no more known (want we keep a redundant CssCommentStyle to avoid this?)

This PR is a little bit big but in my opinion results in a clearer handling of C/C++ (and Css).