### PR TITLE
Fix global licensing being ignored with a .license file

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -143,3 +143,4 @@ Contributors
 - Mersho <code.rezaei@gmail.com>
 - Skyler Grey <sky@a.starrysky.fyi>
 - Emil Velikov <emil.l.velikov@gmail.com>
+- Linnea Gräf <nea@nea.moe>

--- a/changelog.d/fixed/license-overriding-global-name.md
+++ b/changelog.d/fixed/license-overriding-global-name.md
@@ -1,0 +1,2 @@
+- `REUSE.toml` `[[annotations]]` now use the correct path if a `.license` file
+  is present (#1058)

--- a/src/reuse/project.py
+++ b/src/reuse/project.py
@@ -4,6 +4,7 @@
 # SPDX-FileCopyrightText: 2023 Matthias Riße
 # SPDX-FileCopyrightText: 2023 DB Systel GmbH
 # SPDX-FileCopyrightText: 2024 Kerry McAdams <github@klmcadams>
+# SPDX-FileCopyrightText: 2024 Linnea Gräf
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -243,7 +244,7 @@ class Project:
 
         # Search the global licensing file for REUSE information.
         if self.global_licensing:
-            relpath = self.relative_from_root(path)
+            relpath = self.relative_from_root(original_path)
             global_results = defaultdict(
                 list, self.global_licensing.reuse_info_of(relpath)
             )


### PR DESCRIPTION
Fixes https://github.com/fsfe/reuse-tool/issues/1057

<!--
Before submitting a PR, please read CONTRIBUTING.md. Non-trivial changes should
be discussed in an issue before committing to a PR.

Please succinctly describe your changes.
-->

<!-- Next, let's do a check list. Remove what doesn't apply. -->

- [x] Added a change log entry in `changelog.d/<directory>/`.
- [x] Added self to copyright blurb of touched files.
- [x] Added self to `AUTHORS.rst`.
- [x] Wrote tests.
- [ ] Documented my changes in `docs/man/` or elsewhere. (n/a)
- [x] My changes do not contradict
      [the current specification](https://reuse.software/spec/).
- [x] I agree to license my contribution under the licenses indicated in the
      changed files.
