### PR TITLE
Add support for arcanist config file extensions

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -144,3 +144,4 @@ Contributors
 - Skyler Grey <sky@a.starrysky.fyi>
 - Emil Velikov <emil.l.velikov@gmail.com>
 - Linnea Gräf <nea@nea.moe>
+- Yongmin Hong <yewon@revi.email>

--- a/changelog.d/added/added-arcanist.md
+++ b/changelog.d/added/added-arcanist.md
@@ -1,0 +1,2 @@
+Added `.arcconfig`, `.arclint`, `.arcunit` (all uncommentable) as recognized
+file types for comments. (#1123)

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -18,6 +18,7 @@
 # SPDX-FileCopyrightText: 2023 Shun Sakai <sorairolake@protonmail.ch>
 # SPDX-FileCopyrightText: 2024 Rivos Inc.
 # SPDX-FileCopyrightText: 2024 Anthony Loiseau <anthony.loiseau@allcircuits.com>
+# SPDX-FileCopyrightText: 2024 Yongmin Hong <yewon@revi.email>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -838,6 +839,9 @@ EXTENSION_COMMENT_STYLE_MAP_LOWERCASE = {
 }
 
 FILENAME_COMMENT_STYLE_MAP = {
+    ".arcconfig": UncommentableCommentStyle,  # is a JSON file
+    ".arclint": UncommentableCommentStyle,  # is a JSON file
+    ".arcunit": UncommentableCommentStyle,  # is a JSON file
     ".bashrc": PythonCommentStyle,
     ".bazelignore": PythonCommentStyle,
     ".bazelrc": PythonCommentStyle,


### PR DESCRIPTION
Those are used by (Phabricator/Phorge)'s arcanist CLI tools.

- `.arcconfig`: [docs](https://we.phorge.it/book/phorge/article/arcanist_new_project/)
- `.arclint` and `.arcunit`: [docs](https://we.phorge.it/book/phorge/article/arcanist_lint_unit/) says "inside `.arcconfig`" but apparently (according to upstream repo) `.arclint` and `.arcunit` is supported as well.

<!--
Before submitting a PR, please read CONTRIBUTING.md. Non-trivial changes should
be discussed in an issue before committing to a PR.

Please succinctly describe your changes.
-->

<!-- Next, let's do a check list. Remove what doesn't apply. -->

- [x] Added a change log entry in `changelog.d/<directory>/`.
- [x] Added self to copyright blurb of touched files.
- [x] Added self to `AUTHORS.rst`.
- [x] My changes do not contradict
      [the current specification](https://reuse.software/spec/).
- [x] I agree to license my contribution under the licenses indicated in the
      changed files.
