### PR TITLE
Remove deprecation warning from DEP5 aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ CLI command and its behaviour. There are no guarantees of stability for the
 
 ### Removed
 
+- The PendingDeprecationWarning for the aggregation of information between DEP5
+  and the contents of a file has been removed. This behaviour is now explicitly
+  specified in REUSE Specification v3.2. (#1017, related to #779)
+
 ### Fixed
 
 ### Security

--- a/src/reuse/project.py
+++ b/src/reuse/project.py
@@ -281,33 +281,6 @@ class Project:
         else:
             file_result = reuse_info_of_file(path, original_path, self.root)
 
-        # There is both information in a .dep5 file and in the file header
-        if (
-            isinstance(self.global_licensing, ReuseDep5)
-            and global_results
-            and file_result.contains_info()
-        ):
-            warnings.warn(
-                _(
-                    "Copyright and licensing information for"
-                    " '{original_path}' has been found in both '{path}' and"
-                    " in the DEP5 file located at '{dep5_path}'. The"
-                    " information for these two sources has been"
-                    " aggregated. You are recommended to instead use"
-                    " REUSE.toml, where you can specify the order of"
-                    " precedence. Use `reuse convert-dep5` to convert."
-                    " Run with"
-                    " `--suppress-deprecation` to hide this warning."
-                ).format(
-                    original_path=original_path,
-                    path=path,
-                    dep5_path=global_results[PrecedenceType.AGGREGATE][
-                        0
-                    ].source_path,
-                ),
-                PendingDeprecationWarning,
-            )
-
         result.extend(global_results[PrecedenceType.OVERRIDE])
         result.extend(global_results[PrecedenceType.AGGREGATE])
         if file_result.contains_info():

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -333,47 +333,6 @@ def test_reuse_info_of_only_copyright(fake_repository):
     assert reuse_info.path == "foo.py"
 
 
-def test_reuse_info_of_also_covered_by_dep5(fake_repository_dep5):
-    """A file contains all REUSE information, but .reuse/dep5 also
-    provides information on this file. Aggregate the information (for now), and
-    expect a PendingDeprecationWarning.
-    """
-    (fake_repository_dep5 / "doc/foo.py").write_text(
-        cleandoc(
-            """
-            SPDX-License-Identifier: MIT
-            SPDX-FileCopyrightText: in file
-            """
-        )
-    )
-    project = Project.from_directory(fake_repository_dep5)
-    with warnings.catch_warnings(record=True) as caught_warnings:
-        reuse_infos = project.reuse_info_of("doc/foo.py")
-        assert len(reuse_infos) == 2
-        assert reuse_infos[0].source_type != reuse_infos[1].source_type
-        for reuse_info in reuse_infos:
-            if reuse_info.source_type == SourceType.DEP5:
-                assert LicenseSymbol("CC0-1.0") in reuse_info.spdx_expressions
-                assert "2017 Jane Doe" in reuse_info.copyright_lines
-                assert reuse_info.path == "doc/foo.py"
-                assert reuse_info.source_path == ".reuse/dep5"
-            elif reuse_info.source_type == SourceType.FILE_HEADER:
-                assert LicenseSymbol("MIT") in reuse_info.spdx_expressions
-                assert (
-                    "SPDX-FileCopyrightText: in file"
-                    in reuse_info.copyright_lines
-                )
-                assert reuse_info.path == "doc/foo.py"
-                assert reuse_info.source_path == "doc/foo.py"
-            else:
-                assert False
-
-        assert len(caught_warnings) == 1
-        assert issubclass(
-            caught_warnings[0].category, PendingDeprecationWarning
-        )
-
-
 def test_reuse_info_of_toml_precedence(empty_directory):
     """When the precedence is set to toml, ignore file contents."""
     (empty_directory / "REUSE.toml").write_text(


### PR DESCRIPTION
This was previously undefined behaviour. Now that it has been defined, there is no need to raise a warning to the user.

Fixes #1010