### PR TITLE
Add shebang for `.cabal` files

### DIFF
--- a/changelog.d/added/comment-cabal.md
+++ b/changelog.d/added/comment-cabal.md
@@ -1,2 +1,2 @@
 - Added `.cabal` and `cabal.project` (Haskell) as recognised file types for
-  comments. (#1089)
+  comments. (#1089, #1090)

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -422,6 +422,7 @@ class HaskellCommentStyle(CommentStyle):
 
     SINGLE_LINE = "--"
     INDENT_AFTER_SINGLE = " "
+    SHEBANGS = ["cabal-version:"]
 
 
 class HtmlCommentStyle(CommentStyle):


### PR DESCRIPTION
Fixes broken `.cabal` files by adding a shebang specification per https://github.com/fsfe/reuse-tool/pull/1089#issuecomment-2416476098.

- [x] Added a change log entry in `changelog.d/<directory>/`.
- [x] My changes do not contradict [the current specification](https://reuse.software/spec/).
- [x] I agree to license my contribution under the licenses indicated in the
      changed files.