### PR TITLE
man: Clarify where REUSE.toml may be located

### DIFF
--- a/docs/man/reuse-lint.rst
+++ b/docs/man/reuse-lint.rst
@@ -67,7 +67,8 @@ are the methods:
 
 - Placing tags in the header of the file.
 - Placing tags in a ``.license`` file adjacent to the file.
-- Putting the information in the ``REUSE.toml`` file.
+- Putting the information in a ``REUSE.toml`` file, which must be in an ancestor
+  directory relative to the file.
 - Putting the information in the ``.reuse/dep5`` file. (Deprecated)
 
 If a file is found that does not have copyright and/or license information


### PR DESCRIPTION
The usage of 'the REUSE.toml file' was incorrect. There may be multiple ones. The new language use is more correct and adds helpful context.

Issue raised in #1040

<!--
Before submitting a PR, please read CONTRIBUTING.md. Non-trivial changes should
be discussed in an issue before committing to a PR.

Please succinctly describe your changes.
-->

<!-- Next, let's do a check list. Remove what doesn't apply. -->

- [x] Documented my changes in `docs/man/` or elsewhere.
- [x] My changes do not contradict
      [the current specification](https://reuse.software/spec/).
- [x] I agree to license my contribution under the licenses indicated in the
      changed files.
