### PR TITLE
Be more lenient in ignoring LICENSE and COPYING-like files

### DIFF
--- a/changelog.d/changed/unspecly-changes.md
+++ b/changelog.d/changed/unspecly-changes.md
@@ -1,0 +1,6 @@
+- Changes that are not strictly compatible with
+  [REUSE Specification v3.2](https://reuse.software/spec-3.2):
+  - More `LICENSE` and `COPYING`-like files are ignored. Now, such files
+    suffixed by `-anything` are also ignored, typically something like
+    `LICENSE-MIT`. Files with the UK spelling `LICENCE` are also ignored.
+    (#1041)

--- a/src/reuse/__init__.py
+++ b/src/reuse/__init__.py
@@ -64,8 +64,9 @@ _IGNORE_MESON_PARENT_DIR_PATTERNS = [
 ]
 
 _IGNORE_FILE_PATTERNS = [
-    re.compile(r"^LICENSE(\..*)?$"),
-    re.compile(r"^COPYING(\..*)?$"),
+    # LICENSE, LICENSE-MIT, LICENSE.txt
+    re.compile(r"^LICEN[CS]E([-\.].*)?$"),
+    re.compile(r"^COPYING([-\.].*)?$"),
     # ".git" as file happens in submodules
     re.compile(r"^\.git$"),
     re.compile(r"^\.gitkeep$"),

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -112,13 +112,23 @@ def test_all_files_ignore_hg(empty_directory):
 
 
 def test_all_files_ignore_license_copying(empty_directory):
-    """When there are files names LICENSE, LICENSE.ext, COPYING, or COPYING.ext,
-    ignore them.
+    """When there are files named LICENSE, LICENSE.ext, LICENSE-MIT, COPYING,
+    COPYING.ext, or COPYING-MIT, ignore them.
     """
     (empty_directory / "LICENSE").write_text("foo")
     (empty_directory / "LICENSE.txt").write_text("foo")
+    (empty_directory / "LICENSE-MIT").write_text("foo")
     (empty_directory / "COPYING").write_text("foo")
     (empty_directory / "COPYING.txt").write_text("foo")
+    (empty_directory / "COPYING-MIT").write_text("foo")
+
+    project = Project.from_directory(empty_directory)
+    assert not list(project.all_files())
+
+
+def test_all_files_ignore_uk_license(empty_directory):
+    """Ignore UK spelling of licence."""
+    (empty_directory / "LICENCE").write_text("foo")
 
     project = Project.from_directory(empty_directory)
     assert not list(project.all_files())


### PR DESCRIPTION
Fixes #1032.

Also ignore such files separated by a dash instead of a full stop.

Also ignore the UK spelling LICENCE.

<!--
Before submitting a PR, please read CONTRIBUTING.md. Non-trivial changes should
be discussed in an issue before committing to a PR.

Please succinctly describe your changes.
-->

<!-- Next, let's do a check list. Remove what doesn't apply. -->

- [x] Added a change log entry in `changelog.d/<directory>/`.
- [x] Wrote tests.
- [ ] Documented my changes in `docs/man/` or elsewhere.
- [ ] My changes do not contradict
      [the current specification](https://reuse.software/spec/).
- [x] I agree to license my contribution under the licenses indicated in the
      changed files.
