### PR TITLE
Add .gperf as a recognised file type for comments

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -144,3 +144,4 @@ Contributors
 - Skyler Grey <sky@a.starrysky.fyi>
 - Emil Velikov <emil.l.velikov@gmail.com>
 - Linnea Gräf <nea@nea.moe>
+- Raphael Schlarb <info@raphael.schlarb.one>

--- a/changelog.d/added/comment-gperf.md
+++ b/changelog.d/added/comment-gperf.md
@@ -1,0 +1,2 @@
+- Added `.gperf` (CppCommentStyle) as a recognised file type for comments.
+  (#1131)

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -18,6 +18,7 @@
 # SPDX-FileCopyrightText: 2023 Shun Sakai <sorairolake@protonmail.ch>
 # SPDX-FileCopyrightText: 2024 Rivos Inc.
 # SPDX-FileCopyrightText: 2024 Anthony Loiseau <anthony.loiseau@allcircuits.com>
+# SPDX-FileCopyrightText: 2025 Raphael Schlarb <info@raphael.schlarb.one>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -654,6 +655,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".ftl": FtlCommentStyle,
     ".gemspec": PythonCommentStyle,
     ".go": CppCommentStyle,
+    ".gperf": CppCommentStyle,
     ".gradle": CppCommentStyle,
     ".graphql": PythonCommentStyle,
     ".graphqls": PythonCommentStyle,


### PR DESCRIPTION
<!--
Before submitting a PR, please read CONTRIBUTING.md. Non-trivial changes should
be discussed in an issue before committing to a PR.

Please succinctly describe your changes.
-->
Add .gperf ([GNU gperf](https://www.gnu.org/software/gperf/)) as a recognised file type for comments.
<!-- Next, let's do a check list. Remove what doesn't apply. -->

- [x] Added a change log entry in `changelog.d/<directory>/`.
- [x] Added self to copyright blurb of touched files.
- [x] Added self to `AUTHORS.rst`.
- [ ] Wrote tests.
- [ ] Documented my changes in `docs/man/` or elsewhere.
- [x] My changes do not contradict
      [the current specification](https://reuse.software/spec/).
- [x] I agree to license my contribution under the licenses indicated in the
      changed files.
