### PR TITLE
feat(vcs): Add Jujutsu support

### DIFF
--- a/.github/workflows/jujutsu.yaml
+++ b/.github/workflows/jujutsu.yaml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2023 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2024 Skyler Grey <sky@a.starrysky.fyi>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+name: Test with Jujutsu
+
+# These tests are run exclusively on the main branch to reduce CPU time wasted
+# on every single PR that very likely does not affect Jujutsu functionality.
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "src/reuse/**.py"
+      - "tests/**.py"
+jobs:
+  test-jujutsu:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+      - name: Install dependencies
+        run: |
+          pip install poetry~=1.3.0
+          poetry install --no-interaction --only main,test
+      - name: Set up Jujutsu
+        run: |
+          cargo install cargo-binstall
+          cargo binstall --strategies crate-meta-data jj-cli --no-confirm
+          export PATH=~/.cargo/bin:$PATH
+      - name: Run tests with pytest
+        run: |
+          poetry run pytest --cov=reuse

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -150,3 +150,4 @@ Contributors
 - rajivsunar07 <56905029+rajivsunar07@users.noreply.github.com>
 - Сергій <sergiy.goncharuk.1@gmail.com>
 - Mersho <code.rezaei@gmail.com>
+- Skyler Grey <sky@a.starrysky.fyi>

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ For full functionality, the following pieces of software are recommended:
 - Git
 - Mercurial 4.3+
 - Pijul
+- Jujutsu
 
 ### Installation via pip
 

--- a/changelog.d/added/jujutsu.md
+++ b/changelog.d/added/jujutsu.md
@@ -1,0 +1,1 @@
+- Add Jujutsu VCS support. (#TODO)

--- a/src/reuse/_util.py
+++ b/src/reuse/_util.py
@@ -7,6 +7,7 @@
 # SPDX-FileCopyrightText: 2023 DB Systel GmbH
 # SPDX-FileCopyrightText: 2023 Johannes Zarl-Zierl <johannes@zarl-zierl.at>
 # SPDX-FileCopyrightText: 2024 Rivos Inc.
+# SPDX-FileCopyrightText: 2024 Skyler Grey <sky@a.starrysky.fyi>
 # SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
@@ -61,6 +62,7 @@ StrPath = Union[str, PathLike]
 
 GIT_EXE = shutil.which("git")
 HG_EXE = shutil.which("hg")
+JUJUTSU_EXE = shutil.which("jj")
 PIJUL_EXE = shutil.which("pijul")
 
 REUSE_IGNORE_START = "REUSE-IgnoreStart"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2022 Carmen Bianca Bakker <carmenbianca@fsfe.org>
 # SPDX-FileCopyrightText: 2022 Florian Snow <florian@familysnow.net>
 # SPDX-FileCopyrightText: 2023 Matthias Riße
+# SPDX-FileCopyrightText: 2024 Skyler Grey <sky@a.starrysky.fyi>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -37,7 +38,13 @@ try:
 except ImportError:
     sys.path.append(os.path.join(Path(__file__).parent.parent, "src"))
 finally:
-    from reuse._util import GIT_EXE, HG_EXE, PIJUL_EXE, setup_logging
+    from reuse._util import (
+        GIT_EXE,
+        HG_EXE,
+        JUJUTSU_EXE,
+        PIJUL_EXE,
+        setup_logging,
+    )
     from reuse.global_licensing import ReuseDep5
 
 CWD = Path.cwd()
@@ -106,6 +113,14 @@ def hg_exe() -> str:
     if not HG_EXE:
         pytest.skip("cannot run this test without mercurial")
     return str(HG_EXE)
+
+
+@pytest.fixture()
+def jujutsu_exe() -> str:
+    """Run the test with Jujutsu."""
+    if not JUJUTSU_EXE:
+        pytest.skip("cannot run this test without jujutsu")
+    return str(JUJUTSU_EXE)
 
 
 @pytest.fixture()
@@ -270,6 +285,19 @@ def hg_repository(fake_repository: Path, hg_exe: str) -> Path:
             "initial",
         ],
         check=True,
+    )
+
+    return fake_repository
+
+
+@pytest.fixture()
+def jujutsu_repository(fake_repository: Path, jujutsu_exe: str) -> Path:
+    """Create a jujutsu repository with ignored files."""
+    os.chdir(fake_repository)
+    _repo_contents(fake_repository)
+
+    subprocess.run(
+        [jujutsu_exe, "git", "init", str(fake_repository)], check=True
     )
 
     return fake_repository

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,9 +1,10 @@
 # SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V. <https://fsfe.org>
 # SPDX-FileCopyrightText: 2019 Stefan Bakker <s.bakker777@gmail.com>
-# SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 # SPDX-FileCopyrightText: 2022 Florian Snow <florian@familysnow.net>
 # SPDX-FileCopyrightText: 2022 Pietro Albini <pietro.albini@ferrous-systems.com>
 # SPDX-FileCopyrightText: 2024 Carmen Bianca BAKKER <carmenbianca@fsfe.org>
