### PR TITLE
Add support for ignoring files using REUSE.ignore

### DIFF
--- a/src/reuse/__init__.py
+++ b/src/reuse/__init__.py
@@ -87,6 +87,7 @@ _IGNORE_SPDX_PATTERNS = [
 # Combine SPDX patterns into file patterns to ease default ignore usage
 _IGNORE_FILE_PATTERNS.extend(_IGNORE_SPDX_PATTERNS)
 
+
 def load_ignore_patterns() -> None:
     """Load ignore patterns from REUSE.ignore file."""
     ignore_file = "REUSE.ignore"
@@ -104,11 +105,15 @@ def load_ignore_patterns() -> None:
                         else:
                             _IGNORE_FILE_PATTERNS.append(re.compile(pattern))
                     except re.error as err:
-                        print("Invalid regex pattern in REUSE.ignore: " +
-                              f"{pattern} - {err}")
+                        print(
+                            "Invalid regex pattern in REUSE.ignore: "
+                            + f"{pattern} - {err}"
+                        )
+
 
 # Load additional ignore patterns at startup
 load_ignore_patterns()
+
 
 class SourceType(Enum):
     """

--- a/src/reuse/__init__.py
+++ b/src/reuse/__init__.py
@@ -87,7 +87,7 @@ _IGNORE_SPDX_PATTERNS = [
 # Combine SPDX patterns into file patterns to ease default ignore usage
 _IGNORE_FILE_PATTERNS.extend(_IGNORE_SPDX_PATTERNS)
 
-def load_ignore_patterns():
+def load_ignore_patterns() -> None:
     """Load ignore patterns from REUSE.ignore file."""
     ignore_file = "REUSE.ignore"
     if os.path.exists(ignore_file):

--- a/src/reuse/__init__.py
+++ b/src/reuse/__init__.py
@@ -88,22 +88,24 @@ _IGNORE_SPDX_PATTERNS = [
 _IGNORE_FILE_PATTERNS.extend(_IGNORE_SPDX_PATTERNS)
 
 def load_ignore_patterns():
+    """Load ignore patterns from REUSE.ignore file."""
     ignore_file = "REUSE.ignore"
     if os.path.exists(ignore_file):
-        with open(ignore_file, "r") as f:
-            lines = f.readlines()
+        with open(ignore_file, "r", encoding="utf-8") as file:
+            lines = file.readlines()
             for line in lines:
                 pattern = line.strip()
                 if pattern:  # Only add non-empty lines
                     try:
-                        if pattern.endswith('/'):
-                            pattern = pattern.rstrip('/')
-                            pattern = pattern + '$'
+                        if pattern.endswith("/"):
+                            pattern = pattern.rstrip("/")
+                            pattern = pattern + "$"
                             _IGNORE_DIR_PATTERNS.append(re.compile(pattern))
                         else:
                             _IGNORE_FILE_PATTERNS.append(re.compile(pattern))
-                    except re.error as e:
-                        print(f"Invalid regex pattern in REUSE.ignore: {pattern} - {e}")
+                    except re.error as err:
+                        print("Invalid regex pattern in REUSE.ignore: " +
+                              f"{pattern} - {err}")
 
 # Load additional ignore patterns at startup
 load_ignore_patterns()

--- a/src/reuse/__init__.py
+++ b/src/reuse/__init__.py
@@ -64,6 +64,7 @@ _IGNORE_MESON_PARENT_DIR_PATTERNS = [
 ]
 
 _IGNORE_FILE_PATTERNS = [
+    re.compile(r"^REUSE.ignore$"),
     re.compile(r"^LICENSE(\..*)?$"),
     re.compile(r"^COPYING(\..*)?$"),
     # ".git" as file happens in submodules
@@ -86,6 +87,26 @@ _IGNORE_SPDX_PATTERNS = [
 # Combine SPDX patterns into file patterns to ease default ignore usage
 _IGNORE_FILE_PATTERNS.extend(_IGNORE_SPDX_PATTERNS)
 
+def load_ignore_patterns():
+    ignore_file = "REUSE.ignore"
+    if os.path.exists(ignore_file):
+        with open(ignore_file, "r") as f:
+            lines = f.readlines()
+            for line in lines:
+                pattern = line.strip()
+                if pattern:  # Only add non-empty lines
+                    try:
+                        if pattern.endswith('/'):
+                            pattern = pattern.rstrip('/')
+                            pattern = pattern + '$'
+                            _IGNORE_DIR_PATTERNS.append(re.compile(pattern))
+                        else:
+                            _IGNORE_FILE_PATTERNS.append(re.compile(pattern))
+                    except re.error as e:
+                        print(f"Invalid regex pattern in REUSE.ignore: {pattern} - {e}")
+
+# Load additional ignore patterns at startup
+load_ignore_patterns()
 
 class SourceType(Enum):
     """


### PR DESCRIPTION
I'm missing support to ignore certain files or folders for the license check in reuse-tool. In our repos (commercial product) there are certain files that will not be distributed, hence they don't need a license and should not appear in SPDX listing to avoid confusion. The existing solutions are not ideal:
* .gitignore: I don't want to ignore those files in Git, just for SPDX generation
* REUSE.toml: you can specify a license, but cannot ignore the file

I introduced a new file REUSE.ignore, which can be used to extend the IGNORE_FILE/DIR_PATTERNS in the code. This file is read at startup if it exists.

Example patterns:
```
^LICENSE-3RD-PARTY.TXT
^hooks/
^km/
^gitlab/
^src/test/afl/
````

Full regex syntax can be used. If the patterns ends with '/' it will be added to the `_IGNORE_DIR_PATTERNS` variable, otherwise `_IGNORE_FILE_PATTERNS` will be used. Therefor the trailing slash gets replaced with a '$' to terminate the expression and avoid wrong substring matches. More generic patterns are of course still possible using `^dir.*/` which will be expanded to `^dir.*$`.
