### PR TITLE
Bump to REUSE Specification 3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ recommendations.
 - Documentation: <https://reuse.readthedocs.io> and <https://reuse.software>
 - Source code: <https://github.com/fsfe/reuse-tool>
 - PyPI: <https://pypi.python.org/pypi/reuse>
-- REUSE: 3.2
+- REUSE: 3.3
 - Python: 3.8+
 
 ## Table of contents
@@ -179,7 +179,7 @@ To check against the recommendations, use `reuse lint`:
 ~/Projects/reuse-tool $ reuse lint
 [...]
 
-Congratulations! Your project is compliant with version 3.2 of the REUSE Specification :-)
+Congratulations! Your project is compliant with version 3.3 of the REUSE Specification :-)
 ```
 
 This tool can do various more things, detailed in the documentation. Here a

--- a/changelog.d/changed/00_spec-3.3.md
+++ b/changelog.d/changed/00_spec-3.3.md
@@ -1,0 +1,3 @@
+- Bumped REUSE Specification version to
+  [version 3.3](https://reuse.software/spec-3.3). This is a small change.
+  (#1069)

--- a/src/reuse/__init__.py
+++ b/src/reuse/__init__.py
@@ -36,7 +36,7 @@ except PackageNotFoundError:
 __author__ = "Carmen Bianca Bakker"
 __email__ = "carmenbianca@fsfe.org"
 __license__ = "Apache-2.0 AND CC0-1.0 AND CC-BY-SA-4.0 AND GPL-3.0-or-later"
-__REUSE_version__ = "3.2"
+__REUSE_version__ = "3.3"
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
The following PRs all require a spec bump: #1047, #1042, #1041

This is that spec bump. Their respective spec updates are already on reuse-website's main branch:

- https://github.com/fsfe/reuse-website/pull/85
- https://github.com/fsfe/reuse-website/pull/83
- https://github.com/fsfe/reuse-website/pull/82

<!--
Before submitting a PR, please read CONTRIBUTING.md. Non-trivial changes should
be discussed in an issue before committing to a PR.

Please succinctly describe your changes.
-->

<!-- Next, let's do a check list. Remove what doesn't apply. -->

- [x] Added a change log entry in `changelog.d/<directory>/`.
- [x] Documented my changes in `docs/man/` or elsewhere.
- [ ] My changes do not contradict
      [the current specification](https://reuse.software/spec/).
- [x] I agree to license my contribution under the licenses indicated in the
      changed files.
