### PR TITLE
feat: lint-file subcommand

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,10 +3,18 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - id: reuse
-  name: reuse
+  name: reuse lint
   entry: reuse
-  args: ["lint", "lint-file"]
+  args: ["lint"]
   language: python
   pass_filenames: false
   description:
-    "Lint the project directory for compliance with the REUSE Specification"
+    "Lint the project directory for compliance with the REUSE Specification."
+
+- id: reuse-lint-file
+  name: reuse lint-file
+  entry: reuse
+  args: ["lint-file"]
+  language: python
+  description:
+    "Lint the changed files for compliance with the REUSE Specification."

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,7 +5,7 @@
 - id: reuse
   name: reuse
   entry: reuse
-  args: ["lint"]
+  args: ["lint", "lint-file"]
   language: python
   pass_filenames: false
   description:

--- a/.pylintrc
+++ b/.pylintrc
@@ -11,7 +11,8 @@ jobs=0
 
 disable=duplicate-code,
          logging-fstring-interpolation,
-         implicit-str-concat
+         implicit-str-concat,
+         inconsistent-quotes
 enable=useless-suppression
 
 [REPORTS]

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -120,6 +120,7 @@ Contributors
 - Jon Burdo <jon@jonburdo.com>
 - Josef Andersson <josef.andersson@gmail.com>
 - José Vieira <jvieira33@sapo.pt>
+- Kerry McAdams <github@klmcadams>
 - Kevin Meagher <11620178+kjmeagher@users.noreply.github.com>
 - Lars Francke <lars.francke@stackable.de>
 - Libor Pechacek <lpechacek@gmx.com>
@@ -139,6 +140,7 @@ Contributors
 - Romain Tartière <romain@blogreen.org>
 - Ryan Schmidt <git@ryandesign.com>
 - Sebastian Crane <seabass@fsfe.org>
