### PR TITLE
feat: lint output per line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ CLI command and its behaviour. There are no guarantees of stability for the
   - npm `.npmrc` files (#985)
 - Added comment styles:
   - `man` for UNIX Man pages (`.man`) (#954)
+- Added `--lines` output option for `lint`. (#956)
 
 ### Changed
 

--- a/docs/man/reuse-lint.rst
+++ b/docs/man/reuse-lint.rst
@@ -76,21 +76,25 @@ associated with it, then the project is not compliant.
 Options
 -------
 
-.. option:: --quiet
+.. option:: -q, --quiet
 
   Do not print anything to STDOUT.
 
 ..
   TODO: specify the JSON output.
 
-.. option:: --json
+.. option:: -j, --json
 
   Output the results of the lint as JSON.
 
-.. option:: --plain
+.. option:: -p, --plain
 
   Output the results of the lint as descriptive text. The text is valid
   Markdown.
+
+.. option:: -l, --lines
+
+  Output one line per error, prefixed by the file path.
 
 .. option:: -h, --help
 

--- a/src/reuse/lint.py
+++ b/src/reuse/lint.py
@@ -305,6 +305,13 @@ def format_lines(report: ProjectReport) -> str:
                 )
             )
 
+        # Unused licenses
+        for lic in sorted(report.unused_licenses):
+            lic_path = license_path(lic)
+            output.write(
+                _("{lic_path}: unused license\n").format(lic_path=lic_path)
+            )
+
         # Missing licenses
         for lic, files in sorted(report.missing_licenses.items()):
             for path in sorted(files):
@@ -313,13 +320,6 @@ def format_lines(report: ProjectReport) -> str:
                         path=path, lic=lic
                     )
                 )
-
-        # Unused licenses
-        for lic in sorted(report.unused_licenses):
-            lic_path = license_path(lic)
-            output.write(
-                _("{lic_path}: unused license\n").format(lic_path=lic_path)
-            )
 
         # Read errors
         for path in sorted(report.read_errors):

--- a/src/reuse/lint.py
+++ b/src/reuse/lint.py
@@ -285,7 +285,7 @@ def format_lines(report: ProjectReport) -> str:
         # Bad licenses
         for lic, files in sorted(report.bad_licenses.items()):
             for file in sorted(files):
-                output.write(_(f"{file}: bad license: {lic}\n"))
+                output.write(_(f"{file}: bad license {lic}\n"))
 
         # Deprecated licenses
         for lic in sorted(report.deprecated_licenses):
@@ -300,7 +300,7 @@ def format_lines(report: ProjectReport) -> str:
         # Missing licenses
         for lic, files in sorted(report.missing_licenses.items()):
             for file in sorted(files):
-                output.write(_(f"{file}: missing license: {lic}\n"))
+                output.write(_(f"{file}: missing license {lic}\n"))
 
         # Unused licenses
         for lic in sorted(report.unused_licenses):

--- a/src/reuse/lint.py
+++ b/src/reuse/lint.py
@@ -263,7 +263,7 @@ def format_json(report: ProjectReport) -> str:
     )
 
 
-def format_lines(report: ProjectReport, licenses_directory: Path) -> str:
+def format_lines(report: ProjectReport) -> str:
     """Formats data dictionary as plaintext strings to be printed to sys.stdout
     Sorting of output is not guaranteed.
     Symbolic links can result in multiple entries per file.
@@ -274,11 +274,11 @@ def format_lines(report: ProjectReport, licenses_directory: Path) -> str:
     Returns:
         String (in plaintext) that can be output to sys.stdout
     """
-    # TODO: modify so that license_directory isn't needed
     output = StringIO()
 
-    def license_path(lic: str) -> Path:
-        return licenses_directory.joinpath(lic)
+    def license_path(lic: str) -> Path | None:
+        "Resolve a license identifier to a license path."
+        return report.licenses.get(lic)
 
     if not report.is_compliant:
         # Bad licenses
