### PR TITLE
Override LANGUAGE when running tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,7 @@ import pytest
 from jinja2 import Environment
 
 os.environ["LC_ALL"] = "C"
+os.environ["LANGUAGE"] = ""
 
 # A trick that tries to import the installed version of reuse. If that doesn't
 # work, import from the src directory. If that also doesn't work (for some


### PR DESCRIPTION
Apparently LANGUAGE has precedence over LC_ALL. By setting it to an empty string, LC_ALL takes precedence again, and we forcefully use the English translations.

- [x] Added self to copyright blurb of touched files.
- [x] Added self to `AUTHORS.rst`.
- [x] My changes do not contradict
      [the current specification](https://reuse.software/spec/).
- [x] I agree to license my contribution under the licenses indicated in the
      changed files.