+- Sebastien Morais <github@SMoraisAnsys>
 - T. E. Kalaycı <tekrei@tutanota.com>
 - Vishesh Handa <me@vhanda.in>
 - Vlad-Stefan Harbuz <vlad@vladh.net>

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Git. This uses [pre-commit](https://pre-commit.com/). Once you
 ```yaml
 repos:
   - repo: https://github.com/fsfe/reuse-tool
-    rev: v3.0.2
+    rev: v4.0.3
     hooks:
       - id: reuse
 ```
@@ -255,6 +255,17 @@ repos:
 Then run `pre-commit install`. Now, every time you commit, `reuse lint` is run
 in the background, and will prevent your commit from going through if there was
 an error.
+
+If you instead want to only lint files that were changed in your commit, you can
+use the following configuration:
+
+```yaml
+repos:
+  - repo: https://github.com/fsfe/reuse-tool
+    rev: v4.0.3
+    hooks:
+      - id: reuse-lint-file
+```
 
 ## Maintainers
 

--- a/changelog.d/added/lint-file.md
+++ b/changelog.d/added/lint-file.md
@@ -1,0 +1,1 @@
+- Add lint-file subcommand to enable running lint on specific files.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -116,6 +116,14 @@ man_pages = [
         1,
     ),
     (
+        "man/reuse-lint-file",
+        "reuse-lint-file",
+        "Verify whether the specified files are compliant with the REUSE"
+        " Specification",
+        "Free Software Foundation Europe",
+        1,
+    ),
+    (
         "man/reuse-spdx",
         "reuse-spdx",
         "Generate SPDX bill of materials",
@@ -130,6 +138,11 @@ man_pages = [
         1,
     ),
 ]
+manpages_url = (
+    "https://reuse.readthedocs.io/en/v{version}/man/{page}.html".format(
+        version=version, page="{page}"
+    )
+)
 
 # -- Custom ------------------------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,7 +31,7 @@ try:
     # The full version, including alpha/beta/rc tags.
     release = get_version("reuse")
 except PackageNotFoundError:
-    release = "3.0.2"
+    release = "4.0.3"
 
 # The short X.Y.Z version.
 version = ".".join(release.split(".")[:3])

--- a/docs/man/reuse-lint-file.rst
+++ b/docs/man/reuse-lint-file.rst
@@ -1,0 +1,105 @@
+..
+  SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V. <https://fsfe.org>
+  SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+
+  SPDX-License-Identifier: CC-BY-SA-4.0
+
+reuse-lint-file
+================
+
+Synopsis
+--------
+
+**reuse lint-file** [*options*]
+
+Description
+-----------
+
+:program:`reuse-lint-file` verifies whether a file in a project is compliant with the REUSE
+Specification located at `<https://reuse.software/spec>`_.
+
+Criteria
+--------
+
+These are the criteria that the linter checks against.
+
+Bad licenses
+~~~~~~~~~~~~
+
+Licenses that are found in ``LICENSES/`` that are not found in the SPDX License
+List or do not start with ``LicenseRef-`` are bad licenses.
+
+Deprecated licenses
+~~~~~~~~~~~~~~~~~~~
+
+Licenses whose SPDX License Identifier has been deprecated by SPDX.
+
+Licenses without file extension
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+These are licenses whose file names are a valid SPDX License Identifier, but
+which do not have a file extension.
+
+Missing licenses
+~~~~~~~~~~~~~~~~
+
+A license which is referred to in a comment header, but which is not found in
+the ``LICENSES/`` directory.
+
+Unused licenses
+~~~~~~~~~~~~~~~
+
+A license found in the ``LICENSES/`` directory, but which is not referred to in
+any comment header.
+
+Read errors
+~~~~~~~~~~~
+
+Not technically a criterion, but files that cannot be read by the operating
+system are read errors, and need to be fixed.
+
+Files without copyright and license information
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Every file needs to have copyright and licensing information associated with it.
+The REUSE Specification details several ways of doing it. By and large, these
+are the methods:
+
+- Placing tags in the header of the file.
+- Placing tags in a ``.license`` file adjacent to the file.
+- Putting the information in the ``REUSE.toml`` file.
+- Putting the information in the ``.reuse/dep5`` file. (Deprecated)
+
+If a file is found that does not have copyright and/or license information
+associated with it, then the project is not compliant.
+
+Options
+-------
+
+.. option:: <file>
+
+  File(s) that are linted. For example, ``reuse lint-file src/reuse/lint_file.py src/reuse/download.py``.
+
+.. option:: -q, --quiet
+
+  Do not print anything to STDOUT.
+
+..
+  TODO: specify the JSON output.
+
+.. option:: -j, --json
+
+  Output the results of the lint as JSON.
+
+.. option:: -p, --plain
+
+  Output the results of the lint as descriptive text. The text is valid
+  Markdown.
+
+.. option:: -l, --lines
+
+  Output one line per error, prefixed by the file path.
+
+.. option:: -h, --help
+
+  Display help and exit.

--- a/docs/man/reuse-lint-file.rst
+++ b/docs/man/reuse-lint-file.rst
@@ -5,100 +5,45 @@
   SPDX-License-Identifier: CC-BY-SA-4.0
 
 reuse-lint-file
-================
+===============
 
 Synopsis
 --------
 
-**reuse lint-file** [*options*]
+**reuse lint-file** [*options*] [*file* ...]
 
 Description
 -----------
 
-:program:`reuse-lint-file` verifies whether a file in a project is compliant with the REUSE
-Specification located at `<https://reuse.software/spec>`_.
+:program:`reuse-lint-file` verifies whether the specified files are compliant
+with the REUSE Specification located at `<https://reuse.software/spec>`_. It
+runs the linter from :manpage:`reuse-lint(1)` against a subset of files, using a
+subset of criteria.
+
+Files that are ignored by :program:`reuse-lint` are also ignored by
+:program:`reuse-lint-file`, even if specified.
 
 Criteria
 --------
 
-These are the criteria that the linter checks against.
+The criteria are the same as used in :manpage:`reuse-lint(1)`, but using only a
+subset:
 
-Bad licenses
-~~~~~~~~~~~~
-
-Licenses that are found in ``LICENSES/`` that are not found in the SPDX License
-List or do not start with ``LicenseRef-`` are bad licenses.
-
-Deprecated licenses
-~~~~~~~~~~~~~~~~~~~
-
-Licenses whose SPDX License Identifier has been deprecated by SPDX.
-
-Licenses without file extension
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-These are licenses whose file names are a valid SPDX License Identifier, but
-which do not have a file extension.
-
-Missing licenses
-~~~~~~~~~~~~~~~~
-
-A license which is referred to in a comment header, but which is not found in
-the ``LICENSES/`` directory.
-
-Unused licenses
-~~~~~~~~~~~~~~~
-
-A license found in the ``LICENSES/`` directory, but which is not referred to in
-any comment header.
-
-Read errors
-~~~~~~~~~~~
-
-Not technically a criterion, but files that cannot be read by the operating
-system are read errors, and need to be fixed.
-
-Files without copyright and license information
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Every file needs to have copyright and licensing information associated with it.
-The REUSE Specification details several ways of doing it. By and large, these
-are the methods:
-
-- Placing tags in the header of the file.
-- Placing tags in a ``.license`` file adjacent to the file.
-- Putting the information in the ``REUSE.toml`` file.
-- Putting the information in the ``.reuse/dep5`` file. (Deprecated)
-
-If a file is found that does not have copyright and/or license information
-associated with it, then the project is not compliant.
+- Missing licenses.
+- Read errors.
+- Files without copyright and license information.
 
 Options
 -------
-
-.. option:: <file>
-
-  File(s) that are linted. For example, ``reuse lint-file src/reuse/lint_file.py src/reuse/download.py``.
 
 .. option:: -q, --quiet
 
   Do not print anything to STDOUT.
 
-..
-  TODO: specify the JSON output.
-
-.. option:: -j, --json
-
-  Output the results of the lint as JSON.
-
-.. option:: -p, --plain
-
-  Output the results of the lint as descriptive text. The text is valid
-  Markdown.
-
 .. option:: -l, --lines
 
-  Output one line per error, prefixed by the file path.
+  Output one line per error, prefixed by the file path. This option is the
+  default.
 
 .. option:: -h, --help
 

--- a/docs/man/reuse-lint.rst
+++ b/docs/man/reuse-lint.rst
@@ -90,7 +90,7 @@ Options
 .. option:: -p, --plain
 
   Output the results of the lint as descriptive text. The text is valid
-  Markdown.
+  Markdown. This option is the default.
 
 .. option:: -l, --lines
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,12 @@ push = false
 "src/reuse/__init__.py" = [
     '__version__ = "{pep440_version}"$',
 ]
+"docs/conf.py" = [
+    'release = "{pep440_version}"$',
+]
+"README.md" = [
+    'rev: {version}$',
+]
 
 [tool.protokolo]
 changelog = "CHANGELOG.md"

--- a/src/reuse/_lint_file.py
+++ b/src/reuse/_lint_file.py
@@ -12,7 +12,7 @@ from gettext import gettext as _
 from pathlib import Path
 from typing import IO
 
-from ._util import PathType
+from ._util import PathType, is_relative_to
 from .lint import format_lines_subset
 from .project import Project
 from .report import ProjectSubsetReport
@@ -37,7 +37,7 @@ def run(args: Namespace, project: Project, out: IO[str] = sys.stdout) -> int:
     """List all non-compliant files from specified file list."""
     subset_files = {Path(file_) for file_ in args.files}
     for file_ in subset_files:
-        if not file_.resolve().is_relative_to(project.root.resolve()):
+        if not is_relative_to(file_.resolve(), project.root.resolve()):
             args.parser.error(
                 _("'{file}' is not inside of '{root}'").format(
                     file=file_, root=project.root

--- a/src/reuse/_lint_file.py
+++ b/src/reuse/_lint_file.py
@@ -30,7 +30,13 @@ def add_arguments(parser: ArgumentParser) -> None:
         action="store_true",
         help=_("formats output as errors per line (default)"),
     )
-    parser.add_argument("files", action="store", nargs="*", type=PathType("r"))
+    parser.add_argument(
+        "files",
+        action="store",
+        nargs="*",
+        type=PathType("r"),
+        help=_("files to lint"),
+    )
 
 
 def run(args: Namespace, project: Project, out: IO[str] = sys.stdout) -> int:

--- a/src/reuse/_main.py
+++ b/src/reuse/_main.py
@@ -21,10 +21,10 @@ from . import (
     __REUSE_version__,
     __version__,
     _annotate,
+    _lint_file,
     convert_dep5,
     download,
     lint,
-    lint_file,
     spdx,
     supported_licenses,
 )
@@ -178,8 +178,8 @@ def parser() -> argparse.ArgumentParser:
     add_command(
         subparsers,
         "lint-file",
-        lint_file.add_arguments,
-        lint_file.run,
+        _lint_file.add_arguments,
+        _lint_file.run,
         help=_("list non-compliant files from specified list of files"),
     )
 

--- a/src/reuse/_main.py
+++ b/src/reuse/_main.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2022 Florian Snow <florian@familysnow.net>
 # SPDX-FileCopyrightText: 2024 Carmen Bianca BAKKER <carmenbianca@fsfe.org>
 # SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
+# SPDX-FileCopyrightText: 2024 Kerry McAdams <https://github.com/klmcadams>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/reuse/_main.py
+++ b/src/reuse/_main.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: 2022 Florian Snow <florian@familysnow.net>
 # SPDX-FileCopyrightText: 2024 Carmen Bianca BAKKER <carmenbianca@fsfe.org>
 # SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
-# SPDX-FileCopyrightText: 2024 Kerry McAdams <https://github.com/klmcadams>
+# SPDX-FileCopyrightText: 2024 Kerry McAdams <github@klmcadams>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/reuse/_main.py
+++ b/src/reuse/_main.py
@@ -23,6 +23,7 @@ from . import (
     convert_dep5,
     download,
     lint,
+    lint_file,
     spdx,
     supported_licenses,
 )
@@ -171,6 +172,14 @@ def parser() -> argparse.ArgumentParser:
                 " information?"
             ).format(reuse_version=__REUSE_version__)
         ),