@@ -287,13 +287,11 @@ def format_lines(report: ProjectReport, licenses_directory: Path) -> str:
             for file in sorted(files):
                 output.write(_(f"{file}: bad license: {lic}\n"))
 
-        # TODO: maintain the exact path to include the file extension
         # Deprecated licenses
         for lic in sorted(report.deprecated_licenses):
             lic_path = license_path(lic)
             output.write(_(f"{lic_path}: deprecated license\n"))
 
-        # TODO: maintain the exact path to include the file extension
         # Licenses without extension
         for lic in sorted(report.licenses_without_extension):
             lic_path = license_path(lic)
@@ -304,7 +302,6 @@ def format_lines(report: ProjectReport, licenses_directory: Path) -> str:
             for file in sorted(files):
                 output.write(_(f"{file}: missing license: {lic}\n"))
 
-        # TODO: maintain the exact path to include the file extension
         # Unused licenses
         for lic in sorted(report.unused_licenses):
             lic_path = license_path(lic)
@@ -336,7 +333,7 @@ def run(args: Namespace, project: Project, out: IO[str] = sys.stdout) -> int:
     elif args.json:
         out.write(format_json(report))
     elif args.lines:
-        out.write(format_lines(report, project.licenses_directory))
+        out.write(format_lines(report))
     else:
         out.write(format_plain(report))
 

--- a/src/reuse/lint.py
+++ b/src/reuse/lint.py
@@ -327,11 +327,11 @@ def format_lines(report: ProjectReport) -> str:
 
         # Without licenses
         for path in report.files_without_licenses:
-            output.write(_("{path}: without license\n").format(path=path))
+            output.write(_("{path}: no license identifier\n").format(path=path))
 
         # Without copyright
         for path in report.files_without_copyright:
-            output.write(_("{path}: without copyright\n").format(path=path))
+            output.write(_("{path}: no copyright notice\n").format(path=path))
 
     return output.getvalue()
 

--- a/src/reuse/lint.py
+++ b/src/reuse/lint.py
@@ -278,7 +278,7 @@ def format_lines(report: ProjectReport) -> str:
     output = StringIO()
 
     def license_path(lic: str) -> Optional[Path]:
-        "Resolve a license identifier to a license path."
+        """Resolve a license identifier to a license path."""
         return report.licenses.get(lic)
 
     if not report.is_compliant:

--- a/src/reuse/lint.py
+++ b/src/reuse/lint.py
@@ -284,40 +284,54 @@ def format_lines(report: ProjectReport) -> str:
     if not report.is_compliant:
         # Bad licenses
         for lic, files in sorted(report.bad_licenses.items()):
-            for file in sorted(files):
-                output.write(_(f"{file}: bad license {lic}\n"))
+            for path in sorted(files):
+                output.write(
+                    _("{path}: bad license {lic}\n").format(path=path, lic=lic)
+                )
 
         # Deprecated licenses
         for lic in sorted(report.deprecated_licenses):
             lic_path = license_path(lic)
-            output.write(_(f"{lic_path}: deprecated license\n"))
+            output.write(
+                _("{lic_path}: deprecated license\n").format(lic_path=lic_path)
+            )
 
         # Licenses without extension
         for lic in sorted(report.licenses_without_extension):
             lic_path = license_path(lic)
-            output.write(_(f"{lic_path}: license without file extension\n"))
+            output.write(
+                _("{lic_path}: license without file extension\n").format(
+                    lic_path=lic_path
+                )
+            )
 
         # Missing licenses
         for lic, files in sorted(report.missing_licenses.items()):
-            for file in sorted(files):
-                output.write(_(f"{file}: missing license {lic}\n"))
+            for path in sorted(files):
+                output.write(
+                    _("{path}: missing license {lic}\n").format(
+                        path=path, lic=lic
+                    )
+                )
 
         # Unused licenses
         for lic in sorted(report.unused_licenses):
             lic_path = license_path(lic)
