### PR TITLE
TeX file adjustments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,9 +56,12 @@ CLI command and its behaviour. There are no guarantees of stability for the
   - Java `.properties` files (#968)
   - Apache HTTP server config `.htaccess` files (#985)
   - npm `.npmrc` files (#985)
+  - LaTeX class files (`.cls`) (#971)
 - Added comment styles:
   - `man` for UNIX Man pages (`.man`) (#954)
 - Added `--lines` output option for `lint`. (#956)
+- Treat `% !TEX` and `% !BIB` as shebangs in TeX and BibTeX files, respectively
+  (#971)
 
 ### Changed
 

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -607,6 +607,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".clj": LispCommentStyle,
     ".cljc": LispCommentStyle,
     ".cljs": LispCommentStyle,
+    ".cls": TexCommentStyle,
     ".cmake": PythonCommentStyle,  # TODO: Bracket comments not supported.
     ".code-workspace": CCommentStyle,
     ".coffee": PythonCommentStyle,

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -321,6 +321,7 @@ class BibTexCommentStyle(CommentStyle):
     SHORTHAND = "bibtex"
 
     MULTI_LINE = MultiLineSegments("@Comment{", "", "}")
+    SHEBANGS = ["% !BIB", "%!BIB"]
 
 
 class CCommentStyle(CommentStyle):
@@ -525,6 +526,7 @@ class TexCommentStyle(CommentStyle):
 
     SINGLE_LINE = "%"
     INDENT_AFTER_SINGLE = " "
+    SHEBANGS = ["% !TEX", "%!TEX"]
 
 
 class UncommentableCommentStyle(EmptyCommentStyle):


### PR DESCRIPTION
1. Interpret .cls files as LaTeX.
2. Some TeX editors and other programs use a `% !TEX` and `% !BIB` macro at the top of .tex and .bib files, respectively, so I added those as 'shebangs' in the comment style classes. That way, the comment block is injected after the macros.