+# SPDX-FileCopyrightText: 2024 Skyler Grey <sky@a.starrysky.fyi>
+# SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -29,7 +30,7 @@ from freezegun import freeze_time
 
 from reuse import download
 from reuse._main import main
-from reuse._util import GIT_EXE, HG_EXE, PIJUL_EXE, cleandoc_nl
+from reuse._util import GIT_EXE, HG_EXE, JUJUTSU_EXE, PIJUL_EXE, cleandoc_nl
 from reuse.report import LINT_VERSION
 
 # REUSE-IgnoreStart
@@ -54,6 +55,17 @@ def optional_hg_exe(
     exe = HG_EXE if request.param else ""
     monkeypatch.setattr("reuse.vcs.HG_EXE", exe)
     monkeypatch.setattr("reuse._util.HG_EXE", exe)
+    yield exe
+
+
+@pytest.fixture(params=[True, False])
+def optional_jujutsu_exe(
+    request, monkeypatch
+) -> Generator[Optional[str], None, None]:
+    """Run the test with or without Jujutsu."""
+    exe = JUJUTSU_EXE if request.param else ""
+    monkeypatch.setattr("reuse.vcs.JUJUTSU_EXE", exe)
+    monkeypatch.setattr("reuse._util.JUJUTSU_EXE", exe)
     yield exe
 
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
 # SPDX-FileCopyrightText: 2022 Florian Snow <florian@familysnow.net>
 # SPDX-FileCopyrightText: 2023 Carmen Bianca BAKKER <carmenbianca@fsfe.org>
+# SPDX-FileCopyrightText: 2024 Skyler Grey <sky@a.starrysky.fyi>
 # SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
@@ -237,6 +238,40 @@ def test_all_files_hg_ignored_contains_newline(hg_repository):
     """File names that contain newlines are also ignored."""
     (hg_repository / "hello\nworld.pyc").touch()
     project = Project.from_directory(hg_repository)
+    assert Path("hello\nworld.pyc").absolute() not in project.all_files()
+
+
+def test_all_files_jujutsu_ignored(jujutsu_repository):
+    """Given a jujutsu repository where some files are ignored, do not yield
+    those files.
+    """
+    project = Project.from_directory(jujutsu_repository)
+    assert Path("build/hello.py").absolute() not in project.all_files()
+
+
+def test_all_files_jujutsu_ignored_different_cwd(jujutsu_repository):
+    """Given a jujutsu repository where some files are ignored, do not yield
+    those files.
+
+    Be in a different CWD during the above.
+    """
+    os.chdir(jujutsu_repository / "LICENSES")
+    project = Project.from_directory(jujutsu_repository)
+    assert Path("build/hello.py").absolute() not in project.all_files()
+
+
+def test_all_files_jujutsu_ignored_contains_space(jujutsu_repository):
+    """File names that contain spaces are also ignored."""
+    (jujutsu_repository / "I contain spaces.pyc").touch()
+    project = Project.from_directory(jujutsu_repository)
+    assert Path("I contain spaces.pyc").absolute() not in project.all_files()
+
+
+@posix
+def test_all_files_jujutsu_ignored_contains_newline(jujutsu_repository):
+    """File names that contain newlines are also ignored."""
+    (jujutsu_repository / "hello\nworld.pyc").touch()
+    project = Project.from_directory(jujutsu_repository)
     assert Path("hello\nworld.pyc").absolute() not in project.all_files()
 
 

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
-# SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 # SPDX-FileCopyrightText: 2022 Florian Snow <florian@familysnow.net>
+# SPDX-FileCopyrightText: 2024 Skyler Grey <sky@a.starrysky.fyi>
+# SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -31,6 +32,16 @@ def test_find_root_in_hg_repo(hg_repository):
     result = vcs.find_root()
 
     assert Path(result).absolute().resolve() == hg_repository
+
+
+def test_find_root_in_jujutsu_repo(jujutsu_repository):
+    """When using reuse from a child directory in a Jujutsu repo, always find
+    the root directory.
+    """
+    os.chdir("src")
+    result = vcs.find_root()
+
+    assert Path(result).absolute().resolve() == jujutsu_repository
 
 
 def test_find_root_in_pijul_repo(pijul_repository):


### PR DESCRIPTION
Although it uses .gitignore, Jujutsu has support for repositories without git ("non-colocated"), which we can't use "git ls-files" on

jj has its own command for listing out tracked files ("jj files"), and we can use it to determine ignored files in a similar way to Pijul

Fixes: fsfe/reuse-tool#711

- [x] Added a change log entry in `changelog.d/<directory>/`.
- [x] Added self to copyright blurb of touched files.
- [x] Added self to `AUTHORS.rst`.
- [x] Wrote tests.
- [x] Documented my changes in `docs/man/` or elsewhere.
- [x] My changes do not contradict
      [the current specification](https://reuse.software/spec/).
- [x] I agree to license my contribution under the licenses indicated in the
      changed files.