-            output.write(_(f"{lic_path}: unused license\n"))
+            output.write(
+                _("{lic_path}: unused license\n").format(lic_path=lic_path)
+            )
 
         # Read errors
         for path in sorted(report.read_errors):
-            output.write(_(f"{path}: read error\n"))
+            output.write(_("{path}: read error\n").format(path=path))
 
         # Without licenses
-        for file in report.files_without_licenses:
-            output.write(_(f"{file}: without license\n"))
+        for path in report.files_without_licenses:
+            output.write(_("{path}: without license\n").format(path=path))
 
         # Without copyright
-        for file in report.files_without_copyright:
-            output.write(_(f"{file}: without copyright\n"))
+        for path in report.files_without_copyright:
+            output.write(_("{path}: without copyright\n").format(path=path))
 
     return output.getvalue()
 

--- a/src/reuse/lint.py
+++ b/src/reuse/lint.py
@@ -265,6 +265,8 @@ def format_json(report: ProjectReport) -> str:
 
 def format_lines(report: ProjectReport, licenses_directory: Path) -> str:
     """Formats data dictionary as plaintext strings to be printed to sys.stdout
+    Sorting of output is not guaranteed.
+    Symbolic links can result in multiple entries per file.
 
     Args:
         report: ProjectReport data
@@ -274,7 +276,6 @@ def format_lines(report: ProjectReport, licenses_directory: Path) -> str:
     """
     # TODO: modify so that license_directory isn't needed
     output = StringIO()
-    # TODO: perhaps merge with format_plain
 
     def license_path(lic: str) -> Path:
         return licenses_directory.joinpath(lic)
@@ -283,6 +284,7 @@ def format_lines(report: ProjectReport, licenses_directory: Path) -> str:
         # Bad licenses
         for lic, files in sorted(report.bad_licenses.items()):
             for file in sorted(files):
+                # TODO: lic might be "invalid"
                 output.write(_(f"{file}: bad license: {lic}\n"))
 
         # TODO: maintain the exact path rather than assuming it. Also: is this
@@ -301,6 +303,7 @@ def format_lines(report: ProjectReport, licenses_directory: Path) -> str:
         # Missing licenses
         for lic, files in sorted(report.missing_licenses.items()):
             for file in sorted(files):
+                # TODO: lic might be "invalid"
                 output.write(_(f"{file}: missing license: {lic}\n"))
 
         # TODO: maintain the exact path rather than assuming it

--- a/src/reuse/lint.py
+++ b/src/reuse/lint.py
@@ -16,7 +16,7 @@ from gettext import gettext as _
 from io import StringIO
 from pathlib import Path
 from textwrap import TextWrapper
-from typing import IO, Any
+from typing import IO, Any, Optional
 
 from . import __REUSE_version__
 from .project import Project