+    )
+
+    add_command(
+        subparsers,
+        "lint-file",
+        lint_file.add_arguments,
+        lint_file.run,
+        help=_("list non-compliant files from specified list of files"),
     )
 
     add_command(

--- a/src/reuse/_util.py
+++ b/src/reuse/_util.py
@@ -14,7 +14,7 @@
 
 """Misc. utilities for reuse."""
 
-
+import contextlib
 import logging
 import os
 import re
@@ -29,7 +29,7 @@ from hashlib import sha1
 from inspect import cleandoc
 from itertools import chain
 from os import PathLike
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import (
     IO,
     Any,
@@ -663,6 +663,15 @@ def detect_line_endings(text: str) -> str:
 def cleandoc_nl(text: str) -> str:
     """Like :func:`inspect.cleandoc`, but with a newline at the end."""
     return cleandoc(text) + "\n"
+
+
+def is_relative_to(path: PurePath, target: PurePath) -> bool:
+    """Like Path.is_relative_to, but working for Python <3.9."""
+    # TODO: When Python 3.8 is dropped, remove this function.
+    with contextlib.suppress(ValueError):
+        path.relative_to(target)
+        return True
+    return False
 
 
 # REUSE-IgnoreEnd

--- a/src/reuse/global_licensing.py
+++ b/src/reuse/global_licensing.py
@@ -6,7 +6,6 @@
 
 # mypy: disable-error-code=attr-defined
 
-import contextlib
 import logging
 import re
 from abc import ABC, abstractmethod
@@ -40,7 +39,7 @@ from debian.copyright import Error as DebianError
 from license_expression import ExpressionError
 
 from . import ReuseInfo, SourceType
-from ._util import _LICENSING, StrPath
+from ._util import _LICENSING, StrPath, is_relative_to
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -555,9 +554,7 @@ class NestedReuseTOML(GlobalLicensing):
         found = []
         for toml in self.reuse_tomls:
             # TODO: When Python 3.8 is dropped, use is_relative_to instead.
-            with contextlib.suppress(ValueError):
-                PurePath(path).relative_to(toml.directory)
-                # No error.
+            if is_relative_to(PurePath(path), toml.directory):
                 found.append(toml)
         # Sort from topmost to deepest directory.
         found.sort(key=lambda toml: toml.directory.parts)

--- a/src/reuse/lint_file.py
+++ b/src/reuse/lint_file.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2024 Kerry McAdams <https://github.com/klmcadams>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Linting specific files happens here. The linting here is nothing more than 
+reading the reports and printing some conclusions.
+"""
+
+import sys
+from argparse import ArgumentParser, Namespace
+from gettext import gettext as _
+from typing import IO
+
+from .lint import format_json, format_lines, format_plain
+from .project import Project
+from .report import ProjectReport
+
+
+def add_arguments(parser: ArgumentParser) -> None:
+    """Add arguments to parser."""
+    mutex_group = parser.add_mutually_exclusive_group()
+    mutex_group.add_argument(
+        "-q", "--quiet", action="store_true", help=_("prevents output")
+    )
+    mutex_group.add_argument(
+        "-j", "--json", action="store_true", help=_("formats output as JSON")
+    )
+    mutex_group.add_argument(
+        "-p",
+        "--plain",
+        action="store_true",
+        help=_("formats output as plain text"),
+    )
+    mutex_group.add_argument(
+        "-l",
+        "--lines",
+        action="store_true",
+        help=_("formats output as errors per line"),
+    )
+    parser.add_argument("files", nargs="*")
+
+
+def run(args: Namespace, project: Project, out: IO[str] = sys.stdout) -> int:
+    """List all non-compliant files from specified file list."""
+    report = ProjectReport.generate(
+        project,
+        do_checksum=False,
+        file_list=args.files,
+        multiprocessing=not args.no_multiprocessing,
+    )
+
+    if args.quiet:
+        pass
+    elif args.json:
+        out.write(format_json(report))
+    elif args.lines:
+        out.write(format_lines(report))
+    else:
+        out.write(format_plain(report))
+
+    return 0 if report.is_compliant else 1

--- a/src/reuse/lint_file.py
+++ b/src/reuse/lint_file.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Kerry McAdams <https://github.com/klmcadams>
+# SPDX-FileCopyrightText: 2024 Kerry McAdams <github@klmcadams>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/reuse/project.py
+++ b/src/reuse/project.py
@@ -45,6 +45,7 @@ from ._util import (
     _LICENSEREF_PATTERN,
     StrPath,
     _determine_license_path,
+    is_relative_to,
     relative_from_root,
     reuse_info_of_file,
 )
@@ -191,7 +192,7 @@ class Project:
             for dir_ in list(dirs):
                 the_dir = root / dir_
                 if subset_files is not None and not any(
-                    file_.is_relative_to(the_dir.resolve())
+                    is_relative_to(file_, the_dir.resolve())
                     for file_ in subset_files
                 ):
                     continue

--- a/src/reuse/project.py
+++ b/src/reuse/project.py
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: 2023 Carmen Bianca BAKKER <carmenbianca@fsfe.org>
 # SPDX-FileCopyrightText: 2023 Matthias Riße
 # SPDX-FileCopyrightText: 2023 DB Systel GmbH
+# SPDX-FileCopyrightText: 2024 Kerry McAdams <https://github.com/klmcadams>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -172,24 +173,25 @@ class Project:
             directory = self.root
         directory = Path(directory)
 
-        # Filter files.
-        for file_ in files:
-            the_file = directory / file_
-            if self._is_path_ignored(the_file):
-                _LOGGER.debug("ignoring '%s'", the_file)
-                continue
-            if the_file.is_symlink():
-                _LOGGER.debug("skipping symlink '%s'", the_file)
-                continue
-            # Suppressing this error because I simply don't want to deal
-            # with that here.
-            with contextlib.suppress(OSError):
-                if the_file.stat().st_size == 0:
-                    _LOGGER.debug("skipping 0-sized file '%s'", the_file)
+        if files is not None:
+            # Filter files.
+            for file_ in files:
+                the_file = directory / file_
+                if self._is_path_ignored(the_file):
+                    _LOGGER.debug("ignoring '%s'", the_file)
                     continue
+                if the_file.is_symlink():
+                    _LOGGER.debug("skipping symlink '%s'", the_file)
+                    continue
+                # Suppressing this error because I simply don't want to deal
+                # with that here.
+                with contextlib.suppress(OSError):
+                    if the_file.stat().st_size == 0:
+                        _LOGGER.debug("skipping 0-sized file '%s'", the_file)
+                        continue
 
-            _LOGGER.debug("yielding '%s'", the_file)
-            yield the_file
+                _LOGGER.debug("yielding '%s'", the_file)
+                yield the_file
 
     def all_files(self, directory: Optional[StrPath] = None) -> Iterator[Path]:
         """Yield all files in *directory* and its subdirectories.

--- a/src/reuse/project.py
+++ b/src/reuse/project.py
@@ -3,7 +3,7 @@
 # SPDX-FileCopyrightText: 2023 Carmen Bianca BAKKER <carmenbianca@fsfe.org>
 # SPDX-FileCopyrightText: 2023 Matthias Riße
 # SPDX-FileCopyrightText: 2023 DB Systel GmbH
-# SPDX-FileCopyrightText: 2024 Kerry McAdams <https://github.com/klmcadams>
+# SPDX-FileCopyrightText: 2024 Kerry McAdams <github@klmcadams>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/reuse/report.py
+++ b/src/reuse/report.py
@@ -21,7 +21,17 @@ from hashlib import md5
 from io import StringIO
 from os import cpu_count
 from pathlib import Path, PurePath
-from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Set, cast
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    List,
+    NamedTuple,
+    Optional,
+    Set,
+    Union,
+    cast,
+)
 from uuid import uuid4
 
 from . import __REUSE_version__, __version__
@@ -284,7 +294,7 @@ class ProjectReport:  # pylint: disable=too-many-instance-attributes
         file_list: Optional[List[str]] = None,
         multiprocessing: bool = cpu_count() > 1,  # type: ignore
         add_license_concluded: bool = False,
-    ) -> list | Iterable[_MultiprocessingResult]:
+    ) -> Union[list, Iterable[_MultiprocessingResult]]:
         """Get lint results based on multiprocessing and file_list."""
         container = _MultiprocessingContainer(
             project, do_checksum, add_license_concluded

--- a/src/reuse/report.py
+++ b/src/reuse/report.py
@@ -3,8 +3,8 @@
 # SPDX-FileCopyrightText: 2022 Pietro Albini <pietro.albini@ferrous-systems.com>
 # SPDX-FileCopyrightText: 2023 DB Systel GmbH
 # SPDX-FileCopyrightText: 2023 Carmen Bianca BAKKER <carmenbianca@fsfe.org>
-# SPDX-FileCopyrightText: 2024 Kerry McAdams <https://github.com/klmcadams>
-# SPDX-FileCopyrightText: 2024 Sebastien Morais <https://github.com/SMoraisAnsys>
+# SPDX-FileCopyrightText: 2024 Kerry McAdams <github@klmcadams>
+# SPDX-FileCopyrightText: 2024 Sebastien Morais <github@SMoraisAnsys>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/reuse/report.py
+++ b/src/reuse/report.py
@@ -103,7 +103,7 @@ class _MultiprocessingResult(NamedTuple):
 class ProjectReport:  # pylint: disable=too-many-instance-attributes
     """Object that holds linting report about the project."""
 
-    def __init__(self, do_checksum: bool = True, file_list: list = list[Any]):
+    def __init__(self, do_checksum: bool = True, file_list: list[Any] = None):
         self.path: StrPath = ""
         self.licenses: Dict[str, Path] = {}
         self.missing_licenses: Dict[str, Set[Path]] = {}
@@ -277,7 +277,7 @@ class ProjectReport:  # pylint: disable=too-many-instance-attributes
         cls,
         project: Project,
         do_checksum: bool = True,
-        file_list: list = list[Any],
+        file_list: list[Any] = None,
         multiprocessing: bool = cpu_count() > 1,  # type: ignore
         add_license_concluded: bool = False,
     ) -> "ProjectReport":

