### PR TITLE
Add `.envrc` and `flake.lock` extensions

### DIFF
--- a/changelog.d/added/comment-flake-envrc.md
+++ b/changelog.d/added/comment-flake-envrc.md
@@ -1,0 +1,2 @@
+- Added `.envrc` (Python) and `.flake.lock` (uncommentable) as recognised file
+  types for comments. (#1061)

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -851,6 +851,7 @@ FILENAME_COMMENT_STYLE_MAP = {
     ".dockerignore": PythonCommentStyle,
     ".earthlyignore": PythonCommentStyle,
     ".editorconfig": PythonCommentStyle,
+    ".envrc": PythonCommentStyle,
     ".empty": EmptyCommentStyle,
     ".eslintignore": PythonCommentStyle,
     ".eslintrc": UncommentableCommentStyle,

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -884,6 +884,7 @@ FILENAME_COMMENT_STYLE_MAP = {
     "Dockerfile": PythonCommentStyle,
     "Doxyfile": PythonCommentStyle,
     "Earthfile": PythonCommentStyle,
+    "flake.lock": UncommentableCommentStyle,  # is a JSON file
     "Gemfile": PythonCommentStyle,
     "go.mod": CppCommentStyle,
     "go.sum": UncommentableCommentStyle,


### PR DESCRIPTION
I've added the `.envrc` (used by at least [direnv](https://direnv.net/)) and the nix flake lock file (`flake.lock`) to the recognized extensions. I've not added an entry in the changelog, as it seemed to tiny to be included in it (let me know if I should include it.). 

<!-- Next, let's do a check list. Remove what doesn't apply. -->

- [x] My changes do not contradict
      [the current specification](https://reuse.software/spec/).
- [x] I agree to license my contribution under the licenses indicated in the
      changed files.