### PR TITLE
Add support for Unix manual pages (`.man`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ CLI command and its behaviour. There are no guarantees of stability for the
   - CUDA-C++ (`.cu`, `.cuh`) (#938)
   - Various .NET files (`.csproj`, `.fsproj`, `.fsx`, `.props`, `.sln`,
     `.vbproj`) (#940)
+- Added comment styles:
+  - `man` for UNIX Man pages (`.man`) (#954)
 
 ### Changed
 

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -533,6 +533,16 @@ class UncommentableCommentStyle(EmptyCommentStyle):
     """
 
 
+class UnixManCommentStyle(CommentStyle):
+    """UNIX manual page comment style."""
+
+    SHORTHAND = "man"
+
+    # In case the below is difficult to read, the comment character is: .\"
+    SINGLE_LINE = r".\""
+    INDENT_AFTER_SINGLE = " "
+
+
 class VelocityCommentStyle(CommentStyle):
     """Apache Velocity Template Language comment style."""
 
@@ -681,6 +691,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".lsp": LispCommentStyle,
     ".lua": HaskellCommentStyle,
     ".m4": M4CommentStyle,
+    ".man": UnixManCommentStyle,
     ".markdown": HtmlCommentStyle,
     ".md": HtmlCommentStyle,
     ".mjs": CCommentStyle,


### PR DESCRIPTION
Fixes #942 

Code contributed by @lpechacek. Thanks!