--- a/src/reuse/report.py
+++ b/src/reuse/report.py
@@ -3,6 +3,8 @@
 # SPDX-FileCopyrightText: 2022 Pietro Albini <pietro.albini@ferrous-systems.com>
 # SPDX-FileCopyrightText: 2023 DB Systel GmbH
 # SPDX-FileCopyrightText: 2023 Carmen Bianca BAKKER <carmenbianca@fsfe.org>
+# SPDX-FileCopyrightText: 2024 Kerry McAdams <https://github.com/klmcadams>
+# SPDX-FileCopyrightText: 2024 Sebastien Morais <https://github.com/SMoraisAnsys>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -103,7 +105,9 @@ class _MultiprocessingResult(NamedTuple):
 class ProjectReport:  # pylint: disable=too-many-instance-attributes
     """Object that holds linting report about the project."""
 
-    def __init__(self, do_checksum: bool = True, file_list: Optional[List[str]] = None):
+    def __init__(
+        self, do_checksum: bool = True, file_list: Optional[List[str]] = None
+    ):
         self.path: StrPath = ""
         self.licenses: Dict[str, Path] = {}
         self.missing_licenses: Dict[str, Set[Path]] = {}
@@ -295,7 +299,11 @@ class ProjectReport:  # pylint: disable=too-many-instance-attributes
 
         # Iterate over specific file list if files are provided with
         # `reuse lint-file`. Otherwise, lint all files.
-        iter_files = project.specific_files(file_list) if file_list else project.all_files()
+        iter_files = (
+            project.specific_files(file_list)
+            if file_list
+            else project.all_files()
+        )
         if multiprocessing:
             with mp.Pool() as pool:
                 results: Iterable[_MultiprocessingResult] = pool.map(
@@ -303,7 +311,7 @@ class ProjectReport:  # pylint: disable=too-many-instance-attributes
                 )
             pool.join()
         else:
-            results = (map(container, iter_files))
+            results = map(container, iter_files)
 
         for result in results:
             if result.error:

--- a/src/reuse/report.py
+++ b/src/reuse/report.py
@@ -293,20 +293,17 @@ class ProjectReport:  # pylint: disable=too-many-instance-attributes
             project, do_checksum, add_license_concluded
         )
 
