### PR TITLE
Fix downloading `SPDX-IDENTIFIER+`

### DIFF
--- a/changelog.d/fixed/strip-plus.md
+++ b/changelog.d/fixed/strip-plus.md
@@ -1,0 +1,2 @@
+- When running `reuse download SPDX-IDENTIFIER+`, download `SPDX-IDENTIFIER`
+  instead. This also works for `reuse download --all`. (#1098)

--- a/src/reuse/_util.py
+++ b/src/reuse/_util.py
@@ -109,6 +109,32 @@ def _determine_license_suffix_path(path: StrPath) -> Path:
     return Path(f"{path}.license")
 
 
+def _strip_plus_from_identifier(spdx_identifier: str) -> str:
+    """Strip final plus from identifier.
+
+    >>> _strip_plus_from_identifier("EUPL-1.2+")
+    'EUPL-1.2'
+    >>> _strip_plus_from_identifier("EUPL-1.2")
+    'EUPL-1.2'
+    """
+    if spdx_identifier.endswith("+"):
+        return spdx_identifier[:-1]
+    return spdx_identifier
+
+
+def _add_plus_to_identifier(spdx_identifier: str) -> str:
+    """Add final plus to identifier.
+
+    >>> _add_plus_to_identifier("EUPL-1.2")
+    'EUPL-1.2+'
+    >>> _add_plus_to_identifier("EUPL-1.2+")
+    'EUPL-1.2+'
+    """
+    if spdx_identifier.endswith("+"):
+        return spdx_identifier
+    return f"{spdx_identifier}+"
+
+
 def relative_from_root(path: StrPath, root: StrPath) -> Path:
     """A helper function to get *path* relative to *root*."""
     path = Path(path)

--- a/src/reuse/cli/download.py
+++ b/src/reuse/cli/download.py
@@ -15,6 +15,7 @@ from urllib.error import URLError
 import click
 
 from .._licenses import ALL_NON_DEPRECATED_MAP
+from .._util import _strip_plus_from_identifier
 from ..download import _path_to_license_file, put_license_in_file
 from ..i18n import _
 from ..report import ProjectReport
@@ -173,6 +174,7 @@ def download(
             _("Cannot use '--output' with more than one license.")
         )
 
+    licenses = {_strip_plus_from_identifier(lic) for lic in licenses}
     return_code = 0
     for lic in licenses:
         destination: Path = output  # type: ignore

--- a/src/reuse/cli/download.py
+++ b/src/reuse/cli/download.py
@@ -139,7 +139,7 @@ _HELP = (
     ),
 )
 @click.argument(
-    "license_",
+    "licenses",
     # TRANSLATORS: You may translate this. Please preserve capital letters.
     metavar=_("LICENSE"),
     type=str,
@@ -148,21 +148,19 @@ _HELP = (
 @click.pass_obj
 def download(
     obj: ClickObj,
-    license_: Collection[str],
+    licenses: Collection[str],
     all_: bool,
     output: Optional[Path],
     source: Optional[Path],
 ) -> None:
     # pylint: disable=missing-function-docstring
-    if all_ and license_:
+    if all_ and licenses:
         raise click.UsageError(
             _(
                 "The 'LICENSE' argument and '--all' option are mutually"
                 " exclusive."
             )
         )
-
-    licenses: Collection[str] = license_  # type: ignore
 
     if all_:
         # TODO: This is fairly inefficient, but gets the job done.


### PR DESCRIPTION
<!--
Before submitting a PR, please read CONTRIBUTING.md. Non-trivial changes should
be discussed in an issue before committing to a PR.

Please succinctly describe your changes.
-->

Fixes #1096

<!-- Next, let's do a check list. Remove what doesn't apply. -->

- [x] Added a change log entry in `changelog.d/<directory>/`.
- [x] Wrote tests.
- [x] Documented my changes in `docs/man/` or elsewhere.
- [x] My changes do not contradict
      [the current specification](https://reuse.software/spec/).
- [x] I agree to license my contribution under the licenses indicated in the
      changed files.
