### PR TITLE
Use importlib mode for pytest

### DIFF
--- a/changelog.d/changed/importlib_mode_pytest.md
+++ b/changelog.d/changed/importlib_mode_pytest.md
@@ -1,0 +1,3 @@
+- Tests now use
+  [`--import-mode=importlib`](https://docs.pytest.org/en/stable/explanation/goodpractices.html#which-import-mode).
+  (#1046)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,7 +148,7 @@ use_parentheses = true
 line_length = 80
 
 [tool.pytest.ini_options]
-addopts = "--doctest-modules"
+addopts = "--doctest-modules --import-mode=importlib"
 
 [tool.mypy]
 files = [

--- a/tests/test_cli_lint.py
+++ b/tests/test_cli_lint.py
@@ -18,11 +18,12 @@ import shutil
 from inspect import cleandoc
 
 from click.testing import CliRunner
-from conftest import RESOURCES_DIRECTORY
 
 from reuse._util import cleandoc_nl
 from reuse.cli.main import main
 from reuse.report import LINT_VERSION
+
+from .conftest import RESOURCES_DIRECTORY
 
 
 class TestLint:

--- a/tests/test_covered_files.py
+++ b/tests/test_covered_files.py
@@ -10,10 +10,10 @@
 import os
 from pathlib import Path
 
-from conftest import git, hg, pijul, posix
-
 from reuse.covered_files import iter_files
 from reuse.vcs import VCSStrategyGit, VCSStrategyHg, VCSStrategyPijul
+
+from .conftest import git, hg, pijul, posix
 
 
 class TestIterFiles:

--- a/tests/test_global_licensing.py
+++ b/tests/test_global_licensing.py
@@ -9,7 +9,6 @@ from inspect import cleandoc
 from pathlib import Path
 
 import pytest
-from conftest import RESOURCES_DIRECTORY, posix
 from debian.copyright import Copyright
 from license_expression import LicenseSymbol
 
@@ -27,6 +26,8 @@ from reuse.global_licensing import (
     ReuseTOML,
 )
 from reuse.vcs import VCSStrategyGit
+
+from .conftest import RESOURCES_DIRECTORY, posix
 
 # REUSE-IgnoreStart
 

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -9,11 +9,11 @@
 import re
 import shutil
 
-from conftest import cpython, posix
-
 from reuse.lint import format_lines, format_plain
 from reuse.project import Project
 from reuse.report import ProjectReport
+
+from .conftest import cpython, posix
 
 # REUSE-IgnoreStart
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -17,7 +17,6 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
-from conftest import RESOURCES_DIRECTORY
 from license_expression import LicenseSymbol
 
 from reuse import _LICENSING, ReuseInfo, SourceType
@@ -28,6 +27,8 @@ from reuse.exceptions import (
 )
 from reuse.global_licensing import ReuseDep5, ReuseTOML
 from reuse.project import Project
+
+from .conftest import RESOURCES_DIRECTORY
 
 # REUSE-IgnoreStart
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -13,11 +13,11 @@ import warnings
 from inspect import cleandoc
 from textwrap import dedent
 
-from conftest import cpython, posix
-
 from reuse import SourceType
 from reuse.project import Project
 from reuse.report import FileReport, ProjectReport, ProjectSubsetReport
+
+from .conftest import cpython, posix
 
 # REUSE-IgnoreStart
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read CONTRIBUTING.md. Non-trivial changes should
be discussed in an issue before committing to a PR.

Please succinctly describe your changes.
-->

Attempt at implementing #993.

- Treat `tests/` as namespace and relative-import `conftest`. 
- Switch the mode in `pyproject.toml`.

<!-- Next, let's do a check list. Remove what doesn't apply. -->

- [x] Added a change log entry in `changelog.d/<directory>/`.
- [x] My changes do not contradict
      [the current specification](https://reuse.software/spec/).
- [x] I agree to license my contribution under the licenses indicated in the
      changed files.
