### PR TITLE
Licensing header is not needed in REUSE.toml

### DIFF
--- a/changelog.d/changed/no-license-reuse-toml.md
+++ b/changelog.d/changed/no-license-reuse-toml.md
@@ -1,0 +1,1 @@
+- `REUSE.toml` no longer needs a licensing header. (#1042)

--- a/src/reuse/__init__.py
+++ b/src/reuse/__init__.py
@@ -71,6 +71,7 @@ _IGNORE_FILE_PATTERNS = [
     re.compile(r"^\.git$"),
     re.compile(r"^\.hgtags$"),
     re.compile(r".*\.license$"),
+    re.compile(r"^REUSE\.toml$"),
     # Workaround for https://github.com/fsfe/reuse-tool/issues/229
     re.compile(r"^CAL-1.0(-Combined-Work-Exception)?(\..+)?$"),
     re.compile(r"^SHL-2.1(\..+)?$"),

--- a/src/reuse/covered_files.py
+++ b/src/reuse/covered_files.py
@@ -30,6 +30,7 @@ def is_path_ignored(
     subset_files: Optional[Collection[StrPath]] = None,
     include_submodules: bool = False,
     include_meson_subprojects: bool = False,
+    include_reuse_tomls: bool = False,
     vcs_strategy: Optional[VCSStrategy] = None,
 ) -> bool:
     """Is *path* ignored by some mechanism?"""
@@ -46,7 +47,9 @@ def is_path_ignored(
         if subset_files is not None and path.resolve() not in subset_files:
             return True
         for pattern in _IGNORE_FILE_PATTERNS:
-            if pattern.match(name):
+            if pattern.match(name) and (
+                name != "REUSE.toml" or not include_reuse_tomls
+            ):
                 return True
         # Suppressing this error because I simply don't want to deal
         # with that here.
@@ -90,6 +93,7 @@ def iter_files(
     subset_files: Optional[Collection[StrPath]] = None,
     include_submodules: bool = False,
     include_meson_subprojects: bool = False,
+    include_reuse_tomls: bool = False,
     vcs_strategy: Optional[VCSStrategy] = None,
 ) -> Generator[Path, None, None]:
     """Yield all Covered Files in *directory* and its subdirectories according
@@ -113,6 +117,7 @@ def iter_files(
                 subset_files=subset_files,
                 include_submodules=include_submodules,
                 include_meson_subprojects=include_meson_subprojects,
+                include_reuse_tomls=include_reuse_tomls,
                 vcs_strategy=vcs_strategy,
             ):
                 _LOGGER.debug("ignoring '%s'", the_dir)
@@ -126,6 +131,7 @@ def iter_files(
                 subset_files=subset_files,
                 include_submodules=include_submodules,
                 include_meson_subprojects=include_meson_subprojects,
+                include_reuse_tomls=include_reuse_tomls,
                 vcs_strategy=vcs_strategy,
             ):
                 _LOGGER.debug("ignoring '%s'", the_file)

--- a/src/reuse/global_licensing.py
+++ b/src/reuse/global_licensing.py
@@ -595,6 +595,7 @@ class NestedReuseTOML(GlobalLicensing):
                 path,
                 include_submodules=include_submodules,
                 include_meson_subprojects=include_meson_subprojects,
+                include_reuse_tomls=True,
                 vcs_strategy=vcs_strategy,
             )
             if item.name == "REUSE.toml"

--- a/tests/resources/REUSE.toml
+++ b/tests/resources/REUSE.toml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2017 Jane Doe
-#
-# SPDX-License-Identifier: CC0-1.0
-
 version = 1
 
 [[annotations]]

--- a/tests/test_covered_files.py
+++ b/tests/test_covered_files.py
@@ -121,6 +121,12 @@ class TestIterFiles:
             empty_directory, include_meson_subprojects=True
         )
 
+    def test_reuse_toml_ignored(self, empty_directory):
+        """REUSE.toml is ignored."""
+        (empty_directory / "REUSE.toml").write_text("version = 1")
+        assert not list(iter_files(empty_directory))
+        assert list(iter_files(empty_directory, include_reuse_tomls=True))
+
 
 class TestIterFilesSubet:
     """Tests for  subset_files in iter_files."""


### PR DESCRIPTION
As discussed on 2024-07-05

Fixes #1040 

<!--
Before submitting a PR, please read CONTRIBUTING.md. Non-trivial changes should
be discussed in an issue before committing to a PR.

Please succinctly describe your changes.
-->

<!-- Next, let's do a check list. Remove what doesn't apply. -->

- [x] Added a change log entry in `changelog.d/<directory>/`.
- [x] Wrote tests.
- [ ] Documented my changes in `docs/man/` or elsewhere.
- [ ] My changes do not contradict
      [the current specification](https://reuse.software/spec/).
- [x] I agree to license my contribution under the licenses indicated in the
      changed files.
