### PR TITLE
Add support for any Java .properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ CLI command and its behaviour. There are no guarantees of stability for the
     `.vbproj`) (#940)
   - Cargo (`Cargo.lock`) (#937)
   - Clang-Tidy (`.clang-tidy`) (#961)
+  - Java `.properties` files (#968)
 - Added comment styles:
   - `man` for UNIX Man pages (`.man`) (#954)
 

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -733,6 +733,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".pri": PythonCommentStyle,
     ".pro": PythonCommentStyle,
     ".props": HtmlCommentStyle,  # MSBuild files
+    ".properties": PythonCommentStyle,
     ".proto": CCommentStyle,
     ".ps1": PythonCommentStyle,  # TODO: Multiline comments
     ".psm1": PythonCommentStyle,  # TODO: Multiline comments
@@ -865,7 +866,6 @@ FILENAME_COMMENT_STYLE_MAP = {
     "Gemfile": PythonCommentStyle,
     "go.mod": CCommentStyle,
     "go.sum": UncommentableCommentStyle,
-    "gradle-wrapper.properties": PythonCommentStyle,
     "gradlew": PythonCommentStyle,
     "Jenkinsfile": CCommentStyle,
     "Makefile.am": PythonCommentStyle,
@@ -880,7 +880,6 @@ FILENAME_COMMENT_STYLE_MAP = {
     "requirements.txt": PythonCommentStyle,
     "ROOT": MlCommentStyle,
     "setup.cfg": PythonCommentStyle,
-    "sonar-project.properties": PythonCommentStyle,
     "yarn.lock": UncommentableCommentStyle,
 }
 


### PR DESCRIPTION
Not sure if this has been discussed before, but all Java `.properties` files have a similar structure (and support Python-like comments), so it makes sense to support them all at once.