### PR TITLE
feat(BEAM): Add support for Erlang, Elixir, and Gleam comments

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -146,3 +146,4 @@ Contributors
 - Linnea Gräf <nea@nea.moe>
 - Raphael Schlarb <info@raphael.schlarb.one>
 - Matthias Schoettle <opensource@mattsch.com>
+- Kiko Fernandez-Reyes <kiko@erlang.org>

--- a/changelog.d/added/erlang-elixir-gleam.md
+++ b/changelog.d/added/erlang-elixir-gleam.md
@@ -1,0 +1,1 @@
+- Added comment support for Erlang, Elixir, and Gleam. (#1117)

--- a/changelog.d/added/erlang-elixir-gleam.md
+++ b/changelog.d/added/erlang-elixir-gleam.md
@@ -1,1 +1,3 @@
-- Added comment support for Erlang, Elixir, and Gleam. (#1117)
+- Added comment support for Erlang (`.erl` and `.hrl`), Erlang's leex and yecc
+  lexer and parser generators (`.xrl` and `.yrl`), Elixir (`.ex` and `.exs`),
+  and Gleam (`.gleam`). (#1117)

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -404,6 +404,15 @@ class ErlangCommentStyle(CommentStyle):
 
 
 class ElixirCommentStyle(CommentStyle):
+    """Elixir comment style."""
+
+    SHORTHAND = "elixir"
+
+    SINGLE_LINE = "#"
+    INDENT_AFTER_SINGLE = " "
+    SHEBANGS = ["#!"]
+
+
 class FtlCommentStyle(CommentStyle):
     """FreeMarker Template Language comment style."""
 
@@ -644,10 +653,10 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".dts": CppCommentStyle,
     ".dtsi": CppCommentStyle,
     ".el": LispCommentStyle,
-    ".ex": PythonCommentStyle,
-    ".exs": PythonCommentStyle,
     ".erl": ErlangCommentStyle,
     ".escript": ErlangCommentStyle,
+    ".ex": ElixirCommentStyle,
+    ".exs": ElixirCommentStyle,
     ".f": FortranCommentStyle,
     ".fsproj": HtmlCommentStyle,
     ".f03": ModernFortranCommentStyle,

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -19,6 +19,7 @@
 # SPDX-FileCopyrightText: 2024 Rivos Inc.
 # SPDX-FileCopyrightText: 2024 Anthony Loiseau <anthony.loiseau@allcircuits.com>
 # SPDX-FileCopyrightText: 2025 Raphael Schlarb <info@raphael.schlarb.one>
+# SPDX-FileCopyrightText: 2025 Kiko Fernandez-Reyes <kiko@erlang.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -358,6 +358,7 @@ class CppSingleCommentStyle(CommentStyle):
 
     SINGLE_LINE = "//"
     INDENT_AFTER_SINGLE = " "
+    SHEBANGS = ["#!"]  # Gleam
 
 
 class EmptyCommentStyle(CommentStyle):
@@ -410,17 +411,6 @@ class FtlCommentStyle(CommentStyle):
     SHORTHAND = "ftl"
 
     MULTI_LINE = MultiLineSegments("<#--", "", "-->")
-
-
-class GleamCommentStyle(CppSingleCommentStyle):
-    """Gleam comment style."""
-
-    SHORTHAND = "gleam"
-
-    # CppCommentStyle does not work on Gleam due to multilines.
-    # CppSingleCommentStyle does not contain SHEBANGS,
-    # but Gleam can interpret them
-    SHEBANGS = ["#!"]
 
 
 class HandlebarsCommentStyle(CommentStyle):
@@ -678,7 +668,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".fsx": CppCommentStyle,
     ".ftl": FtlCommentStyle,
     ".gemspec": PythonCommentStyle,
-    ".gleam": GleamCommentStyle,
+    ".gleam": CppSingleCommentStyle,
     ".go": CppCommentStyle,
     ".gperf": CppCommentStyle,
     ".gradle": CppCommentStyle,

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -421,6 +421,16 @@ class FtlCommentStyle(CommentStyle):
     MULTI_LINE = MultiLineSegments("<#--", "", "-->")
 
 
+class GleamCommentStyle(CommentStyle):
+    """Gleam comment style."""
+
+    SHORTHAND = "gleam"
+
+    SINGLE_LINE = "//"
+    INDENT_AFTER_SINGLE = " "
+    SHEBANGS = ["#!"]
+
+
 class HandlebarsCommentStyle(CommentStyle):
     """Handlebars comment style."""
 
@@ -675,6 +685,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".fsx": CppCommentStyle,
     ".ftl": FtlCommentStyle,
     ".gemspec": PythonCommentStyle,
+    ".gleam": GleamCommentStyle,
     ".go": CppCommentStyle,
     ".gperf": CppCommentStyle,
     ".gradle": CppCommentStyle,

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -859,11 +859,13 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".xqm": XQueryCommentStyle,
     ".xqy": XQueryCommentStyle,
     ".xquery": XQueryCommentStyle,
+    ".xrl": ErlangCommentStyle,
     ".xsd": HtmlCommentStyle,
     ".xsh": PythonCommentStyle,
     ".xsl": HtmlCommentStyle,
     ".yaml": PythonCommentStyle,
     ".yml": PythonCommentStyle,
+    ".yrl": ErlangCommentStyle,
     ".zig": CppSingleCommentStyle,
     ".zsh": PythonCommentStyle,
 }

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -666,6 +666,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".el": LispCommentStyle,
     ".erl": ErlangCommentStyle,
     ".escript": ErlangCommentStyle,
+    ".es": ErlangCommentStyle,
     ".ex": ElixirCommentStyle,
     ".exs": ElixirCommentStyle,
     ".f": FortranCommentStyle,

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -411,13 +411,14 @@ class FtlCommentStyle(CommentStyle):
     MULTI_LINE = MultiLineSegments("<#--", "", "-->")
 
 
-class GleamCommentStyle(CommentStyle):
+class GleamCommentStyle(CppSingleCommentStyle):
     """Gleam comment style."""
 
     SHORTHAND = "gleam"
 
-    SINGLE_LINE = "//"
-    INDENT_AFTER_SINGLE = " "
+    # CppCommentStyle does not work on Gleam due to multilines.
+    # CppSingleCommentStyle does not contain SHEBANGS,
+    # but Gleam can interpret them
     SHEBANGS = ["#!"]
 
 

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -393,6 +393,17 @@ class ModernFortranCommentStyle(CommentStyle):
     INDENT_AFTER_SINGLE = " "
 
 
+class ErlangCommentStyle(CommentStyle):
+    """Erlang comment style."""
+
+    SHORTHAND = "erlang"
+
+    SINGLE_LINE = "%"
+    INDENT_AFTER_SINGLE = " "
+    SHEBANGS = ["#!"]
+
+
+class ElixirCommentStyle(CommentStyle):
 class FtlCommentStyle(CommentStyle):
     """FreeMarker Template Language comment style."""
 
@@ -633,9 +644,10 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".dts": CppCommentStyle,
     ".dtsi": CppCommentStyle,
     ".el": LispCommentStyle,
-    ".erl": TexCommentStyle,
     ".ex": PythonCommentStyle,
     ".exs": PythonCommentStyle,
+    ".erl": ErlangCommentStyle,
+    ".escript": ErlangCommentStyle,
     ".f": FortranCommentStyle,
     ".fsproj": HtmlCommentStyle,
     ".f03": ModernFortranCommentStyle,
@@ -668,7 +680,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".hh": CppCommentStyle,
     ".hjson": CppCommentStyle,
     ".hpp": CppCommentStyle,
-    ".hrl": TexCommentStyle,
+    ".hrl": ErlangCommentStyle,
     ".hs": HaskellCommentStyle,
     ".html": HtmlCommentStyle,
     ".hx": CppCommentStyle,

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -403,17 +403,6 @@ class ErlangCommentStyle(CommentStyle):
     INDENT_AFTER_SINGLE = " "
     SHEBANGS = ["#!"]
 
-
-class ElixirCommentStyle(CommentStyle):
-    """Elixir comment style."""
-
-    SHORTHAND = "elixir"
-
-    SINGLE_LINE = "#"
-    INDENT_AFTER_SINGLE = " "
-    SHEBANGS = ["#!"]
-
-
 class FtlCommentStyle(CommentStyle):
     """FreeMarker Template Language comment style."""
 
@@ -667,8 +656,8 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".erl": ErlangCommentStyle,
     ".escript": ErlangCommentStyle,
     ".es": ErlangCommentStyle,
-    ".ex": ElixirCommentStyle,
-    ".exs": ElixirCommentStyle,
+    ".ex": PythonCommentStyle,
+    ".exs": PythonCommentStyle,
     ".f": FortranCommentStyle,
     ".fsproj": HtmlCommentStyle,
     ".f03": ModernFortranCommentStyle,

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -403,6 +403,7 @@ class ErlangCommentStyle(CommentStyle):
     INDENT_AFTER_SINGLE = " "
     SHEBANGS = ["#!"]
 
+
 class FtlCommentStyle(CommentStyle):
     """FreeMarker Template Language comment style."""
 


### PR DESCRIPTION
Adds support for comments for the most used BEAM languages:
- Erlang
- Elixir
- Gleam


- [X] Added a change log entry in `changelog.d/<directory>/`.
- [X] Added self to copyright blurb of touched files.
- [X] Added self to `AUTHORS.rst`.
- [X] My changes do not contradict
      [the current specification](https://reuse.software/spec/).
- [x] I agree to license my contribution under the licenses indicated in the
      changed files.
