### PR TITLE
Get rid of newline at start of lint output

### DIFF
--- a/changelog.d/fixed/plain-format-output-new-line-fix.md
+++ b/changelog.d/fixed/plain-format-output-new-line-fix.md
@@ -1,0 +1,2 @@
+- The plain output of `lint` has been slightly improved, getting rid of an
+  errant newline. (#1091)

--- a/src/reuse/lint.py
+++ b/src/reuse/lint.py
@@ -136,7 +136,6 @@ def format_plain(report: ProjectReport) -> str:
                 output.write(f"* {file}\n")
             output.write("\n")
 
-    output.write("\n")
     output.write("# " + _("SUMMARY"))
     output.write("\n\n")
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read CONTRIBUTING.md. Non-trivial changes should
be discussed in an issue before committing to a PR.

Please succinctly describe your changes.
-->

With this PR,

```
📺 carmenbianca reuse-tool $ reuse lint

# SUMMARY

* Bad licenses: 0
* Deprecated licenses: 0
* Licenses without file extension: 0
[...]
```

becomes

```
📺 carmenbianca reuse-tool $ reuse lint
# SUMMARY

* Bad licenses: 0
* Deprecated licenses: 0
* Licenses without file extension: 0
[...]
```

<!-- Next, let's do a check list. Remove what doesn't apply. -->

- [x] Added a change log entry in `changelog.d/<directory>/`.
- [ ] Wrote tests.
- [x] My changes do not contradict
      [the current specification](https://reuse.software/spec/).
- [x] I agree to license my contribution under the licenses indicated in the
      changed files.