+        # Iterate over specific file list if files are provided with
+        # `reuse lint-file`. Otherwise, lint all files.
+        iter_files = project.specific_files(file_list) if file_list else project.all_files()
         if multiprocessing:
             with mp.Pool() as pool:
                 results: Iterable[_MultiprocessingResult] = pool.map(
-                    container, project.all_files()
+                    container, iter_files
                 )
             pool.join()
         else:
-            # Search specific file list if files are provided with
-            # `reuse lint-file`. Otherwise, lint all files
-            results = (
-                map(container, project.specific_files(file_list))
-                if file_list
-                else map(container, project.all_files())
-            )
+            results = (map(container, iter_files))
 
         for result in results:
             if result.error:

--- a/src/reuse/report.py
+++ b/src/reuse/report.py
@@ -103,7 +103,7 @@ class _MultiprocessingResult(NamedTuple):
 class ProjectReport:  # pylint: disable=too-many-instance-attributes
     """Object that holds linting report about the project."""
 
-    def __init__(self, do_checksum: bool = True, file_list: list[Any] = None):
+    def __init__(self, do_checksum: bool = True, file_list: Optional[List[str]] = None):
         self.path: StrPath = ""
         self.licenses: Dict[str, Path] = {}
         self.missing_licenses: Dict[str, Set[Path]] = {}
@@ -277,7 +277,7 @@ class ProjectReport:  # pylint: disable=too-many-instance-attributes
         cls,
         project: Project,
         do_checksum: bool = True,
-        file_list: list[Any] = None,
+        file_list: Optional[List[str]] = None,
         multiprocessing: bool = cpu_count() > 1,  # type: ignore
         add_license_concluded: bool = False,
     ) -> "ProjectReport":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -167,25 +167,6 @@ def fake_repository(tmpdir_factory) -> Path:
     # Get rid of those pesky pyc files.
     shutil.rmtree(directory / "src/__pycache__", ignore_errors=True)
 
-    # Adding this here to avoid conflict in main project.
-    (directory / "src/exception.py").write_text(
-        "SPDX-FileCopyrightText: 2017 Jane Doe\n"
-        "SPDX-License-Identifier: GPL-3.0-or-later WITH Autoconf-exception-3.0",
-        encoding="utf-8",
-    )
-    (directory / "src/custom.py").write_text(
-        "SPDX-FileCopyrightText: 2017 Jane Doe\n"
-        "SPDX-License-Identifier: LicenseRef-custom",
-        encoding="utf-8",
-    )
-    (directory / "src/multiple_licenses.rs").write_text(
-        "SPDX-FileCopyrightText: 2022 Jane Doe\n"
-        "SPDX-License-Identifier: GPL-3.0-or-later\n"
-        "SPDX-License-Identifier: Apache-2.0 OR CC0-1.0"
-        " WITH Autoconf-exception-3.0\n",
-        encoding="utf-8",
-    )
-
     os.chdir(directory)
     return directory
 

--- a/tests/resources/fake_repository/src/custom.py
+++ b/tests/resources/fake_repository/src/custom.py
@@ -1,1 +1,3 @@
-# This file is overridden by the fake_repository fixture.
+# SPDX-FileCopyrightText: 2017 Jane Doe
+#
+# SPDX-License-Identifier: LicenseRef-custom

--- a/tests/resources/fake_repository/src/exception.py
+++ b/tests/resources/fake_repository/src/exception.py
@@ -1,1 +1,3 @@
-# This file is overridden by the fake_repository fixture.
+# SPDX-FileCopyrightText: 2017 Jane Doe
+#
+# SPDX-License-Identifier: GPL-3.0-or-later WITH Autoconf-exception-3.0

--- a/tests/resources/fake_repository/src/multiple_licenses.rs
+++ b/tests/resources/fake_repository/src/multiple_licenses.rs
@@ -1,1 +1,3 @@
-// This file is overridden by the fake_repository fixture.
+// SPDX-FileCopyrightText: 2022 Jane Doe
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: Apache-2.0 OR CC0-1.0 WITH Autoconf-exception-3.0

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-"""All tests for reuse.lint and reuse.lint_files"""
+"""All tests for reuse.lint."""
 
 import re
 import shutil
@@ -269,20 +269,6 @@ def test_lint_lines_read_errors(fake_repository):
     assert len(result.splitlines()) == 1
     assert "restricted.py" in result
     assert "read error" in result
-
-
-def test_lint_specific_files(fake_repository):
-    """Check lint-file subcommand."""
-    (fake_repository / "foo.py").write_text("foo")
-    (fake_repository / "bar.py").write_text("bar")
-
-    project = Project.from_directory(fake_repository)
-    report = ProjectReport.generate(project, file_list=["foo.py"])
-    result = format_plain(report)
-
-    assert ":-(" in result
-    assert "# UNUSED LICENSES" in result
-    assert "bar.py" not in result
 
 
 # REUSE-IgnoreEnd

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -1,6 +1,6 @@
-# SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V. <https://fsfe.org>
 # SPDX-FileCopyrightText: 2022 Florian Snow <florian@familysnow.net>
 # SPDX-FileCopyrightText: 2024 Nico Rikken <nico@nicorikken.eu>
+# SPDX-FileCopyrightText: 2024 Sebastien Morais <https://github.com/SMoraisAnsys>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -270,11 +270,12 @@ def test_lint_lines_read_errors(fake_repository):
     assert "restricted.py" in result
     assert "read error" in result
 
+
 def test_lint_specific_files(fake_repository):
     """Check lint-file subcommand."""
     (fake_repository / "foo.py").write_text("foo")
     (fake_repository / "bar.py").write_text("bar")
-    
+
     project = Project.from_directory(fake_repository)
     report = ProjectReport.generate(project, file_list=["foo.py"])
     result = format_plain(report)

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -270,5 +270,18 @@ def test_lint_lines_read_errors(fake_repository):
     assert "restricted.py" in result
     assert "read error" in result
 
+def test_lint_specific_files(fake_repository):
+    """Check lint-file subcommand."""
+    (fake_repository / "foo.py").write_text("foo")
+    (fake_repository / "bar.py").write_text("bar")
+    
+    project = Project.from_directory(fake_repository)
+    report = ProjectReport.generate(project, file_list=["foo.py"])
+    result = format_plain(report)
+
+    assert ":-(" in result
+    assert "# UNUSED LICENSES" in result
+    assert "bar.py" not in result
+
 
 # REUSE-IgnoreEnd

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -1,10 +1,10 @@
 # SPDX-FileCopyrightText: 2022 Florian Snow <florian@familysnow.net>
 # SPDX-FileCopyrightText: 2024 Nico Rikken <nico@nicorikken.eu>