@@ -277,7 +277,7 @@ def format_lines(report: ProjectReport) -> str:
     """
     output = StringIO()
 
-    def license_path(lic: str) -> Path | None:
+    def license_path(lic: str) -> Optional[Path]:
         "Resolve a license identifier to a license path."
         return report.licenses.get(lic)
 

--- a/src/reuse/lint.py
+++ b/src/reuse/lint.py
@@ -283,7 +283,6 @@ def format_lines(report: ProjectReport) -> str:
 
     if not report.is_compliant:
         # Bad licenses
-        # TODO: include source code line number of the finding
         for lic, files in sorted(report.bad_licenses.items()):
             for file in sorted(files):
                 output.write(_(f"{file}: bad license: {lic}\n"))

--- a/src/reuse/lint.py
+++ b/src/reuse/lint.py
@@ -276,6 +276,9 @@ def format_lines(report: ProjectReport, licenses_directory: Path) -> str:
     output = StringIO()
     # TODO: perhaps merge with format_plain
 
+    def license_path(lic: str) -> Path:
+        return licenses_directory.joinpath(lic)
+
     if not report.is_compliant:
         # Bad licenses
         for lic, files in sorted(report.bad_licenses.items()):
@@ -286,14 +289,14 @@ def format_lines(report: ProjectReport, licenses_directory: Path) -> str:
         # based on the analysis of the license file?
         # Deprecated licenses
         for lic in sorted(report.deprecated_licenses):
-            license_path = licenses_directory.joinpath(lic)
-            output.write(_(f"{license_path}: deprecated license\n"))
+            lic_path = license_path(lic)
+            output.write(_(f"{lic_path}: deprecated license\n"))
 
         # TODO: maintain the exact path rather than assuming it
         # Licenses without extension
         for lic in sorted(report.licenses_without_extension):
-            license_path = licenses_directory.joinpath(lic)
-            output.write(_(f"{license_path}: license without file extension\n"))
+            lic_path = license_path(lic)
+            output.write(_(f"{lic_path}: license without file extension\n"))
 
         # Missing licenses
         for lic, files in sorted(report.missing_licenses.items()):
@@ -303,8 +306,8 @@ def format_lines(report: ProjectReport, licenses_directory: Path) -> str:
         # TODO: maintain the exact path rather than assuming it
         # Unused licenses
         for lic in sorted(report.unused_licenses):
-            license_path = licenses_directory.joinpath(lic)
-            output.write(_(f"{license_path}: unused license\n"))
+            lic_path = license_path(lic)
+            output.write(_(f"{lic_path}: unused license\n"))
 
         # Read errors
         for path in sorted(report.read_errors):

--- a/src/reuse/lint.py
+++ b/src/reuse/lint.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
 # SPDX-FileCopyrightText: 2022 Florian Snow <florian@familysnow.net>
 # SPDX-FileCopyrightText: 2023 DB Systel GmbH
+# SPDX-FileCopyrightText: 2024 Nico Rikken <nico@nicorikken.eu>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/reuse/lint.py
+++ b/src/reuse/lint.py
@@ -282,19 +282,18 @@ def format_lines(report: ProjectReport, licenses_directory: Path) -> str:
 
     if not report.is_compliant:
         # Bad licenses
+        # TODO: include source code line number of the finding
         for lic, files in sorted(report.bad_licenses.items()):
             for file in sorted(files):
-                # TODO: lic might be "invalid"
                 output.write(_(f"{file}: bad license: {lic}\n"))
 
-        # TODO: maintain the exact path rather than assuming it. Also: is this
-        # based on the analysis of the license file?
+        # TODO: maintain the exact path to include the file extension
         # Deprecated licenses
         for lic in sorted(report.deprecated_licenses):
             lic_path = license_path(lic)
             output.write(_(f"{lic_path}: deprecated license\n"))
 
-        # TODO: maintain the exact path rather than assuming it
+        # TODO: maintain the exact path to include the file extension
         # Licenses without extension
         for lic in sorted(report.licenses_without_extension):
             lic_path = license_path(lic)
@@ -303,10 +302,9 @@ def format_lines(report: ProjectReport, licenses_directory: Path) -> str:
         # Missing licenses
         for lic, files in sorted(report.missing_licenses.items()):
             for file in sorted(files):
-                # TODO: lic might be "invalid"
                 output.write(_(f"{file}: missing license: {lic}\n"))
 
-        # TODO: maintain the exact path rather than assuming it
+        # TODO: maintain the exact path to include the file extension
         # Unused licenses
         for lic in sorted(report.unused_licenses):
             lic_path = license_path(lic)

--- a/src/reuse/project.py
+++ b/src/reuse/project.py
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: 2023 Carmen Bianca BAKKER <carmenbianca@fsfe.org>
 # SPDX-FileCopyrightText: 2023 Matthias Riße
 # SPDX-FileCopyrightText: 2023 DB Systel GmbH
+# SPDX-FileCopyrightText: 2024 Nico Rikken <nico@nicorikken.eu>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/reuse/project.py
+++ b/src/reuse/project.py
@@ -75,6 +75,7 @@ class Project:
         include_meson_subprojects: bool = False,
     ):
         self.root = Path(root)
+        self.licenses_directory = Path(root).joinpath("LICENSES")
 
         if vcs_strategy is None:
             vcs_strategy = VCSStrategyNone
@@ -424,7 +425,7 @@ class Project:
         # TODO: This method does more than one thing. We ought to simplify it.
         license_files: Dict[str, Path] = {}
 
-        directory = str(self.root / "LICENSES/**")
+        directory = str(self.licenses_directory / "**")
         for path_str in glob.iglob(directory, recursive=True):
             path = Path(path_str)
             # For some reason, LICENSES/** is resolved even though it

--- a/src/reuse/project.py
+++ b/src/reuse/project.py
@@ -3,7 +3,6 @@
 # SPDX-FileCopyrightText: 2023 Carmen Bianca BAKKER <carmenbianca@fsfe.org>
 # SPDX-FileCopyrightText: 2023 Matthias Riße
 # SPDX-FileCopyrightText: 2023 DB Systel GmbH
-# SPDX-FileCopyrightText: 2024 Nico Rikken <nico@nicorikken.eu>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -76,9 +75,6 @@ class Project:
         include_meson_subprojects: bool = False,
     ):
         self.root = Path(root)
-        self.licenses_directory = self.root.joinpath("LICENSES").relative_to(
-            self.root
-        )
 
         if vcs_strategy is None:
             vcs_strategy = VCSStrategyNone
@@ -428,7 +424,7 @@ class Project:
         # TODO: This method does more than one thing. We ought to simplify it.
         license_files: Dict[str, Path] = {}
 
-        directory = str(self.licenses_directory / "**")
+        directory = str(self.root / "LICENSES/**")
         for path_str in glob.iglob(directory, recursive=True):
             path = Path(path_str)
             # For some reason, LICENSES/** is resolved even though it

--- a/src/reuse/project.py
+++ b/src/reuse/project.py
@@ -75,7 +75,9 @@ class Project:
         include_meson_subprojects: bool = False,
     ):
         self.root = Path(root)
-        self.licenses_directory = Path(root).joinpath("LICENSES")
+        self.licenses_directory = self.root.joinpath("LICENSES").relative_to(
+            self.root
+        )
 
         if vcs_strategy is None:
             vcs_strategy = VCSStrategyNone

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V. <https://fsfe.org>
 # SPDX-FileCopyrightText: 2022 Florian Snow <florian@familysnow.net>
+# SPDX-FileCopyrightText: 2024 Nico Rikken <nico@nicorikken.eu>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -241,7 +241,7 @@ def test_lint_lines_output(fake_repository):
     project = Project.from_directory(fake_repository)
     report = ProjectReport.generate(project)
 
-    lines_result = format_lines(report, project.licenses_directory)
+    lines_result = format_lines(report)
     lines_result_lines = lines_result.splitlines()
 
     assert len(lines_result_lines) == 15
@@ -253,7 +253,6 @@ def test_lint_lines_output(fake_repository):
     assert lines_result.count("no-license.py") == 1
     assert lines_result.count("LICENSES") == 6
     assert lines_result.count("invalid-license-text") == 3
-    # TODO: file extension of license isn't kept in the data
     assert lines_result.count("Nokia-Qt-exception-1.1.txt") == 2
     assert lines_result.count("MIT") == 2
     assert lines_result.count("restricted.py") == 1

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -235,7 +235,6 @@ def test_lint_lines_output(fake_repository):
     (fake_repository / "LICENSES" / "MIT").write_text("foo")
     (fake_repository / "restricted.py").write_text("foo")
     (fake_repository / "restricted.py").chmod(0o000)
-    # TODO: should potentially conflicting filenames be handled differently?
     (fake_repository / "file:with:colons.py").write_text("foo")
     (fake_repository / "file with spaces.py").write_text("foo")
 

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -243,7 +243,8 @@ def test_lint_lines_output(fake_repository):
     lines_result = format_lines(report)
     lines_result_lines = lines_result.splitlines()
 
-    assert len(lines_result_lines) == 13
+    print(lines_result_lines)  # TODO: remove this debug
+    assert len(lines_result_lines) == 12
 
     for line in lines_result_lines:
         assert re.match(".+: [^:]+", line)

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -233,8 +233,6 @@ def test_lint_lines_output(fake_repository):
         "Deprecated"
     )
     (fake_repository / "LICENSES" / "MIT").write_text("foo")
-    (fake_repository / "restricted.py").write_text("foo")
-    (fake_repository / "restricted.py").chmod(0o000)
     (fake_repository / "file with spaces.py").write_text("foo")
 
     project = Project.from_directory(fake_repository)
@@ -243,7 +241,6 @@ def test_lint_lines_output(fake_repository):
     lines_result = format_lines(report)
     lines_result_lines = lines_result.splitlines()
 
-    print(lines_result_lines)  # TODO: remove this debug
     assert len(lines_result_lines) == 12
 
     for line in lines_result_lines:
@@ -255,8 +252,23 @@ def test_lint_lines_output(fake_repository):
     assert lines_result.count("invalid-license-text") == 3
     assert lines_result.count("Nokia-Qt-exception-1.1.txt") == 2
     assert lines_result.count("MIT") == 2
-    assert lines_result.count("restricted.py") == 1
     assert lines_result.count("file with spaces.py") == 2
+
+
+@cpython
+@posix
+def test_lint_lines_read_errors(fake_repository):
+    """Check read error output"""
+    (fake_repository / "restricted.py").write_text("foo")
+    (fake_repository / "restricted.py").chmod(0o000)
+    project = Project.from_directory(fake_repository)
+    report = ProjectReport.generate(project)
+    result = format_lines(report)
+    print(result)
+
+    assert len(result.splitlines()) == 1
+    assert "restricted.py" in result
+    assert "read error" in result
 
 
 # REUSE-IgnoreEnd

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -247,7 +247,7 @@ def test_lint_lines_output(fake_repository):
     assert len(lines_result_lines) == 15
 
     for line in lines_result_lines:
-        assert re.match(".+: .+", line)
+        assert re.match(".+: [^:]+", line)
 
     assert lines_result.count("invalid-license.py") == 3
     assert lines_result.count("no-license.py") == 1

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -235,7 +235,6 @@ def test_lint_lines_output(fake_repository):
     (fake_repository / "LICENSES" / "MIT").write_text("foo")
     (fake_repository / "restricted.py").write_text("foo")
     (fake_repository / "restricted.py").chmod(0o000)
-    (fake_repository / "file:with:colons.py").write_text("foo")
     (fake_repository / "file with spaces.py").write_text("foo")
 
     project = Project.from_directory(fake_repository)
@@ -244,7 +243,7 @@ def test_lint_lines_output(fake_repository):
     lines_result = format_lines(report)
     lines_result_lines = lines_result.splitlines()
 
-    assert len(lines_result_lines) == 15
+    assert len(lines_result_lines) == 13
 
     for line in lines_result_lines:
         assert re.match(".+: [^:]+", line)
@@ -256,7 +255,6 @@ def test_lint_lines_output(fake_repository):
     assert lines_result.count("Nokia-Qt-exception-1.1.txt") == 2
     assert lines_result.count("MIT") == 2
     assert lines_result.count("restricted.py") == 1
-    assert lines_result.count("file:with:colons.py") == 2
     assert lines_result.count("file with spaces.py") == 2
 
 


### PR DESCRIPTION
Adds an '-line' or '-l' option to the 'lint' command. Prints a line for
each error, starting with the file to which the error belongs.

This output can be a starting point for some parsers, in particular ones
that implement something similar to Vim errorformat parsing.

Related to https://github.com/fsfe/reuse-tool/issues/925, needed for #578

Additional work needed:

- [x] Needs tests
- [ ] Error messages might have to be improved
- [x] Not all errors are found, as some issues aren't in the
  FileReports. This requires additional investigation.

Signed-off-by: Nico Rikken <nico@nicorikken.eu>
