### PR TITLE
Improve source distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ CLI command and its behaviour. There are no guarantees of stability for the
 - Repaired the behaviour of `reuse download` where being inside of a LICENSES/
   directory should not create a deeper LICENSES/LICENSES/ directory. (#975)
 - Support annotating a file that contains only a shebang. (#965)
+- Add `CONTRIBUTING.md` to the sdist. (#987)
 
 ### Security
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ include = [
     { path = "AUTHORS.rst", format = "sdist" },
     { path = "README.md", format = "sdist" },
     { path = "CHANGELOG.md", format = "sdist" },
+    { path = "CONTRIBUTING.md", format = "sdist" },
     { path = ".reuse", format = "sdist" },
     { path = "REUSE.toml", format = "sdist" },
     { path = "LICENSES", format = "sdist" },


### PR DESCRIPTION
I have recently taken maintenance of reuse in Fedora, and these are fixes for two minor issues I ran into while packaging the most current version (3.0.2).

1. `CONTRIBUTING.md` is missing from the sdist archive, but is included/used by Sphinx while building docs. So currently the docs cannot be built from sdist.
2. Our pytest invocation does some black magic with PYTHONPATH, and with the current configuration it leads to bunch of `ImportMismatchError`s when the tests are being collected. Swithing to `importlib` mode (which should be [the blessed way nowadays](https://docs.pytest.org/en/stable/explanation/goodpractices.html#which-import-mode)) fixes them and allows the tests to run (successfully on my machine).

   This change looks fine to me, but I'm fine with dropping it if it would cause any issues to anyone else.