### PR TITLE
Add `.cabal` and `cabal.project` as recognised file types for comments

### DIFF
--- a/changelog.d/added/comment-cabal.md
+++ b/changelog.d/added/comment-cabal.md
@@ -1,0 +1,2 @@
+- Added `.cabal` and `cabal.project` (Haskell) as recognised file types for
+  comments. (#1089)

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -608,6 +608,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".bib": BibTexCommentStyle,
     ".bzl": PythonCommentStyle,
     ".c": CCommentStyle,
+    ".cabal": HaskellCommentStyle,
     ".cc": CppCommentStyle,
     ".cjs": CppCommentStyle,
     ".cl": LispCommentStyle,
@@ -878,6 +879,7 @@ FILENAME_COMMENT_STYLE_MAP = {
     ".yarnrc": PythonCommentStyle,
     "ansible.cfg": PythonCommentStyle,
     "archive.sctxar": UncommentableCommentStyle,  # SuperCollider global archive
+    "cabal.project": HaskellCommentStyle,
     "Cargo.lock": PythonCommentStyle,
     "CMakeLists.txt": PythonCommentStyle,
     "CODEOWNERS": PythonCommentStyle,


### PR DESCRIPTION
This PR adds `.cabal` and `cabal.project` as recognized file types for comments. These files are used by the [Cabal](https://www.haskell.org/cabal/) build tool.

<!-- Next, let's do a check list. Remove what doesn't apply. -->

- [x] Added a change log entry in `changelog.d/<directory>/`.
- [x] My changes do not contradict
      [the current specification](https://reuse.software/spec/).
- [x] I agree to license my contribution under the licenses indicated in the
      changed files.
