### PR TITLE
comment: fix GNU ld and as files

### DIFF
--- a/changelog.d/changed/comment_gnu_as.md
+++ b/changelog.d/changed/comment_gnu_as.md
@@ -1,0 +1,1 @@
+- `.s` files (GNU as) now use the C comment style (#1034)

--- a/changelog.d/changed/comment_gnu_ld.md
+++ b/changelog.d/changed/comment_gnu_ld.md
@@ -1,0 +1,1 @@
+- `.ld` files (GNU ld) now use the C comment style (#1034)

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -17,6 +17,7 @@
 # SPDX-FileCopyrightText: 2023 Redradix S.L. <info@redradix.com>
 # SPDX-FileCopyrightText: 2023 Shun Sakai <sorairolake@protonmail.ch>
 # SPDX-FileCopyrightText: 2024 Rivos Inc.
+# SPDX-FileCopyrightText: 2024 Anthony Loiseau <anthony.loiseau@allcircuits.com>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -695,7 +695,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".kts": CppCommentStyle,
     ".l": LispCommentStyle,
     ".latex": TexCommentStyle,
-    ".ld": CppCommentStyle,
+    ".ld": CCommentStyle,
     ".less": CCommentStyle,
     ".license": EmptyCommentStyle,
     ".lisp": LispCommentStyle,

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -768,7 +768,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".rs": CppCommentStyle,
     ".rss": HtmlCommentStyle,
     ".rst": ReStructedTextCommentStyle,
-    ".s": PythonCommentStyle,  # Assume GNU Assembler for x86
+    ".s": CCommentStyle,
     ".sass": CCommentStyle,
     ".sbt": CppCommentStyle,
     ".sc": CppCommentStyle,  # SuperCollider source file


### PR DESCRIPTION
### comment: fix GNU as comment style (*.s)
    
As well described by sourceware website [1]:
There are two ways of rendering comments to as:
- Anything from `/*` through the next `*/` is a comment.
- The line comment character is target specific
    
We therefore better should use the C style comment instead of any single-line comment which can't fit every cases.
    
Wikipedia [2] provides a list of target-specific GNU as single-line comments:
- A hash symbol (#) — i386, x86-64, i960, 68HC11, 68HC12, VAX, V850, M32R,
                          PowerPC, MIPS, M680x0, and RISC-V
- A semicolon (;) — AMD 29k family, ARC, H8/300 family, HPPA, PDP-11,
                        picoJava, Motorola, and M32C
- The at sign (@) — 32-bit ARM
- A double slash (//) — AArch64
- A vertical bar (|) — M680x0
- An exclamation mark (!) — Renesas SH


Hash symbol is currently used, this PR make it `/* */`


### comment: fix GNU ld comment style (*.ld)
    
As per documentation: "You may include comments in linker scripts just as in C: delimited by `/*` and `*/`."
    
Link: https://ftp.gnu.org/old-gnu/Manuals/ld-2.9.1/html_chapter/ld_3.html#SEC6

---

<!-- Next, let's do a check list. Remove what doesn't apply. -->

- [x] Added a change log entry in `changelog.d/<directory>/`.
- [x] Added self to copyright blurb of touched files.
- [x] Added self to `AUTHORS.rst`.
- ~~[ ] Wrote tests.~~ ==> Don't think this desserves a new test
- ~~[ ] Documented my changes in `docs/man/` or elsewhere.~~ ==> Don't think this desserves a doc
- [x] My changes do not contradict
      [the current specification](https://reuse.software/spec/).
- [x] I agree to license my contribution under the licenses indicated in the
      changed files.
