### PR TITLE
.pre-commit-config.yaml: update prettier repo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,8 +27,8 @@ repos:
         # to be defined here for identical behaviour between `poetry run mypy`
         # and `pre-commit run mypy`.
         additional_dependencies: [attrs==23.2.0]
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.3
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.3.3
     hooks:
       - id: prettier
         name: prettier


### PR DESCRIPTION
The `pre-commit/mirrors-prettier` repository has been archived for some time now, the discussion is mainly at https://github.com/prettier/prettier/issues/15742#issuecomment-2052160032 where I think most have switched to rbubley's repo or local hook.

I don't know is this so big change that I should start clicking the checkboxes and maybe this should be an issue anyway.

------

- [ ] Added a change log entry in `changelog.d/<directory>/`.
- [ ] Added self to copyright blurb of touched files.
- [ ] Added self to `AUTHORS.rst`.
- [ ] Wrote tests.
- [ ] Documented my changes in `docs/man/` or elsewhere.
- [ ] My changes do not contradict
      [the current specification](https://reuse.software/spec/).
- [x] I agree to license my contribution under the licenses indicated in the
      changed files.