-# SPDX-FileCopyrightText: 2024 Sebastien Morais <https://github.com/SMoraisAnsys>
+# SPDX-FileCopyrightText: 2024 Sebastien Morais <github@SMoraisAnsys>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-"""All tests for reuse.lint"""
+"""All tests for reuse.lint and reuse.lint_files"""
 
 import re
 import shutil

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -391,8 +391,8 @@ class TestLintFile:
     def test_path_outside_project(self, empty_directory, capsys):
         """A file can't be outside the project."""
         with pytest.raises(SystemExit):
-            main(["lint-file", "/"])
-        assert "'/' is not in" in capsys.readouterr().err
+            main(["lint-file", ".."])
+        assert "'..' is not in" in capsys.readouterr().err
 
     def test_file_not_exists(self, empty_directory, capsys):
         """A file must exist."""

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -367,6 +367,54 @@ def test_lint_no_multiprocessing(fake_repository, stringio, multiprocessing):
     assert ":-)" in stringio.getvalue()
 
 
+class TestLintFile:
+    """Tests for lint-file."""
+
+    def test_simple(self, fake_repository, stringio):
+        """A simple test to make sure it works."""
+        result = main(["lint-file", "src/custom.py"], out=stringio)
+        assert result == 0
+        assert not stringio.getvalue()
+
+    def test_no_copyright_licensing(self, fake_repository, stringio):
+        """A file is correctly spotted when it has no copyright or licensing
+        info.
+        """
+        (fake_repository / "foo.py").write_text("foo")
+        result = main(["lint-file", "foo.py"], out=stringio)
+        assert result == 1
+        output = stringio.getvalue()
+        assert "foo.py" in output
+        assert "no license identifier" in output
+        assert "no copyright notice" in output
+
+    def test_path_outside_project(self, empty_directory, capsys):
+        """A file can't be outside the project."""
+        with pytest.raises(SystemExit):
+            main(["lint-file", "/"])
+        assert "'/' is not in" in capsys.readouterr().err
+
+    def test_file_not_exists(self, empty_directory, capsys):
+        """A file must exist."""
+        with pytest.raises(SystemExit):
+            main(["lint-file", "foo.py"])
+        assert "can't open 'foo.py'" in capsys.readouterr().err
+
+    def test_ignored_file(self, fake_repository, stringio):
+        """A corner case where a specified file is ignored. It isn't checked at
+        all.
+        """
+        (fake_repository / "COPYING").write_text("foo")
+        result = main(["lint-file", "COPYING"], out=stringio)
+        assert result == 0
+
+    def test_file_covered_by_toml(self, fake_repository_reuse_toml, stringio):
+        """If a file is covered by REUSE.toml, use its infos."""
+        (fake_repository_reuse_toml / "doc/foo.md").write_text("foo")
+        result = main(["lint-file", "doc/foo.md"], out=stringio)
+        assert result == 0
+
+
 @freeze_time("2024-04-08T17:34:00Z")
 def test_spdx(fake_repository, stringio):
     """Compile to an SPDX document."""

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -321,7 +321,7 @@ class TestSubsetFiles:
     def test_two(self, fake_repository):
         """Yield multiple specified files."""
         project = Project.from_directory(fake_repository)
