### PR TITLE
Allow Python-style comments in Cargo.lock files

### DIFF
--- a/changelog.d/changed/comment-cargo-lock.md
+++ b/changelog.d/changed/comment-cargo-lock.md
@@ -1,0 +1,1 @@
+- Allow Python-style comments in Cargo.lock files

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -875,7 +875,7 @@ FILENAME_COMMENT_STYLE_MAP = {
     ".yarnrc": PythonCommentStyle,
     "ansible.cfg": PythonCommentStyle,
     "archive.sctxar": UncommentableCommentStyle,  # SuperCollider global archive
-    "Cargo.lock": UncommentableCommentStyle,
+    "Cargo.lock": PythonCommentStyle,
     "CMakeLists.txt": PythonCommentStyle,
     "CODEOWNERS": PythonCommentStyle,
     "configure.ac": M4CommentStyle,


### PR DESCRIPTION
<!--
Before submitting a PR, please read CONTRIBUTING.md. Non-trivial changes should
be discussed in an issue before committing to a PR.

Please succinctly describe your changes.
-->

`Cargo.lock` files are TOML and allow comments. Cargo is clever and preserves these comments when it makes changes to the lock file.

<!-- Next, let's do a check list. Remove what doesn't apply. -->

- [x] Added a change log entry in `changelog.d/<directory>/`.
- [x] My changes do not contradict
      [the current specification](https://reuse.software/spec/).
- [x] I agree to license my contribution under the licenses indicated in the
      changed files.
