### PR TITLE
Be stricter about regenerating reuse.pot

### DIFF
--- a/.github/workflows/gettext.yaml
+++ b/.github/workflows/gettext.yaml
@@ -43,8 +43,8 @@ jobs:
       - name: Check if sufficient lines were changed
         id: diff
         run:
-          echo "changed=$(git diff -U0 | grep '^[+|-][^+|-]' | grep -Ev
-          '^[+-]("POT-Creation-Date|#:)' | wc -l)" >> $GITHUB_OUTPUT
+          echo "changed=$(git diff -U0 po/reuse.pot | grep '^[+|-][^+|-]' | grep
+          -Ev '^[+-]("POT-Creation-Date|#:)' | wc -l)" >> $GITHUB_OUTPUT
       - name: Commit and push updated reuse.pot
         if: ${{ steps.diff.outputs.changed != '0' }}
         run: |


### PR DESCRIPTION
Sometimes when `make create-pot` is run, the wrapping in the `.po` files wouldn't exactly match how Weblate does the wrapping. This would trigger a commit. By only checking for the diff in `po/reuse.pot`, we avoid this problem.

<!--
Before submitting a PR, please read CONTRIBUTING.md. Non-trivial changes should
be discussed in an issue before committing to a PR.

Please succinctly describe your changes.
-->

<!-- Next, let's do a check list. Remove what doesn't apply. -->

- [x] My changes do not contradict
      [the current specification](https://reuse.software/spec/).
- [x] I agree to license my contribution under the licenses indicated in the
      changed files.
