### PR TITLE
comment: threat .j2 files as Jinja2

### DIFF
--- a/changelog.d/added/comment-j2.md
+++ b/changelog.d/added/comment-j2.md
@@ -1,0 +1,1 @@
+  - Ansible Jinja2 (`.j2`) (#1036)

--- a/changelog.d/added/comment-j2.md
+++ b/changelog.d/added/comment-j2.md
@@ -1,1 +1,2 @@
+- More file types are recognised:
   - Ansible Jinja2 (`.j2`) (#1036)

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -677,6 +677,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".ino": CppCommentStyle,
     ".ipynb": UncommentableCommentStyle,
     ".iuml": PlantUmlCommentStyle,
+    ".j2": JinjaCommentStyle,
     ".java": CppCommentStyle,
     ".jinja": JinjaCommentStyle,
     ".jinja2": JinjaCommentStyle,


### PR DESCRIPTION
[Ansible](https://www.ansible.com) commonly uses `.j2` file extensions for [Jinja2](https://jinja.palletsprojects.com) template files it relies on.

Link: <https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_templating.html>

---

<!--
Before submitting a PR, please read CONTRIBUTING.md. Non-trivial changes should
be discussed in an issue before committing to a PR.

Please succinctly describe your changes.
-->

<!-- Next, let's do a check list. Remove what doesn't apply. -->

- [x] Added a change log entry in `changelog.d/<directory>/`.
- ~~[ ] Added self to copyright blurb of touched files.~~ addition pending in another MR, not added here to avoid conflicts
- [x] Added self to `AUTHORS.rst`.
- ~~[ ] Wrote tests.~~
- ~~[ ] Documented my changes in `docs/man/` or elsewhere.~~
- [x] My changes do not contradict [the current specification](https://reuse.software/spec/).
- [x] I agree to license my contribution under the licenses indicated in the changed files.
