### PR TITLE
Fix copyright merging for all copyright styles.

### DIFF
--- a/src/reuse/_util.py
+++ b/src/reuse/_util.py
@@ -114,12 +114,12 @@ _SPDX_TAGS: Dict[str, re.Pattern] = {
 
 _COPYRIGHT_PATTERNS = [
     re.compile(
-        r"(?P<copyright>(?P<prefix>SPDX-(File|Snippet)CopyrightText:)\s+"
+        r"(?P<copyright>(?P<prefix>SPDX-(File|Snippet)CopyrightText:(\s\([cC]\)|\s©)?)\s+"
         r"((?P<year>\d{4} ?- ?\d{4}|\d{4}),?\s+)?"
         r"(?P<statement>.*?))" + _END_PATTERN
     ),
     re.compile(
-        r"(?P<copyright>(?P<prefix>Copyright(\s?\([cC]\))?)\s+"
+        r"(?P<copyright>(?P<prefix>Copyright(\s\([cC]\)|\s©)?)\s+"
         r"((?P<year>\d{4} ?- ?\d{4}|\d{4}),?\s+)?"
         r"(?P<statement>.*?))" + _END_PATTERN
     ),

--- a/src/reuse/_util.py
+++ b/src/reuse/_util.py
@@ -114,7 +114,8 @@ _SPDX_TAGS: Dict[str, re.Pattern] = {
 
 _COPYRIGHT_PATTERNS = [
     re.compile(
-        r"(?P<copyright>(?P<prefix>SPDX-(File|Snippet)CopyrightText:(\s\([cC]\)|\s©)?)\s+"
+        r"(?P<copyright>"
+        r"(?P<prefix>SPDX-(File|Snippet)CopyrightText:(\s\([cC]\)|\s©)?)\s+"
         r"((?P<year>\d{4} ?- ?\d{4}|\d{4}),?\s+)?"
         r"(?P<statement>.*?))" + _END_PATTERN
     ),

--- a/tests/test_main_annotate_merge.py
+++ b/tests/test_main_annotate_merge.py
@@ -21,7 +21,7 @@ def test_annotate_merge_copyrights_simple(fake_repository, stringio):
     simple_file = fake_repository / "foo.py"
 
     for copyright_style, copyright_string in _COPYRIGHT_STYLES.items():
-        simple_file.write_text("pass")
+        simple_file.write_text("pass", encoding="utf-8")
         result = main(
             [
                 "annotate",
@@ -40,7 +40,7 @@ def test_annotate_merge_copyrights_simple(fake_repository, stringio):
         )
 
         assert result == 0
-        assert simple_file.read_text() == cleandoc(
+        assert simple_file.read_text(encoding="utf-8") == cleandoc(
             f"""
                 # {copyright_string} 2016 Mary Sue
                 #
@@ -68,7 +68,7 @@ def test_annotate_merge_copyrights_simple(fake_repository, stringio):
         )
 
         assert result == 0
-        assert simple_file.read_text() == cleandoc(
+        assert simple_file.read_text(encoding="utf-8") == cleandoc(
             f"""
                 # {copyright_string} 2016 - 2018 Mary Sue
                 #

--- a/tests/test_main_annotate_merge.py
+++ b/tests/test_main_annotate_merge.py
@@ -8,7 +8,6 @@
 from inspect import cleandoc
 
 from reuse._main import main
-
 from reuse._util import _COPYRIGHT_STYLES
 
 # pylint: disable=unused-argument

--- a/tests/test_main_annotate_merge.py
+++ b/tests/test_main_annotate_merge.py
@@ -9,6 +9,8 @@ from inspect import cleandoc
 
 from reuse._main import main
 
+from reuse._util import _COPYRIGHT_STYLES
+
 # pylint: disable=unused-argument
 
 # REUSE-IgnoreStart
@@ -17,59 +19,64 @@ from reuse._main import main
 def test_annotate_merge_copyrights_simple(fake_repository, stringio):
     """Add multiple headers to a file with merge copyrights."""
     simple_file = fake_repository / "foo.py"
-    simple_file.write_text("pass")
 
-    result = main(
-        [
-            "annotate",
-            "--year",
-            "2016",
-            "--license",
-            "GPL-3.0-or-later",
-            "--copyright",
-            "Mary Sue",
-            "--merge-copyrights",
-            "foo.py",
-        ],
-        out=stringio,
-    )
+    for copyright_style, copyright_string in _COPYRIGHT_STYLES.items():
+        simple_file.write_text("pass")
+        result = main(
+            [
+                "annotate",
+                "--year",
+                "2016",
+                "--license",
+                "GPL-3.0-or-later",
+                "--copyright",
+                "Mary Sue",
+                "--copyright-style",
+                copyright_style,
+                "--merge-copyrights",
+                "foo.py",
+            ],
+            out=stringio,
+        )
 
-    assert result == 0
-    assert simple_file.read_text() == cleandoc(
-        """
-            # SPDX-FileCopyrightText: 2016 Mary Sue
-            #
-            # SPDX-License-Identifier: GPL-3.0-or-later
+        assert result == 0
+        assert simple_file.read_text() == cleandoc(
+            f"""
+                # {copyright_string} 2016 Mary Sue
+                #
+                # SPDX-License-Identifier: GPL-3.0-or-later
 
-            pass
-            """
-    )
+                pass
+                """
+        )
 
-    result = main(
-        [
-            "annotate",
-            "--year",
-            "2018",
-            "--license",
-            "GPL-3.0-or-later",
-            "--copyright",
-            "Mary Sue",
-            "--merge-copyrights",
-            "foo.py",
-        ],
-        out=stringio,
-    )
+        result = main(
+            [
+                "annotate",
+                "--year",
+                "2018",
+                "--license",
+                "GPL-3.0-or-later",
+                "--copyright",
+                "Mary Sue",
+                "--copyright-style",
+                copyright_style,
+                "--merge-copyrights",
+                "foo.py",
+            ],
+            out=stringio,
+        )
 
-    assert result == 0
-    assert simple_file.read_text() == cleandoc(
-        """
-            # SPDX-FileCopyrightText: 2016 - 2018 Mary Sue
-            #
-            # SPDX-License-Identifier: GPL-3.0-or-later
+        assert result == 0
+        assert simple_file.read_text() == cleandoc(
+            f"""
+                # {copyright_string} 2016 - 2018 Mary Sue
+                #
+                # SPDX-License-Identifier: GPL-3.0-or-later
 
-            pass
-            """
-    )
+                pass
+                """
+        )
 
 
 def test_annotate_merge_copyrights_multi_prefix(fake_repository, stringio):


### PR DESCRIPTION
Fixes patterns not matching `spdx-c`, `spdx-symbol`, and `string-symbol` correctly, thereby causing merges to not occur.

Also change `test_annotate_merge_copyrights_simple()` to test copyright merging for all copyright styles defined in `_COPYRIGHT_STYLES` dictionary.