### PR TITLE
Generate project object on demand

### DIFF
--- a/.github/workflows/gettext.yaml
+++ b/.github/workflows/gettext.yaml
@@ -23,6 +23,10 @@ jobs:
           # exception to the branch protection, so we'll use that account's
           # token to push to the main branch.
           token: ${{ secrets.FSFE_SYSTEM_TOKEN }}
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
       - name: Install gettext and wlc
         run: sudo apt-get install -y gettext wlc
       # We mostly install reuse to install the click dependency.

--- a/src/reuse/cli/annotate.py
+++ b/src/reuse/cli/annotate.py
@@ -44,7 +44,7 @@ from ..comment import (
 )
 from ..i18n import _
 from ..project import Project
-from .common import ClickObj, MutexOption, requires_project, spdx_identifier
+from .common import ClickObj, MutexOption, spdx_identifier
 from .main import main
 
 _LOGGER = logging.getLogger(__name__)
@@ -285,7 +285,6 @@ _HELP = (
 )
 
 
-@requires_project
 @main.command(name="annotate", help=_HELP)
 @click.option(
     "--copyright",
@@ -449,7 +448,7 @@ def annotate(
     paths: Sequence[Path],
 ) -> None:
     # pylint: disable=too-many-arguments,too-many-locals,missing-function-docstring
-    project = cast(Project, obj.project)
+    project = obj.project
 
     test_mandatory_option_required(copyrights, licenses, contributors)
     paths = all_paths(paths, recursive, project)

--- a/src/reuse/cli/convert_dep5.py
+++ b/src/reuse/cli/convert_dep5.py
@@ -12,8 +12,7 @@ import click
 from ..convert_dep5 import toml_from_dep5
 from ..global_licensing import ReuseDep5
 from ..i18n import _
-from ..project import Project
-from .common import ClickObj, requires_project
+from .common import ClickObj
 from .main import main
 
 _HELP = _(
@@ -23,12 +22,11 @@ _HELP = _(
 )
 
 
-@requires_project
 @main.command(name="convert-dep5", help=_HELP)
 @click.pass_obj
 def convert_dep5(obj: ClickObj) -> None:
     # pylint: disable=missing-function-docstring
-    project = cast(Project, obj.project)
+    project = obj.project
     if not (project.root / ".reuse/dep5").exists():
         raise click.UsageError(_("No '.reuse/dep5' file."))
 

--- a/src/reuse/cli/download.py
+++ b/src/reuse/cli/download.py
@@ -9,7 +9,7 @@ import logging
 import sys
 from difflib import SequenceMatcher
 from pathlib import Path
-from typing import IO, Collection, Optional, cast
+from typing import IO, Collection, Optional
 from urllib.error import URLError
 
 import click
@@ -17,10 +17,9 @@ import click
 from .._licenses import ALL_NON_DEPRECATED_MAP
 from ..download import _path_to_license_file, put_license_in_file
 from ..i18n import _
-from ..project import Project
 from ..report import ProjectReport
 from ..types import StrPath
-from .common import ClickObj, MutexOption, requires_project
+from .common import ClickObj, MutexOption
 from .main import main
 
 _LOGGER = logging.getLogger(__name__)
@@ -113,7 +112,6 @@ _HELP = (
 )
 
 
-@requires_project
 @main.command(name="download", help=_HELP)
 @click.option(
     "--all",
@@ -166,9 +164,7 @@ def download(
 
     if all_:
         # TODO: This is fairly inefficient, but gets the job done.
-        report = ProjectReport.generate(
-            cast(Project, obj.project), do_checksum=False
-        )
+        report = ProjectReport.generate(obj.project, do_checksum=False)
         licenses = report.missing_licenses.keys()
 
     if len(licenses) > 1 and output:

--- a/src/reuse/cli/lint.py
+++ b/src/reuse/cli/lint.py
@@ -10,16 +10,14 @@
 """Click code for lint subcommand."""
 
 import sys
-from typing import cast
 
 import click
 
 from .. import __REUSE_version__
 from ..i18n import _
 from ..lint import format_json, format_lines, format_plain
-from ..project import Project
 from ..report import ProjectReport
-from .common import ClickObj, MutexOption, requires_project
+from .common import ClickObj, MutexOption
 from .main import main
 
 _OUTPUT_MUTEX = ["quiet", "json", "plain", "lines"]
@@ -62,7 +60,6 @@ _HELP = (
 )
 
 
-@requires_project
 @main.command(name="lint", help=_HELP)
 @click.option(
     "--quiet",
@@ -102,7 +99,7 @@ def lint(
 ) -> None:
     # pylint: disable=missing-function-docstring
     report = ProjectReport.generate(
-        cast(Project, obj.project),
+        obj.project,
         do_checksum=False,
         multiprocessing=not obj.no_multiprocessing,
     )

--- a/src/reuse/cli/lint_file.py
+++ b/src/reuse/cli/lint_file.py
@@ -9,15 +9,14 @@
 
 import sys
 from pathlib import Path
-from typing import Collection, cast
+from typing import Collection
 
 import click
 
 from ..i18n import _
 from ..lint import format_lines_subset
-from ..project import Project
 from ..report import ProjectSubsetReport
-from .common import ClickObj, MutexOption, requires_project
+from .common import ClickObj, MutexOption
 from .main import main
 
 _OUTPUT_MUTEX = ["quiet", "lines"]
@@ -29,7 +28,6 @@ _HELP = _(
 )
 
 
-@requires_project
 @main.command(name="lint-file", help=_HELP)
 @click.option(
     "--quiet",
@@ -58,7 +56,7 @@ def lint_file(
     obj: ClickObj, quiet: bool, lines: bool, files: Collection[Path]
 ) -> None:
     # pylint: disable=missing-function-docstring
-    project = cast(Project, obj.project)
+    project = obj.project
     subset_files = {Path(file_) for file_ in files}
     for file_ in subset_files:
         if not file_.resolve().is_relative_to(project.root.resolve()):

--- a/src/reuse/cli/spdx.py
+++ b/src/reuse/cli/spdx.py
@@ -8,15 +8,14 @@
 import contextlib
 import logging
 import sys
-from typing import Optional, cast
+from typing import Optional
 
 import click
 
 from .. import _IGNORE_SPDX_PATTERNS
 from ..i18n import _
-from ..project import Project
 from ..report import ProjectReport
-from .common import ClickObj, requires_project
+from .common import ClickObj
 from .main import main
 
 _LOGGER = logging.getLogger(__name__)
@@ -24,7 +23,6 @@ _LOGGER = logging.getLogger(__name__)
 _HELP = _("Generate an SPDX bill of materials.")
 
 
-@requires_project
 @main.command(name="spdx", help=_HELP)
 @click.option(
     "--output",
@@ -103,7 +101,7 @@ def spdx(
         )
 
     report = ProjectReport.generate(
-        cast(Project, obj.project),
+        obj.project,
         multiprocessing=not obj.no_multiprocessing,
         add_license_concluded=add_license_concluded,
     )


### PR DESCRIPTION
This is a lot cleaner, and has better performance benefits. Commands like 'download' do not always require a project object. Now, if the code never touches 'obj.project', the object is never created.

Apart from performance benefits, it also means that irrelevant errors spawned from creation of the project object are sidestepped, because the object is never instantiated (in some cases).

<!--
Before submitting a PR, please read CONTRIBUTING.md. Non-trivial changes should
be discussed in an issue before committing to a PR.

Please succinctly describe your changes.
-->

<!-- Next, let's do a check list. Remove what doesn't apply. -->

- [x] My changes do not contradict
      [the current specification](https://reuse.software/spec/).
- [x] I agree to license my contribution under the licenses indicated in the
      changed files.