-        result = list(
+        result = set(
             project.subset_files(
                 {
                     fake_repository / "src/custom.py",
@@ -329,10 +329,10 @@ class TestSubsetFiles:
                 }
             )
         )
-        assert result == [
+        assert result == {
             fake_repository / "src/custom.py",
             fake_repository / "src/exception.py",
-        ]
+        }
 
     def test_non_existent(self, fake_repository):
         """If a file does not exist, don't yield it."""

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -260,213 +260,222 @@ def test_generate_file_report_to_dict_lint_source_information(
             assert expression["value"] == "MIT OR 0BSD"
 
 
-def test_generate_project_report_simple(fake_repository, multiprocessing):
-    """Simple generate test, just to see if it sort of works."""
-    project = Project.from_directory(fake_repository)
-    result = ProjectReport.generate(project, multiprocessing=multiprocessing)
+class TestGenerateProjectReport:
+    """Tests for ProjectReport.generate."""
 
-    assert not result.bad_licenses
-    assert not result.licenses_without_extension
-    assert not result.missing_licenses
-    assert not result.unused_licenses
-    assert result.used_licenses
-    assert not result.read_errors
-    assert result.file_reports
-
-
-def test_generate_project_report_licenses_without_extension(
-    fake_repository, multiprocessing
-):
-    """Licenses without extension are detected."""
-    (fake_repository / "LICENSES/CC0-1.0.txt").rename(
-        fake_repository / "LICENSES/CC0-1.0"
-    )
-
-    project = Project.from_directory(fake_repository)
-    result = ProjectReport.generate(project, multiprocessing=multiprocessing)
-
-    assert "CC0-1.0" in result.licenses_without_extension
-
-
-def test_generate_project_report_missing_license(
-    fake_repository, multiprocessing
-):
-    """Missing licenses are detected."""
-    (fake_repository / "LICENSES/GPL-3.0-or-later.txt").unlink()
-
-    project = Project.from_directory(fake_repository)
-    result = ProjectReport.generate(project, multiprocessing=multiprocessing)
-
-    assert "GPL-3.0-or-later" in result.missing_licenses
-    assert not result.bad_licenses
-
-
-def test_generate_project_report_bad_license(fake_repository, multiprocessing):
-    """Bad licenses are detected."""
-    (fake_repository / "LICENSES/bad.txt").write_text("foo")
-
-    project = Project.from_directory(fake_repository)
-    result = ProjectReport.generate(project, multiprocessing=multiprocessing)
-
-    assert result.bad_licenses
-    assert not result.missing_licenses
-
-
-def test_generate_project_report_unused_license(
-    fake_repository, multiprocessing
-):
-    """Unused licenses are detected."""
-    (fake_repository / "LICENSES/MIT.txt").write_text("foo")
-
-    project = Project.from_directory(fake_repository)
-    result = ProjectReport.generate(project, multiprocessing=multiprocessing)
-
-    assert result.unused_licenses == {"MIT"}
-
-
-def test_generate_project_report_unused_license_plus(
-    fake_repository, multiprocessing
-):
-    """Apache-1.0+ is not an unused license if LICENSES/Apache-1.0.txt
-    exists.
-
-    Furthermore, Apache-1.0+ is separately identified as a used license.
-    """
-    (fake_repository / "foo.py").write_text(
-        "SPDX-License-Identifier: Apache-1.0+"
-    )
-    (fake_repository / "bar.py").write_text(
-        "SPDX-License-Identifier: Apache-1.0"
-    )
-    (fake_repository / "LICENSES/Apache-1.0.txt").touch()
-
-    project = Project.from_directory(fake_repository)
-    result = ProjectReport.generate(project, multiprocessing=multiprocessing)
-
-    assert not result.unused_licenses
-    assert {"Apache-1.0", "Apache-1.0+"}.issubset(result.used_licenses)
-
-
-def test_generate_project_report_unused_license_plus_only_plus(
-    fake_repository, multiprocessing
-):
-    """If Apache-1.0+ is the only declared license in the project,
-    LICENSES/Apache-1.0.txt should not be an unused license.
-    """
-    (fake_repository / "foo.py").write_text(
-        "SPDX-License-Identifier: Apache-1.0+"
-    )
-    (fake_repository / "LICENSES/Apache-1.0.txt").touch()
-
-    project = Project.from_directory(fake_repository)
-    result = ProjectReport.generate(project, multiprocessing=multiprocessing)
-
-    assert not result.unused_licenses
-    assert "Apache-1.0+" in result.used_licenses
-    assert "Apache-1.0" not in result.used_licenses
-
-
-def test_generate_project_report_bad_license_in_file(
-    fake_repository, multiprocessing
-):
-    """Bad licenses in files are detected."""
-    (fake_repository / "foo.py").write_text("SPDX-License-Identifier: bad")
-
-    project = Project.from_directory(fake_repository)
-    result = ProjectReport.generate(project, multiprocessing=multiprocessing)
-
-    assert "bad" in result.bad_licenses
-
-
-def test_generate_project_report_bad_license_can_also_be_missing(
-    fake_repository, multiprocessing
-):
-    """Bad licenses can also be missing licenses."""
-    (fake_repository / "foo.py").write_text("SPDX-License-Identifier: bad")
-
-    project = Project.from_directory(fake_repository)
-    result = ProjectReport.generate(project, multiprocessing=multiprocessing)
-
-    assert "bad" in result.bad_licenses
-    assert "bad" in result.missing_licenses
-
-
-def test_generate_project_report_deprecated_license(
-    fake_repository, multiprocessing
-):
-    """Deprecated licenses are detected."""
-    (fake_repository / "LICENSES/GPL-3.0-or-later.txt").rename(
-        fake_repository / "LICENSES/GPL-3.0.txt"
-    )
-
-    project = Project.from_directory(fake_repository)
-    result = ProjectReport.generate(project, multiprocessing=multiprocessing)
-
-    assert "GPL-3.0" in result.deprecated_licenses
-
-
-@cpython
-@posix
-def test_generate_project_report_read_error(fake_repository, multiprocessing):
-    """Files that cannot be read are added to the read error list."""
-    (fake_repository / "bad").write_text("foo")
-    (fake_repository / "bad").chmod(0o000)
-
-    project = Project.from_directory(fake_repository)
-    result = ProjectReport.generate(project, multiprocessing=multiprocessing)
-
-    # pylint: disable=superfluous-parens
-    assert (fake_repository / "bad") in result.read_errors
-
-
-def test_generate_project_report_to_dict_lint(fake_repository, multiprocessing):
-    """Generate dictionary output and verify correct ordering."""
-    project = Project.from_directory(fake_repository)
-    report = ProjectReport.generate(project, multiprocessing=multiprocessing)
-    result = report.to_dict_lint()
-
-    # Check if the top three keys are at the beginning of the dictionary
-    assert list(result.keys())[:3] == [
-        "lint_version",
-        "reuse_spec_version",
-        "reuse_tool_version",
-    ]
-
-    # Check if the recommendation key is at the bottom of the dictionary
-    assert list(result.keys())[-1] == "recommendations"
-
-    # Check if the rest of the keys are sorted alphabetically
-    assert list(result.keys())[3:-1] == sorted(list(result.keys())[3:-1])
-
-
-def test_generate_project_partial_info_in_toml(
-    empty_directory, multiprocessing
-):
-    """Some information is in REUSE.toml, and some is inside of the file."""
-    (empty_directory / "REUSE.toml").write_text(
-        cleandoc(
-            """
-            version = 1
-
-            [[annotations]]
-            path = "foo.py"
-            precedence = "closest"
-            SPDX-FileCopyrightText = "Jane Doe"
-            # This is ignored because it's in the file!
-            SPDX-License-Identifier = "MIT"
-            """
+    def test_simple(self, fake_repository, multiprocessing):
+        """Simple generate test, just to see if it sort of works."""
+        project = Project.from_directory(fake_repository)
+        result = ProjectReport.generate(
+            project, multiprocessing=multiprocessing
         )
-    )
-    (empty_directory / "foo.py").write_text("# SPDX-License-Identifier: 0BSD")
-    project = Project.from_directory(empty_directory)
-    report = ProjectReport.generate(project, multiprocessing=multiprocessing)
-    file_report = next(
-        report for report in report.file_reports if report.path.name == "foo.py"
-    )
-    infos = file_report.reuse_infos
-    assert len(infos) == 2
-    assert file_report.copyright == "Jane Doe"
-    assert file_report.licenses_in_file == ["0BSD"]
+
+        assert not result.bad_licenses
+        assert not result.licenses_without_extension
+        assert not result.missing_licenses
+        assert not result.unused_licenses
+        assert result.used_licenses
+        assert not result.read_errors
+        assert result.file_reports
+
+    def test__licenses_without_extension(
+        self, fake_repository, multiprocessing
+    ):
+        """Licenses without extension are detected."""
+        (fake_repository / "LICENSES/CC0-1.0.txt").rename(
+            fake_repository / "LICENSES/CC0-1.0"
+        )
+
+        project = Project.from_directory(fake_repository)
+        result = ProjectReport.generate(
+            project, multiprocessing=multiprocessing
+        )
+
+        assert "CC0-1.0" in result.licenses_without_extension
+
+    def test_missing_license(self, fake_repository, multiprocessing):
+        """Missing licenses are detected."""
+        (fake_repository / "LICENSES/GPL-3.0-or-later.txt").unlink()
+
+        project = Project.from_directory(fake_repository)
+        result = ProjectReport.generate(
+            project, multiprocessing=multiprocessing
+        )
+
+        assert "GPL-3.0-or-later" in result.missing_licenses
+        assert not result.bad_licenses
+
+    def test_bad_license(self, fake_repository, multiprocessing):
+        """Bad licenses are detected."""
+        (fake_repository / "LICENSES/bad.txt").write_text("foo")
+
+        project = Project.from_directory(fake_repository)
+        result = ProjectReport.generate(
+            project, multiprocessing=multiprocessing
+        )
+
+        assert result.bad_licenses
+        assert not result.missing_licenses
+
+    def test_unused_license(self, fake_repository, multiprocessing):
+        """Unused licenses are detected."""
+        (fake_repository / "LICENSES/MIT.txt").write_text("foo")
+
+        project = Project.from_directory(fake_repository)
+        result = ProjectReport.generate(
+            project, multiprocessing=multiprocessing
+        )
+
+        assert result.unused_licenses == {"MIT"}
+
+    def test_unused_license_plus(self, fake_repository, multiprocessing):
+        """Apache-1.0+ is not an unused license if LICENSES/Apache-1.0.txt
+        exists.
+
+        Furthermore, Apache-1.0+ is separately identified as a used license.
+        """
+        (fake_repository / "foo.py").write_text(
+            "SPDX-License-Identifier: Apache-1.0+"
+        )
+        (fake_repository / "bar.py").write_text(
+            "SPDX-License-Identifier: Apache-1.0"
+        )
+        (fake_repository / "LICENSES/Apache-1.0.txt").touch()
+
+        project = Project.from_directory(fake_repository)
+        result = ProjectReport.generate(
+            project, multiprocessing=multiprocessing
+        )
+
+        assert not result.unused_licenses
+        assert {"Apache-1.0", "Apache-1.0+"}.issubset(result.used_licenses)
+
+    def test_unused_license_plus_only_plus(
+        self, fake_repository, multiprocessing
+    ):
+        """If Apache-1.0+ is the only declared license in the project,
+        LICENSES/Apache-1.0.txt should not be an unused license.
+        """
+        (fake_repository / "foo.py").write_text(
+            "SPDX-License-Identifier: Apache-1.0+"
+        )
+        (fake_repository / "LICENSES/Apache-1.0.txt").touch()
+
+        project = Project.from_directory(fake_repository)
+        result = ProjectReport.generate(
+            project, multiprocessing=multiprocessing
+        )
+
+        assert not result.unused_licenses
+        assert "Apache-1.0+" in result.used_licenses
+        assert "Apache-1.0" not in result.used_licenses
+
+    def test_bad_license_in_file(self, fake_repository, multiprocessing):
+        """Bad licenses in files are detected."""
+        (fake_repository / "foo.py").write_text("SPDX-License-Identifier: bad")
+
+        project = Project.from_directory(fake_repository)
+        result = ProjectReport.generate(
+            project, multiprocessing=multiprocessing
+        )
+
+        assert "bad" in result.bad_licenses
+
+    def test_bad_license_can_also_be_missing(
+        self, fake_repository, multiprocessing
+    ):
+        """Bad licenses can also be missing licenses."""
+        (fake_repository / "foo.py").write_text("SPDX-License-Identifier: bad")
+
+        project = Project.from_directory(fake_repository)
+        result = ProjectReport.generate(
+            project, multiprocessing=multiprocessing
+        )
+
+        assert "bad" in result.bad_licenses
+        assert "bad" in result.missing_licenses
+
+    def test_deprecated_license(self, fake_repository, multiprocessing):
+        """Deprecated licenses are detected."""
+        (fake_repository / "LICENSES/GPL-3.0-or-later.txt").rename(
+            fake_repository / "LICENSES/GPL-3.0.txt"
+        )
+
+        project = Project.from_directory(fake_repository)
+        result = ProjectReport.generate(
+            project, multiprocessing=multiprocessing
+        )
+
+        assert "GPL-3.0" in result.deprecated_licenses
+
+    @cpython
+    @posix
+    def test_read_error(self, fake_repository, multiprocessing):
+        """Files that cannot be read are added to the read error list."""
+        (fake_repository / "bad").write_text("foo")
+        (fake_repository / "bad").chmod(0o000)
+
+        project = Project.from_directory(fake_repository)
+        result = ProjectReport.generate(
+            project, multiprocessing=multiprocessing
+        )
+
+        # pylint: disable=superfluous-parens
+        assert (fake_repository / "bad") in result.read_errors
+
+    def test_to_dict_lint(self, fake_repository, multiprocessing):
+        """Generate dictionary output and verify correct ordering."""
+        project = Project.from_directory(fake_repository)
+        report = ProjectReport.generate(
+            project, multiprocessing=multiprocessing
+        )
+        result = report.to_dict_lint()
+
+        # Check if the top three keys are at the beginning of the dictionary
+        assert list(result.keys())[:3] == [
+            "lint_version",
+            "reuse_spec_version",
+            "reuse_tool_version",
+        ]
+
+        # Check if the recommendation key is at the bottom of the dictionary
+        assert list(result.keys())[-1] == "recommendations"
+
+        # Check if the rest of the keys are sorted alphabetically
+        assert list(result.keys())[3:-1] == sorted(list(result.keys())[3:-1])
+
+    def test_partial_info_in_toml(self, empty_directory, multiprocessing):
+        """Some information is in REUSE.toml, and some is inside of the file."""
+        (empty_directory / "REUSE.toml").write_text(
+            cleandoc(
+                """
+                version = 1
+
+                [[annotations]]
+                path = "foo.py"
+                precedence = "closest"
+                SPDX-FileCopyrightText = "Jane Doe"
+                # This is ignored because it's in the file!
+                SPDX-License-Identifier = "MIT"
+                """
+            )
+        )
+        (empty_directory / "foo.py").write_text(
+            "# SPDX-License-Identifier: 0BSD"
+        )
+        project = Project.from_directory(empty_directory)
+        report = ProjectReport.generate(
+            project, multiprocessing=multiprocessing
+        )
+        file_report = next(
+            report
+            for report in report.file_reports
+            if report.path.name == "foo.py"
+        )
+        infos = file_report.reuse_infos
+        assert len(infos) == 2
+        assert file_report.copyright == "Jane Doe"
+        assert file_report.licenses_in_file == ["0BSD"]
 
 
 def test_bill_of_materials(fake_repository, multiprocessing):


### PR DESCRIPTION
Added `lint-file` subcommand to allow people to lint specified file(s). In the command line, you can run `reuse lint-file <files>`. For example, `reuse lint-file src/reuse/download.py src/reuse/_annotate.py`. If you only run `reuse lint-file` with no files listed, then it will lint all files (as if you were just running `reuse lint`).

Let @SMoraisAnsys or I know if you have any questions or concerns! This PR addresses the suggestions in #903.

Here is a picture of running `reuse lint-file` in the command line with a file that doesn't exist (dne_file.py), two files that exist and are compliant, and one file that exists but is not compliant (empty_file.py):

![lint_files_example](https://github.com/user-attachments/assets/8bb36087-b010-443a-864a-3c970e05ddf5)

- [x] Added a change log entry in `changelog.d/<directory>/`.
- [x] Added self to copyright blurb of touched files.
- [x] Added self to `AUTHORS.rst`.
- [x] Wrote tests.
- [x] Documented my changes in `docs/man/` or elsewhere.
- [x] My changes do not contradict
      [the current specification](https://reuse.software/spec/).
- [x] I agree to license my contribution under the licenses indicated in the
      changed files.
