### PR TITLE
update license resources to latest

### DIFF
--- a/src/reuse/resources/exceptions.json
+++ b/src/reuse/resources/exceptions.json
@@ -1,11 +1,11 @@
 {
-  "licenseListVersion": "3.25.0",
+  "licenseListVersion": "3.26.0",
   "exceptions": [
     {
-      "reference": "./389-exception.json",
+      "reference": "https://spdx.org/licenses/389-exception.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./389-exception.html",
-      "referenceNumber": 53,
+      "detailsUrl": "https://spdx.org/licenses/389-exception.json",
+      "referenceNumber": 54,
       "name": "389 Directory Server Exception",
       "licenseExceptionId": "389-exception",
       "seeAlso": [
@@ -14,10 +14,10 @@
       ]
     },
     {
-      "reference": "./Asterisk-exception.json",
+      "reference": "https://spdx.org/licenses/Asterisk-exception.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./Asterisk-exception.html",
-      "referenceNumber": 60,
+      "detailsUrl": "https://spdx.org/licenses/Asterisk-exception.json",
+      "referenceNumber": 25,
       "name": "Asterisk exception",
       "licenseExceptionId": "Asterisk-exception",
       "seeAlso": [
@@ -26,10 +26,10 @@
       ]
     },
     {
-      "reference": "./Asterisk-linking-protocols-exception.json",
+      "reference": "https://spdx.org/licenses/Asterisk-linking-protocols-exception.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./Asterisk-linking-protocols-exception.html",
-      "referenceNumber": 24,
+      "detailsUrl": "https://spdx.org/licenses/Asterisk-linking-protocols-exception.json",
+      "referenceNumber": 42,
       "name": "Asterisk linking protocols exception",
       "licenseExceptionId": "Asterisk-linking-protocols-exception",
       "seeAlso": [
@@ -37,10 +37,10 @@
       ]
     },
     {
-      "reference": "./Autoconf-exception-2.0.json",
+      "reference": "https://spdx.org/licenses/Autoconf-exception-2.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./Autoconf-exception-2.0.html",
-      "referenceNumber": 72,
+      "detailsUrl": "https://spdx.org/licenses/Autoconf-exception-2.0.json",
+      "referenceNumber": 17,
       "name": "Autoconf exception 2.0",
       "licenseExceptionId": "Autoconf-exception-2.0",
       "seeAlso": [
@@ -49,10 +49,10 @@
       ]
     },
     {
-      "reference": "./Autoconf-exception-3.0.json",
+      "reference": "https://spdx.org/licenses/Autoconf-exception-3.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./Autoconf-exception-3.0.html",
-      "referenceNumber": 17,
+      "detailsUrl": "https://spdx.org/licenses/Autoconf-exception-3.0.json",
+      "referenceNumber": 20,
       "name": "Autoconf exception 3.0",
       "licenseExceptionId": "Autoconf-exception-3.0",
       "seeAlso": [
@@ -60,10 +60,10 @@
       ]
     },
     {
-      "reference": "./Autoconf-exception-generic.json",
+      "reference": "https://spdx.org/licenses/Autoconf-exception-generic.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./Autoconf-exception-generic.html",
-      "referenceNumber": 48,
+      "detailsUrl": "https://spdx.org/licenses/Autoconf-exception-generic.json",
+      "referenceNumber": 66,
       "name": "Autoconf generic exception",
       "licenseExceptionId": "Autoconf-exception-generic",
       "seeAlso": [
@@ -74,10 +74,10 @@
       ]
     },
     {
-      "reference": "./Autoconf-exception-generic-3.0.json",
+      "reference": "https://spdx.org/licenses/Autoconf-exception-generic-3.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./Autoconf-exception-generic-3.0.html",
-      "referenceNumber": 64,
+      "detailsUrl": "https://spdx.org/licenses/Autoconf-exception-generic-3.0.json",
+      "referenceNumber": 16,
       "name": "Autoconf generic exception for GPL-3.0",
       "licenseExceptionId": "Autoconf-exception-generic-3.0",
       "seeAlso": [
@@ -85,10 +85,10 @@
       ]
     },
     {
-      "reference": "./Autoconf-exception-macro.json",
+      "reference": "https://spdx.org/licenses/Autoconf-exception-macro.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./Autoconf-exception-macro.html",
-      "referenceNumber": 51,
+      "detailsUrl": "https://spdx.org/licenses/Autoconf-exception-macro.json",
+      "referenceNumber": 41,
       "name": "Autoconf macro exception",
       "licenseExceptionId": "Autoconf-exception-macro",
       "seeAlso": [
@@ -98,10 +98,10 @@
       ]
     },
     {
-      "reference": "./Bison-exception-1.24.json",
+      "reference": "https://spdx.org/licenses/Bison-exception-1.24.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./Bison-exception-1.24.html",
-      "referenceNumber": 59,
+      "detailsUrl": "https://spdx.org/licenses/Bison-exception-1.24.json",
+      "referenceNumber": 34,
       "name": "Bison exception 1.24",
       "licenseExceptionId": "Bison-exception-1.24",
       "seeAlso": [
@@ -109,10 +109,10 @@
       ]
     },
     {
-      "reference": "./Bison-exception-2.2.json",
+      "reference": "https://spdx.org/licenses/Bison-exception-2.2.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./Bison-exception-2.2.html",
-      "referenceNumber": 21,
+      "detailsUrl": "https://spdx.org/licenses/Bison-exception-2.2.json",
+      "referenceNumber": 50,
       "name": "Bison exception 2.2",
       "licenseExceptionId": "Bison-exception-2.2",
       "seeAlso": [
@@ -120,10 +120,10 @@
       ]
     },
     {
-      "reference": "./Bootloader-exception.json",
+      "reference": "https://spdx.org/licenses/Bootloader-exception.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./Bootloader-exception.html",
-      "referenceNumber": 40,
+      "detailsUrl": "https://spdx.org/licenses/Bootloader-exception.json",
+      "referenceNumber": 67,
       "name": "Bootloader Distribution Exception",
       "licenseExceptionId": "Bootloader-exception",
       "seeAlso": [
@@ -131,10 +131,22 @@
       ]
     },
     {
-      "reference": "./Classpath-exception-2.0.json",
+      "reference": "https://spdx.org/licenses/CGAL-linking-exception.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./Classpath-exception-2.0.html",
-      "referenceNumber": 34,
+      "detailsUrl": "https://spdx.org/licenses/CGAL-linking-exception.json",
+      "referenceNumber": 43,
+      "name": "CGAL Linking Exception",
+      "licenseExceptionId": "CGAL-linking-exception",
+      "seeAlso": [
+        "https://github.com/openscad/openscad/blob/openscad-2021.01/COPYING#L3",
+        "https://github.com/floriankirsch/OpenCSG/blob/opencsg-1-4-2-release/license.txt#L3"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/Classpath-exception-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Classpath-exception-2.0.json",
+      "referenceNumber": 69,
       "name": "Classpath exception 2.0",
       "licenseExceptionId": "Classpath-exception-2.0",
       "seeAlso": [
@@ -143,10 +155,10 @@
       ]
     },
     {
-      "reference": "./CLISP-exception-2.0.json",
+      "reference": "https://spdx.org/licenses/CLISP-exception-2.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./CLISP-exception-2.0.html",
-      "referenceNumber": 71,
+      "detailsUrl": "https://spdx.org/licenses/CLISP-exception-2.0.json",
+      "referenceNumber": 1,
       "name": "CLISP exception 2.0",
       "licenseExceptionId": "CLISP-exception-2.0",
       "seeAlso": [
@@ -154,10 +166,10 @@
       ]
     },
     {
-      "reference": "./cryptsetup-OpenSSL-exception.json",
+      "reference": "https://spdx.org/licenses/cryptsetup-OpenSSL-exception.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./cryptsetup-OpenSSL-exception.html",
-      "referenceNumber": 5,
+      "detailsUrl": "https://spdx.org/licenses/cryptsetup-OpenSSL-exception.json",
+      "referenceNumber": 53,
       "name": "cryptsetup OpenSSL exception",
       "licenseExceptionId": "cryptsetup-OpenSSL-exception",
       "seeAlso": [
@@ -169,10 +181,10 @@
       ]
     },
     {
-      "reference": "./DigiRule-FOSS-exception.json",
+      "reference": "https://spdx.org/licenses/DigiRule-FOSS-exception.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./DigiRule-FOSS-exception.html",
-      "referenceNumber": 66,
+      "detailsUrl": "https://spdx.org/licenses/DigiRule-FOSS-exception.json",
+      "referenceNumber": 13,
       "name": "DigiRule FOSS License Exception",
       "licenseExceptionId": "DigiRule-FOSS-exception",
       "seeAlso": [
@@ -180,10 +192,10 @@
       ]
     },
     {
-      "reference": "./eCos-exception-2.0.json",
+      "reference": "https://spdx.org/licenses/eCos-exception-2.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./eCos-exception-2.0.html",
-      "referenceNumber": 35,
+      "detailsUrl": "https://spdx.org/licenses/eCos-exception-2.0.json",
+      "referenceNumber": 58,
       "name": "eCos exception 2.0",
       "licenseExceptionId": "eCos-exception-2.0",
       "seeAlso": [
@@ -191,10 +203,10 @@
       ]
     },
     {
-      "reference": "./erlang-otp-linking-exception.json",
+      "reference": "https://spdx.org/licenses/erlang-otp-linking-exception.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./erlang-otp-linking-exception.html",
-      "referenceNumber": 46,
+      "detailsUrl": "https://spdx.org/licenses/erlang-otp-linking-exception.json",
+      "referenceNumber": 38,
       "name": "Erlang/OTP Linking Exception",
       "licenseExceptionId": "erlang-otp-linking-exception",
       "seeAlso": [
@@ -204,10 +216,10 @@
       ]
     },
     {
-      "reference": "./Fawkes-Runtime-exception.json",
+      "reference": "https://spdx.org/licenses/Fawkes-Runtime-exception.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./Fawkes-Runtime-exception.html",
-      "referenceNumber": 23,
+      "detailsUrl": "https://spdx.org/licenses/Fawkes-Runtime-exception.json",
+      "referenceNumber": 12,
       "name": "Fawkes Runtime Exception",
       "licenseExceptionId": "Fawkes-Runtime-exception",
       "seeAlso": [
@@ -215,10 +227,10 @@
       ]
     },
     {
-      "reference": "./FLTK-exception.json",
+      "reference": "https://spdx.org/licenses/FLTK-exception.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./FLTK-exception.html",
-      "referenceNumber": 9,
+      "detailsUrl": "https://spdx.org/licenses/FLTK-exception.json",
+      "referenceNumber": 8,
       "name": "FLTK exception",
       "licenseExceptionId": "FLTK-exception",
       "seeAlso": [
@@ -226,10 +238,10 @@
       ]
     },
     {
-      "reference": "./fmt-exception.json",
+      "reference": "https://spdx.org/licenses/fmt-exception.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./fmt-exception.html",
-      "referenceNumber": 69,
+      "detailsUrl": "https://spdx.org/licenses/fmt-exception.json",
+      "referenceNumber": 2,
       "name": "fmt exception",
       "licenseExceptionId": "fmt-exception",
       "seeAlso": [
@@ -238,10 +250,10 @@
       ]
     },
     {
-      "reference": "./Font-exception-2.0.json",
+      "reference": "https://spdx.org/licenses/Font-exception-2.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./Font-exception-2.0.html",
-      "referenceNumber": 19,
+      "detailsUrl": "https://spdx.org/licenses/Font-exception-2.0.json",
+      "referenceNumber": 59,
       "name": "Font exception 2.0",
       "licenseExceptionId": "Font-exception-2.0",
       "seeAlso": [
@@ -249,10 +261,10 @@
       ]
     },
     {
-      "reference": "./freertos-exception-2.0.json",
+      "reference": "https://spdx.org/licenses/freertos-exception-2.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./freertos-exception-2.0.html",
-      "referenceNumber": 54,
+      "detailsUrl": "https://spdx.org/licenses/freertos-exception-2.0.json",
+      "referenceNumber": 37,
       "name": "FreeRTOS Exception 2.0",
       "licenseExceptionId": "freertos-exception-2.0",
       "seeAlso": [
@@ -260,10 +272,10 @@
       ]
     },
     {
-      "reference": "./GCC-exception-2.0.json",
+      "reference": "https://spdx.org/licenses/GCC-exception-2.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./GCC-exception-2.0.html",
-      "referenceNumber": 14,
+      "detailsUrl": "https://spdx.org/licenses/GCC-exception-2.0.json",
+      "referenceNumber": 27,
       "name": "GCC Runtime Library exception 2.0",
       "licenseExceptionId": "GCC-exception-2.0",
       "seeAlso": [
@@ -272,10 +284,10 @@
       ]
     },
     {
-      "reference": "./GCC-exception-2.0-note.json",
+      "reference": "https://spdx.org/licenses/GCC-exception-2.0-note.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./GCC-exception-2.0-note.html",
-      "referenceNumber": 55,
+      "detailsUrl": "https://spdx.org/licenses/GCC-exception-2.0-note.json",
+      "referenceNumber": 47,
       "name": "GCC    Runtime Library exception 2.0 - note variant",
       "licenseExceptionId": "GCC-exception-2.0-note",
       "seeAlso": [
@@ -283,10 +295,10 @@
       ]
     },
     {
-      "reference": "./GCC-exception-3.1.json",
+      "reference": "https://spdx.org/licenses/GCC-exception-3.1.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./GCC-exception-3.1.html",
-      "referenceNumber": 6,
+      "detailsUrl": "https://spdx.org/licenses/GCC-exception-3.1.json",
+      "referenceNumber": 65,
       "name": "GCC Runtime Library exception 3.1",
       "licenseExceptionId": "GCC-exception-3.1",
       "seeAlso": [
@@ -294,21 +306,21 @@
       ]
     },
     {
-      "reference": "./Gmsh-exception.json",
+      "reference": "https://spdx.org/licenses/Gmsh-exception.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./Gmsh-exception.html",
-      "referenceNumber": 58,
-      "name": "Gmsh exception\u003e",
+      "detailsUrl": "https://spdx.org/licenses/Gmsh-exception.json",
+      "referenceNumber": 24,
+      "name": "Gmsh exception",
       "licenseExceptionId": "Gmsh-exception",
       "seeAlso": [
         "https://gitlab.onelab.info/gmsh/gmsh/-/raw/master/LICENSE.txt"
       ]
     },
     {
-      "reference": "./GNAT-exception.json",
+      "reference": "https://spdx.org/licenses/GNAT-exception.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./GNAT-exception.html",
-      "referenceNumber": 26,
+      "detailsUrl": "https://spdx.org/licenses/GNAT-exception.json",
+      "referenceNumber": 14,
       "name": "GNAT exception",
       "licenseExceptionId": "GNAT-exception",
       "seeAlso": [
@@ -316,10 +328,10 @@
       ]
     },
     {
-      "reference": "./GNOME-examples-exception.json",
+      "reference": "https://spdx.org/licenses/GNOME-examples-exception.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./GNOME-examples-exception.html",
-      "referenceNumber": 12,
+      "detailsUrl": "https://spdx.org/licenses/GNOME-examples-exception.json",
+      "referenceNumber": 19,
       "name": "GNOME examples exception",
       "licenseExceptionId": "GNOME-examples-exception",
       "seeAlso": [
@@ -328,10 +340,10 @@
       ]
     },
     {
-      "reference": "./GNU-compiler-exception.json",
+      "reference": "https://spdx.org/licenses/GNU-compiler-exception.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./GNU-compiler-exception.html",
-      "referenceNumber": 18,
+      "detailsUrl": "https://spdx.org/licenses/GNU-compiler-exception.json",
+      "referenceNumber": 57,
       "name": "GNU Compiler Exception",
       "licenseExceptionId": "GNU-compiler-exception",
       "seeAlso": [
@@ -339,10 +351,10 @@
       ]
     },
     {
-      "reference": "./gnu-javamail-exception.json",
+      "reference": "https://spdx.org/licenses/gnu-javamail-exception.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./gnu-javamail-exception.html",
-      "referenceNumber": 43,
+      "detailsUrl": "https://spdx.org/licenses/gnu-javamail-exception.json",
+      "referenceNumber": 63,
       "name": "GNU JavaMail exception",
       "licenseExceptionId": "gnu-javamail-exception",
       "seeAlso": [
@@ -350,10 +362,19 @@
       ]
     },
     {
-      "reference": "./GPL-3.0-interface-exception.json",
+      "reference": "https://spdx.org/licenses/GPL-3.0-389-ds-base-exception.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./GPL-3.0-interface-exception.html",
-      "referenceNumber": 28,
+      "detailsUrl": "https://spdx.org/licenses/GPL-3.0-389-ds-base-exception.json",
+      "referenceNumber": 64,
+      "name": "GPL-3.0 389 DS Base Exception",
+      "licenseExceptionId": "GPL-3.0-389-ds-base-exception",
+      "seeAlso": []
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-3.0-interface-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GPL-3.0-interface-exception.json",
+      "referenceNumber": 44,
       "name": "GPL-3.0 Interface Exception",
       "licenseExceptionId": "GPL-3.0-interface-exception",
       "seeAlso": [
@@ -361,10 +382,10 @@
       ]
     },
     {
-      "reference": "./GPL-3.0-linking-exception.json",
+      "reference": "https://spdx.org/licenses/GPL-3.0-linking-exception.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./GPL-3.0-linking-exception.html",
-      "referenceNumber": 45,
+      "detailsUrl": "https://spdx.org/licenses/GPL-3.0-linking-exception.json",
+      "referenceNumber": 10,
       "name": "GPL-3.0 Linking Exception",
       "licenseExceptionId": "GPL-3.0-linking-exception",
       "seeAlso": [
@@ -372,10 +393,10 @@
       ]
     },
     {
-      "reference": "./GPL-3.0-linking-source-exception.json",
+      "reference": "https://spdx.org/licenses/GPL-3.0-linking-source-exception.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./GPL-3.0-linking-source-exception.html",
-      "referenceNumber": 39,
+      "detailsUrl": "https://spdx.org/licenses/GPL-3.0-linking-source-exception.json",
+      "referenceNumber": 71,
       "name": "GPL-3.0 Linking Exception (with Corresponding Source)",
       "licenseExceptionId": "GPL-3.0-linking-source-exception",
       "seeAlso": [
@@ -384,10 +405,10 @@
       ]
     },
     {
-      "reference": "./GPL-CC-1.0.json",
+      "reference": "https://spdx.org/licenses/GPL-CC-1.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./GPL-CC-1.0.html",
-      "referenceNumber": 27,
+      "detailsUrl": "https://spdx.org/licenses/GPL-CC-1.0.json",
+      "referenceNumber": 18,
       "name": "GPL Cooperation Commitment 1.0",
       "licenseExceptionId": "GPL-CC-1.0",
       "seeAlso": [
@@ -396,10 +417,10 @@
       ]
     },
     {
-      "reference": "./GStreamer-exception-2005.json",
+      "reference": "https://spdx.org/licenses/GStreamer-exception-2005.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./GStreamer-exception-2005.html",
-      "referenceNumber": 63,
+      "detailsUrl": "https://spdx.org/licenses/GStreamer-exception-2005.json",
+      "referenceNumber": 72,
       "name": "GStreamer Exception (2005)",
       "licenseExceptionId": "GStreamer-exception-2005",
       "seeAlso": [
@@ -407,10 +428,10 @@
       ]
     },
     {
-      "reference": "./GStreamer-exception-2008.json",
+      "reference": "https://spdx.org/licenses/GStreamer-exception-2008.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./GStreamer-exception-2008.html",
-      "referenceNumber": 30,
+      "detailsUrl": "https://spdx.org/licenses/GStreamer-exception-2008.json",
+      "referenceNumber": 6,
       "name": "GStreamer Exception (2008)",
       "licenseExceptionId": "GStreamer-exception-2008",
       "seeAlso": [
@@ -418,10 +439,21 @@
       ]
     },
     {
-      "reference": "./i2p-gpl-java-exception.json",
+      "reference": "https://spdx.org/licenses/harbour-exception.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./i2p-gpl-java-exception.html",
-      "referenceNumber": 36,
+      "detailsUrl": "https://spdx.org/licenses/harbour-exception.json",
+      "referenceNumber": 7,
+      "name": "harbour exception",
+      "licenseExceptionId": "harbour-exception",
+      "seeAlso": [
+        "https://github.com/harbour/core/blob/master/LICENSE.txt#L44-L66"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/i2p-gpl-java-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/i2p-gpl-java-exception.json",
+      "referenceNumber": 40,
       "name": "i2p GPL+Java Exception",
       "licenseExceptionId": "i2p-gpl-java-exception",
       "seeAlso": [
@@ -429,10 +461,21 @@
       ]
     },
     {
-      "reference": "./KiCad-libraries-exception.json",
+      "reference": "https://spdx.org/licenses/Independent-modules-exception.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./KiCad-libraries-exception.html",
-      "referenceNumber": 10,
+      "detailsUrl": "https://spdx.org/licenses/Independent-modules-exception.json",
+      "referenceNumber": 61,
+      "name": "Independent Module Linking exception",
+      "licenseExceptionId": "Independent-modules-exception",
+      "seeAlso": [
+        "https://gitlab.com/freepascal.org/fpc/source/-/blob/release_3_2_2/rtl/COPYING.FPC"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/KiCad-libraries-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/KiCad-libraries-exception.json",
+      "referenceNumber": 68,
       "name": "KiCad Libraries Exception",
       "licenseExceptionId": "KiCad-libraries-exception",
       "seeAlso": [
@@ -440,10 +483,10 @@
       ]
     },
     {
-      "reference": "./LGPL-3.0-linking-exception.json",
+      "reference": "https://spdx.org/licenses/LGPL-3.0-linking-exception.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./LGPL-3.0-linking-exception.html",
-      "referenceNumber": 31,
+      "detailsUrl": "https://spdx.org/licenses/LGPL-3.0-linking-exception.json",
+      "referenceNumber": 33,
       "name": "LGPL-3.0 Linking Exception",
       "licenseExceptionId": "LGPL-3.0-linking-exception",
       "seeAlso": [
@@ -453,10 +496,10 @@
       ]
     },
     {
-      "reference": "./libpri-OpenH323-exception.json",
+      "reference": "https://spdx.org/licenses/libpri-OpenH323-exception.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./libpri-OpenH323-exception.html",
-      "referenceNumber": 15,
+      "detailsUrl": "https://spdx.org/licenses/libpri-OpenH323-exception.json",
+      "referenceNumber": 55,
       "name": "libpri OpenH323 exception",
       "licenseExceptionId": "libpri-OpenH323-exception",
       "seeAlso": [
@@ -464,10 +507,10 @@
       ]
     },
     {
-      "reference": "./Libtool-exception.json",
+      "reference": "https://spdx.org/licenses/Libtool-exception.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./Libtool-exception.html",
-      "referenceNumber": 20,
+      "detailsUrl": "https://spdx.org/licenses/Libtool-exception.json",
+      "referenceNumber": 15,
       "name": "Libtool Exception",
       "licenseExceptionId": "Libtool-exception",
       "seeAlso": [
@@ -476,10 +519,10 @@
       ]
     },
     {
-      "reference": "./Linux-syscall-note.json",
+      "reference": "https://spdx.org/licenses/Linux-syscall-note.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./Linux-syscall-note.html",
-      "referenceNumber": 52,
+      "detailsUrl": "https://spdx.org/licenses/Linux-syscall-note.json",
+      "referenceNumber": 22,
       "name": "Linux Syscall Note",
       "licenseExceptionId": "Linux-syscall-note",
       "seeAlso": [
@@ -487,10 +530,10 @@
       ]
     },
     {
-      "reference": "./LLGPL.json",
+      "reference": "https://spdx.org/licenses/LLGPL.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./LLGPL.html",
-      "referenceNumber": 37,
+      "detailsUrl": "https://spdx.org/licenses/LLGPL.json",
+      "referenceNumber": 3,
       "name": "LLGPL Preamble",
       "licenseExceptionId": "LLGPL",
       "seeAlso": [
@@ -498,10 +541,10 @@
       ]
     },
     {
-      "reference": "./LLVM-exception.json",
+      "reference": "https://spdx.org/licenses/LLVM-exception.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./LLVM-exception.html",
-      "referenceNumber": 1,
+      "detailsUrl": "https://spdx.org/licenses/LLVM-exception.json",
+      "referenceNumber": 74,
       "name": "LLVM Exception",
       "licenseExceptionId": "LLVM-exception",
       "seeAlso": [
@@ -509,10 +552,10 @@
       ]
     },
     {
-      "reference": "./LZMA-exception.json",
+      "reference": "https://spdx.org/licenses/LZMA-exception.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./LZMA-exception.html",
-      "referenceNumber": 61,
+      "detailsUrl": "https://spdx.org/licenses/LZMA-exception.json",
+      "referenceNumber": 32,
       "name": "LZMA exception",
       "licenseExceptionId": "LZMA-exception",
       "seeAlso": [
@@ -520,10 +563,10 @@
       ]
     },
     {
-      "reference": "./mif-exception.json",
+      "reference": "https://spdx.org/licenses/mif-exception.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./mif-exception.html",
-      "referenceNumber": 7,
+      "detailsUrl": "https://spdx.org/licenses/mif-exception.json",
+      "referenceNumber": 75,
       "name": "Macros and Inline Functions Exception",
       "licenseExceptionId": "mif-exception",
       "seeAlso": [
@@ -533,10 +576,22 @@
       ]
     },
     {
-      "reference": "./Nokia-Qt-exception-1.1.json",
+      "reference": "https://spdx.org/licenses/mxml-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/mxml-exception.json",
+      "referenceNumber": 21,
+      "name": "mxml Exception",
+      "licenseExceptionId": "mxml-exception",
+      "seeAlso": [
+        "https://github.com/michaelrsweet/mxml/blob/master/NOTICE",
+        "https://github.com/michaelrsweet/mxml/blob/master/LICENSE"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/Nokia-Qt-exception-1.1.html",
       "isDeprecatedLicenseId": true,
-      "detailsUrl": "./Nokia-Qt-exception-1.1.html",
-      "referenceNumber": 13,
+      "detailsUrl": "https://spdx.org/licenses/Nokia-Qt-exception-1.1.json",
+      "referenceNumber": 51,
       "name": "Nokia Qt LGPL exception 1.1",
       "licenseExceptionId": "Nokia-Qt-exception-1.1",
       "seeAlso": [
@@ -544,10 +599,10 @@
       ]
     },
     {
-      "reference": "./OCaml-LGPL-linking-exception.json",
+      "reference": "https://spdx.org/licenses/OCaml-LGPL-linking-exception.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./OCaml-LGPL-linking-exception.html",
-      "referenceNumber": 2,
+      "detailsUrl": "https://spdx.org/licenses/OCaml-LGPL-linking-exception.json",
+      "referenceNumber": 35,
       "name": "OCaml LGPL Linking Exception",
       "licenseExceptionId": "OCaml-LGPL-linking-exception",
       "seeAlso": [
@@ -555,10 +610,10 @@
       ]
     },
     {
-      "reference": "./OCCT-exception-1.0.json",
+      "reference": "https://spdx.org/licenses/OCCT-exception-1.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./OCCT-exception-1.0.html",
-      "referenceNumber": 49,
+      "detailsUrl": "https://spdx.org/licenses/OCCT-exception-1.0.json",
+      "referenceNumber": 70,
       "name": "Open CASCADE Exception 1.0",
       "licenseExceptionId": "OCCT-exception-1.0",
       "seeAlso": [
@@ -566,10 +621,10 @@
       ]
     },
     {
-      "reference": "./OpenJDK-assembly-exception-1.0.json",
+      "reference": "https://spdx.org/licenses/OpenJDK-assembly-exception-1.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./OpenJDK-assembly-exception-1.0.html",
-      "referenceNumber": 44,
+      "detailsUrl": "https://spdx.org/licenses/OpenJDK-assembly-exception-1.0.json",
+      "referenceNumber": 77,
       "name": "OpenJDK Assembly exception 1.0",
       "licenseExceptionId": "OpenJDK-assembly-exception-1.0",
       "seeAlso": [
@@ -577,10 +632,10 @@
       ]
     },
     {
-      "reference": "./openvpn-openssl-exception.json",
+      "reference": "https://spdx.org/licenses/openvpn-openssl-exception.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./openvpn-openssl-exception.html",
-      "referenceNumber": 29,
+      "detailsUrl": "https://spdx.org/licenses/openvpn-openssl-exception.json",
+      "referenceNumber": 9,
       "name": "OpenVPN OpenSSL Exception",
       "licenseExceptionId": "openvpn-openssl-exception",
       "seeAlso": [
@@ -589,10 +644,10 @@
       ]
     },
     {
-      "reference": "./PCRE2-exception.json",
+      "reference": "https://spdx.org/licenses/PCRE2-exception.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./PCRE2-exception.html",
-      "referenceNumber": 8,
+      "detailsUrl": "https://spdx.org/licenses/PCRE2-exception.json",
+      "referenceNumber": 76,
       "name": "PCRE2 exception",
       "licenseExceptionId": "PCRE2-exception",
       "seeAlso": [
@@ -600,10 +655,10 @@
       ]
     },
     {
-      "reference": "./PS-or-PDF-font-exception-20170817.json",
+      "reference": "https://spdx.org/licenses/PS-or-PDF-font-exception-20170817.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./PS-or-PDF-font-exception-20170817.html",
-      "referenceNumber": 16,
+      "detailsUrl": "https://spdx.org/licenses/PS-or-PDF-font-exception-20170817.json",
+      "referenceNumber": 4,
       "name": "PS/PDF font exception (2017-08-17)",
       "licenseExceptionId": "PS-or-PDF-font-exception-20170817",
       "seeAlso": [
@@ -611,10 +666,10 @@
       ]
     },
     {
-      "reference": "./QPL-1.0-INRIA-2004-exception.json",
+      "reference": "https://spdx.org/licenses/QPL-1.0-INRIA-2004-exception.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./QPL-1.0-INRIA-2004-exception.html",
-      "referenceNumber": 68,
+      "detailsUrl": "https://spdx.org/licenses/QPL-1.0-INRIA-2004-exception.json",
+      "referenceNumber": 48,
       "name": "INRIA QPL 1.0 2004 variant exception",
       "licenseExceptionId": "QPL-1.0-INRIA-2004-exception",
       "seeAlso": [
@@ -623,10 +678,10 @@
       ]
     },
     {
-      "reference": "./Qt-GPL-exception-1.0.json",
+      "reference": "https://spdx.org/licenses/Qt-GPL-exception-1.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./Qt-GPL-exception-1.0.html",
-      "referenceNumber": 50,
+      "detailsUrl": "https://spdx.org/licenses/Qt-GPL-exception-1.0.json",
+      "referenceNumber": 45,
       "name": "Qt GPL exception 1.0",
       "licenseExceptionId": "Qt-GPL-exception-1.0",
       "seeAlso": [
@@ -634,10 +689,10 @@
       ]
     },
     {
-      "reference": "./Qt-LGPL-exception-1.1.json",
+      "reference": "https://spdx.org/licenses/Qt-LGPL-exception-1.1.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./Qt-LGPL-exception-1.1.html",
-      "referenceNumber": 38,
+      "detailsUrl": "https://spdx.org/licenses/Qt-LGPL-exception-1.1.json",
+      "referenceNumber": 73,
       "name": "Qt LGPL exception 1.1",
       "licenseExceptionId": "Qt-LGPL-exception-1.1",
       "seeAlso": [
@@ -645,10 +700,10 @@
       ]
     },
     {
-      "reference": "./Qwt-exception-1.0.json",
+      "reference": "https://spdx.org/licenses/Qwt-exception-1.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./Qwt-exception-1.0.html",
-      "referenceNumber": 25,
+      "detailsUrl": "https://spdx.org/licenses/Qwt-exception-1.0.json",
+      "referenceNumber": 11,
       "name": "Qwt exception 1.0",
       "licenseExceptionId": "Qwt-exception-1.0",
       "seeAlso": [
@@ -656,10 +711,10 @@
       ]
     },
     {
-      "reference": "./romic-exception.json",
+      "reference": "https://spdx.org/licenses/romic-exception.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./romic-exception.html",
-      "referenceNumber": 22,
+      "detailsUrl": "https://spdx.org/licenses/romic-exception.json",
+      "referenceNumber": 28,
       "name": "Romic Exception",
       "licenseExceptionId": "romic-exception",
       "seeAlso": [
@@ -672,10 +727,10 @@
       ]
     },
     {
-      "reference": "./RRDtool-FLOSS-exception-2.0.json",
+      "reference": "https://spdx.org/licenses/RRDtool-FLOSS-exception-2.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./RRDtool-FLOSS-exception-2.0.html",
-      "referenceNumber": 4,
+      "detailsUrl": "https://spdx.org/licenses/RRDtool-FLOSS-exception-2.0.json",
+      "referenceNumber": 29,
       "name": "RRDtool FLOSS exception 2.0",
       "licenseExceptionId": "RRDtool-FLOSS-exception-2.0",
       "seeAlso": [
@@ -684,10 +739,10 @@
       ]
     },
     {
-      "reference": "./SANE-exception.json",
+      "reference": "https://spdx.org/licenses/SANE-exception.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./SANE-exception.html",
-      "referenceNumber": 11,
+      "detailsUrl": "https://spdx.org/licenses/SANE-exception.json",
+      "referenceNumber": 26,
       "name": "SANE Exception",
       "licenseExceptionId": "SANE-exception",
       "seeAlso": [
@@ -697,10 +752,10 @@
       ]
     },
     {
-      "reference": "./SHL-2.0.json",
+      "reference": "https://spdx.org/licenses/SHL-2.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./SHL-2.0.html",
-      "referenceNumber": 56,
+      "detailsUrl": "https://spdx.org/licenses/SHL-2.0.json",
+      "referenceNumber": 30,
       "name": "Solderpad Hardware License v2.0",
       "licenseExceptionId": "SHL-2.0",
       "seeAlso": [
@@ -708,10 +763,10 @@
       ]
     },
     {
-      "reference": "./SHL-2.1.json",
+      "reference": "https://spdx.org/licenses/SHL-2.1.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./SHL-2.1.html",
-      "referenceNumber": 65,
+      "detailsUrl": "https://spdx.org/licenses/SHL-2.1.json",
+      "referenceNumber": 36,
       "name": "Solderpad Hardware License v2.1",
       "licenseExceptionId": "SHL-2.1",
       "seeAlso": [
@@ -719,10 +774,10 @@
       ]
     },
     {
-      "reference": "./stunnel-exception.json",
+      "reference": "https://spdx.org/licenses/stunnel-exception.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./stunnel-exception.html",
-      "referenceNumber": 70,
+      "detailsUrl": "https://spdx.org/licenses/stunnel-exception.json",
+      "referenceNumber": 60,
       "name": "stunnel Exception",
       "licenseExceptionId": "stunnel-exception",
       "seeAlso": [
@@ -730,10 +785,10 @@
       ]
     },
     {
-      "reference": "./SWI-exception.json",
+      "reference": "https://spdx.org/licenses/SWI-exception.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./SWI-exception.html",
-      "referenceNumber": 41,
+      "detailsUrl": "https://spdx.org/licenses/SWI-exception.json",
+      "referenceNumber": 46,
       "name": "SWI exception",
       "licenseExceptionId": "SWI-exception",
       "seeAlso": [
@@ -741,10 +796,10 @@
       ]
     },
     {
-      "reference": "./Swift-exception.json",
+      "reference": "https://spdx.org/licenses/Swift-exception.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./Swift-exception.html",
-      "referenceNumber": 33,
+      "detailsUrl": "https://spdx.org/licenses/Swift-exception.json",
+      "referenceNumber": 56,
       "name": "Swift Exception",
       "licenseExceptionId": "Swift-exception",
       "seeAlso": [
@@ -753,10 +808,10 @@
       ]
     },
     {
-      "reference": "./Texinfo-exception.json",
+      "reference": "https://spdx.org/licenses/Texinfo-exception.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./Texinfo-exception.html",
-      "referenceNumber": 67,
+      "detailsUrl": "https://spdx.org/licenses/Texinfo-exception.json",
+      "referenceNumber": 62,
       "name": "Texinfo exception",
       "licenseExceptionId": "Texinfo-exception",
       "seeAlso": [
@@ -764,10 +819,10 @@
       ]
     },
     {
-      "reference": "./u-boot-exception-2.0.json",
+      "reference": "https://spdx.org/licenses/u-boot-exception-2.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./u-boot-exception-2.0.html",
-      "referenceNumber": 3,
+      "detailsUrl": "https://spdx.org/licenses/u-boot-exception-2.0.json",
+      "referenceNumber": 5,
       "name": "U-Boot exception 2.0",
       "licenseExceptionId": "u-boot-exception-2.0",
       "seeAlso": [
@@ -775,10 +830,10 @@
       ]
     },
     {
-      "reference": "./UBDL-exception.json",
+      "reference": "https://spdx.org/licenses/UBDL-exception.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./UBDL-exception.html",
-      "referenceNumber": 62,
+      "detailsUrl": "https://spdx.org/licenses/UBDL-exception.json",
+      "referenceNumber": 23,
       "name": "Unmodified Binary Distribution exception",
       "licenseExceptionId": "UBDL-exception",
       "seeAlso": [
@@ -786,10 +841,10 @@
       ]
     },
     {
-      "reference": "./Universal-FOSS-exception-1.0.json",
+      "reference": "https://spdx.org/licenses/Universal-FOSS-exception-1.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./Universal-FOSS-exception-1.0.html",
-      "referenceNumber": 42,
+      "detailsUrl": "https://spdx.org/licenses/Universal-FOSS-exception-1.0.json",
+      "referenceNumber": 52,
       "name": "Universal FOSS Exception, Version 1.0",
       "licenseExceptionId": "Universal-FOSS-exception-1.0",
       "seeAlso": [
@@ -797,10 +852,10 @@
       ]
     },
     {
-      "reference": "./vsftpd-openssl-exception.json",
+      "reference": "https://spdx.org/licenses/vsftpd-openssl-exception.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./vsftpd-openssl-exception.html",
-      "referenceNumber": 32,
+      "detailsUrl": "https://spdx.org/licenses/vsftpd-openssl-exception.json",
+      "referenceNumber": 39,
       "name": "vsftpd OpenSSL exception",
       "licenseExceptionId": "vsftpd-openssl-exception",
       "seeAlso": [
@@ -810,10 +865,10 @@
       ]
     },
     {
-      "reference": "./WxWindows-exception-3.1.json",
+      "reference": "https://spdx.org/licenses/WxWindows-exception-3.1.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./WxWindows-exception-3.1.html",
-      "referenceNumber": 57,
+      "detailsUrl": "https://spdx.org/licenses/WxWindows-exception-3.1.json",
+      "referenceNumber": 49,
       "name": "WxWindows Library Exception 3.1",
       "licenseExceptionId": "WxWindows-exception-3.1",
       "seeAlso": [
@@ -821,10 +876,10 @@
       ]
     },
     {
-      "reference": "./x11vnc-openssl-exception.json",
+      "reference": "https://spdx.org/licenses/x11vnc-openssl-exception.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "./x11vnc-openssl-exception.html",
-      "referenceNumber": 47,
+      "detailsUrl": "https://spdx.org/licenses/x11vnc-openssl-exception.json",
+      "referenceNumber": 31,
       "name": "x11vnc OpenSSL Exception",
       "licenseExceptionId": "x11vnc-openssl-exception",
       "seeAlso": [
@@ -832,5 +887,5 @@
       ]
     }
   ],
-  "releaseDate": "2024-08-19"
+  "releaseDate": "2024-12-30T00:00:00Z"
 }

--- a/src/reuse/resources/licenses.json
+++ b/src/reuse/resources/licenses.json
@@ -1,11 +1,11 @@
 {
-  "licenseListVersion": "3.25.0",
+  "licenseListVersion": "3.26.0",
   "licenses": [
     {
       "reference": "https://spdx.org/licenses/0BSD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/0BSD.json",
-      "referenceNumber": 582,
+      "referenceNumber": 502,
       "name": "BSD Zero Clause License",
       "licenseId": "0BSD",
       "seeAlso": [
@@ -18,7 +18,7 @@
       "reference": "https://spdx.org/licenses/3D-Slicer-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/3D-Slicer-1.0.json",
-      "referenceNumber": 466,
+      "referenceNumber": 490,
       "name": "3D Slicer License v1.0",
       "licenseId": "3D-Slicer-1.0",
       "seeAlso": [
@@ -31,7 +31,7 @@
       "reference": "https://spdx.org/licenses/AAL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AAL.json",
-      "referenceNumber": 252,
+      "referenceNumber": 136,
       "name": "Attribution Assurance License",
       "licenseId": "AAL",
       "seeAlso": [
@@ -43,7 +43,7 @@
       "reference": "https://spdx.org/licenses/Abstyles.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Abstyles.json",
-      "referenceNumber": 456,
+      "referenceNumber": 641,
       "name": "Abstyles License",
       "licenseId": "Abstyles",
       "seeAlso": [
@@ -55,7 +55,7 @@
       "reference": "https://spdx.org/licenses/AdaCore-doc.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AdaCore-doc.json",
-      "referenceNumber": 355,
+      "referenceNumber": 403,
       "name": "AdaCore Doc License",
       "licenseId": "AdaCore-doc",
       "seeAlso": [
@@ -69,7 +69,7 @@
       "reference": "https://spdx.org/licenses/Adobe-2006.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Adobe-2006.json",
-      "referenceNumber": 128,
+      "referenceNumber": 131,
       "name": "Adobe Systems Incorporated Source Code License Agreement",
       "licenseId": "Adobe-2006",
       "seeAlso": [
@@ -81,7 +81,7 @@
       "reference": "https://spdx.org/licenses/Adobe-Display-PostScript.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Adobe-Display-PostScript.json",
-      "referenceNumber": 433,
+      "referenceNumber": 366,
       "name": "Adobe Display PostScript License",
       "licenseId": "Adobe-Display-PostScript",
       "seeAlso": [
@@ -93,7 +93,7 @@
       "reference": "https://spdx.org/licenses/Adobe-Glyph.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Adobe-Glyph.json",
-      "referenceNumber": 125,
+      "referenceNumber": 510,
       "name": "Adobe Glyph List License",
       "licenseId": "Adobe-Glyph",
       "seeAlso": [
@@ -105,7 +105,7 @@
       "reference": "https://spdx.org/licenses/Adobe-Utopia.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Adobe-Utopia.json",
-      "referenceNumber": 495,
+      "referenceNumber": 591,
       "name": "Adobe Utopia Font License",
       "licenseId": "Adobe-Utopia",
       "seeAlso": [
@@ -117,7 +117,7 @@
       "reference": "https://spdx.org/licenses/ADSL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ADSL.json",
-      "referenceNumber": 560,
+      "referenceNumber": 45,
       "name": "Amazon Digital Services License",
       "licenseId": "ADSL",
       "seeAlso": [
@@ -129,7 +129,7 @@
       "reference": "https://spdx.org/licenses/AFL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AFL-1.1.json",
-      "referenceNumber": 14,
+      "referenceNumber": 428,
       "name": "Academic Free License v1.1",
       "licenseId": "AFL-1.1",
       "seeAlso": [
@@ -143,7 +143,7 @@
       "reference": "https://spdx.org/licenses/AFL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AFL-1.2.json",
-      "referenceNumber": 622,
+      "referenceNumber": 292,
       "name": "Academic Free License v1.2",
       "licenseId": "AFL-1.2",
       "seeAlso": [
@@ -157,7 +157,7 @@
       "reference": "https://spdx.org/licenses/AFL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AFL-2.0.json",
-      "referenceNumber": 559,
+      "referenceNumber": 356,
       "name": "Academic Free License v2.0",
       "licenseId": "AFL-2.0",
       "seeAlso": [
@@ -170,7 +170,7 @@
       "reference": "https://spdx.org/licenses/AFL-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AFL-2.1.json",
-      "referenceNumber": 570,
+      "referenceNumber": 219,
       "name": "Academic Free License v2.1",
       "licenseId": "AFL-2.1",
       "seeAlso": [
@@ -183,7 +183,7 @@
       "reference": "https://spdx.org/licenses/AFL-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AFL-3.0.json",
-      "referenceNumber": 332,
+      "referenceNumber": 121,
       "name": "Academic Free License v3.0",
       "licenseId": "AFL-3.0",
       "seeAlso": [
@@ -197,7 +197,7 @@
       "reference": "https://spdx.org/licenses/Afmparse.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Afmparse.json",
-      "referenceNumber": 163,
+      "referenceNumber": 328,
       "name": "Afmparse License",
       "licenseId": "Afmparse",
       "seeAlso": [
@@ -209,7 +209,7 @@
       "reference": "https://spdx.org/licenses/AGPL-1.0.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/AGPL-1.0.json",
-      "referenceNumber": 657,
+      "referenceNumber": 326,
       "name": "Affero General Public License v1.0",
       "licenseId": "AGPL-1.0",
       "seeAlso": [
@@ -222,7 +222,7 @@
       "reference": "https://spdx.org/licenses/AGPL-1.0-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AGPL-1.0-only.json",
-      "referenceNumber": 142,
+      "referenceNumber": 404,
       "name": "Affero General Public License v1.0 only",
       "licenseId": "AGPL-1.0-only",
       "seeAlso": [
@@ -234,7 +234,7 @@
       "reference": "https://spdx.org/licenses/AGPL-1.0-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AGPL-1.0-or-later.json",
-      "referenceNumber": 155,
+      "referenceNumber": 444,
       "name": "Affero General Public License v1.0 or later",
       "licenseId": "AGPL-1.0-or-later",
       "seeAlso": [
@@ -246,7 +246,7 @@
       "reference": "https://spdx.org/licenses/AGPL-3.0.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/AGPL-3.0.json",
-      "referenceNumber": 70,
+      "referenceNumber": 517,
       "name": "GNU Affero General Public License v3.0",
       "licenseId": "AGPL-3.0",
       "seeAlso": [
@@ -260,7 +260,7 @@
       "reference": "https://spdx.org/licenses/AGPL-3.0-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AGPL-3.0-only.json",
-      "referenceNumber": 330,
+      "referenceNumber": 180,
       "name": "GNU Affero General Public License v3.0 only",
       "licenseId": "AGPL-3.0-only",
       "seeAlso": [
@@ -274,7 +274,7 @@
       "reference": "https://spdx.org/licenses/AGPL-3.0-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AGPL-3.0-or-later.json",
-      "referenceNumber": 366,
+      "referenceNumber": 543,
       "name": "GNU Affero General Public License v3.0 or later",
       "licenseId": "AGPL-3.0-or-later",
       "seeAlso": [
@@ -288,7 +288,7 @@
       "reference": "https://spdx.org/licenses/Aladdin.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Aladdin.json",
-      "referenceNumber": 557,
+      "referenceNumber": 67,
       "name": "Aladdin Free Public License",
       "licenseId": "Aladdin",
       "seeAlso": [
@@ -301,7 +301,7 @@
       "reference": "https://spdx.org/licenses/AMD-newlib.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AMD-newlib.json",
-      "referenceNumber": 340,
+      "referenceNumber": 413,
       "name": "AMD newlib License",
       "licenseId": "AMD-newlib",
       "seeAlso": [
@@ -313,7 +313,7 @@
       "reference": "https://spdx.org/licenses/AMDPLPA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AMDPLPA.json",
-      "referenceNumber": 467,
+      "referenceNumber": 529,
       "name": "AMD\u0027s plpa_map.c License",
       "licenseId": "AMDPLPA",
       "seeAlso": [
@@ -325,7 +325,7 @@
       "reference": "https://spdx.org/licenses/AML.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AML.json",
-      "referenceNumber": 299,
+      "referenceNumber": 553,
       "name": "Apple MIT License",
       "licenseId": "AML",
       "seeAlso": [
@@ -337,7 +337,7 @@
       "reference": "https://spdx.org/licenses/AML-glslang.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AML-glslang.json",
-      "referenceNumber": 567,
+      "referenceNumber": 27,
       "name": "AML glslang variant License",
       "licenseId": "AML-glslang",
       "seeAlso": [
@@ -350,7 +350,7 @@
       "reference": "https://spdx.org/licenses/AMPAS.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AMPAS.json",
-      "referenceNumber": 414,
+      "referenceNumber": 79,
       "name": "Academy of Motion Picture Arts and Sciences BSD",
       "licenseId": "AMPAS",
       "seeAlso": [
@@ -362,7 +362,7 @@
       "reference": "https://spdx.org/licenses/ANTLR-PD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ANTLR-PD.json",
-      "referenceNumber": 460,
+      "referenceNumber": 454,
       "name": "ANTLR Software Rights Notice",
       "licenseId": "ANTLR-PD",
       "seeAlso": [
@@ -374,7 +374,7 @@
       "reference": "https://spdx.org/licenses/ANTLR-PD-fallback.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ANTLR-PD-fallback.json",
-      "referenceNumber": 65,
+      "referenceNumber": 635,
       "name": "ANTLR Software Rights Notice with license fallback",
       "licenseId": "ANTLR-PD-fallback",
       "seeAlso": [
@@ -386,7 +386,7 @@
       "reference": "https://spdx.org/licenses/any-OSI.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/any-OSI.json",
-      "referenceNumber": 310,
+      "referenceNumber": 117,
       "name": "Any OSI License",
       "licenseId": "any-OSI",
       "seeAlso": [
@@ -395,10 +395,24 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/any-OSI-perl-modules.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/any-OSI-perl-modules.json",
+      "referenceNumber": 286,
+      "name": "Any OSI License - Perl Modules",
+      "licenseId": "any-OSI-perl-modules",
+      "seeAlso": [
+        "https://metacpan.org/release/JUERD/Exporter-Tidy-0.09/view/Tidy.pm#LICENSE",
+        "https://metacpan.org/pod/Qmail::Deliverable::Client#LICENSE",
+        "https://metacpan.org/pod/Net::MQTT::Simple#LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/Apache-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Apache-1.0.json",
-      "referenceNumber": 250,
+      "referenceNumber": 347,
       "name": "Apache License 1.0",
       "licenseId": "Apache-1.0",
       "seeAlso": [
@@ -411,7 +425,7 @@
       "reference": "https://spdx.org/licenses/Apache-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Apache-1.1.json",
-      "referenceNumber": 288,
+      "referenceNumber": 628,
       "name": "Apache License 1.1",
       "licenseId": "Apache-1.1",
       "seeAlso": [
@@ -425,7 +439,7 @@
       "reference": "https://spdx.org/licenses/Apache-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Apache-2.0.json",
-      "referenceNumber": 143,
+      "referenceNumber": 418,
       "name": "Apache License 2.0",
       "licenseId": "Apache-2.0",
       "seeAlso": [
@@ -439,7 +453,7 @@
       "reference": "https://spdx.org/licenses/APAFML.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/APAFML.json",
-      "referenceNumber": 636,
+      "referenceNumber": 575,
       "name": "Adobe Postscript AFM License",
       "licenseId": "APAFML",
       "seeAlso": [
@@ -451,7 +465,7 @@
       "reference": "https://spdx.org/licenses/APL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/APL-1.0.json",
-      "referenceNumber": 85,
+      "referenceNumber": 233,
       "name": "Adaptive Public License 1.0",
       "licenseId": "APL-1.0",
       "seeAlso": [
@@ -463,7 +477,7 @@
       "reference": "https://spdx.org/licenses/App-s2p.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/App-s2p.json",
-      "referenceNumber": 238,
+      "referenceNumber": 612,
       "name": "App::s2p License",
       "licenseId": "App-s2p",
       "seeAlso": [
@@ -475,7 +489,7 @@
       "reference": "https://spdx.org/licenses/APSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/APSL-1.0.json",
-      "referenceNumber": 335,
+      "referenceNumber": 263,
       "name": "Apple Public Source License 1.0",
       "licenseId": "APSL-1.0",
       "seeAlso": [
@@ -488,7 +502,7 @@
       "reference": "https://spdx.org/licenses/APSL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/APSL-1.1.json",
-      "referenceNumber": 308,
+      "referenceNumber": 381,
       "name": "Apple Public Source License 1.1",
       "licenseId": "APSL-1.1",
       "seeAlso": [
@@ -500,7 +514,7 @@
       "reference": "https://spdx.org/licenses/APSL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/APSL-1.2.json",
-      "referenceNumber": 280,
+      "referenceNumber": 262,
       "name": "Apple Public Source License 1.2",
       "licenseId": "APSL-1.2",
       "seeAlso": [
@@ -512,7 +526,7 @@
       "reference": "https://spdx.org/licenses/APSL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/APSL-2.0.json",
-      "referenceNumber": 592,
+      "referenceNumber": 438,
       "name": "Apple Public Source License 2.0",
       "licenseId": "APSL-2.0",
       "seeAlso": [
@@ -525,7 +539,7 @@
       "reference": "https://spdx.org/licenses/Arphic-1999.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Arphic-1999.json",
-      "referenceNumber": 32,
+      "referenceNumber": 122,
       "name": "Arphic Public License",
       "licenseId": "Arphic-1999",
       "seeAlso": [
@@ -537,7 +551,7 @@
       "reference": "https://spdx.org/licenses/Artistic-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Artistic-1.0.json",
-      "referenceNumber": 138,
+      "referenceNumber": 580,
       "name": "Artistic License 1.0",
       "licenseId": "Artistic-1.0",
       "seeAlso": [
@@ -550,7 +564,7 @@
       "reference": "https://spdx.org/licenses/Artistic-1.0-cl8.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Artistic-1.0-cl8.json",
-      "referenceNumber": 353,
+      "referenceNumber": 205,
       "name": "Artistic License 1.0 w/clause 8",
       "licenseId": "Artistic-1.0-cl8",
       "seeAlso": [
@@ -562,7 +576,7 @@
       "reference": "https://spdx.org/licenses/Artistic-1.0-Perl.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Artistic-1.0-Perl.json",
-      "referenceNumber": 660,
+      "referenceNumber": 183,
       "name": "Artistic License 1.0 (Perl)",
       "licenseId": "Artistic-1.0-Perl",
       "seeAlso": [
@@ -574,7 +588,7 @@
       "reference": "https://spdx.org/licenses/Artistic-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Artistic-2.0.json",
-      "referenceNumber": 277,
+      "referenceNumber": 519,
       "name": "Artistic License 2.0",
       "licenseId": "Artistic-2.0",
       "seeAlso": [
@@ -589,7 +603,7 @@
       "reference": "https://spdx.org/licenses/ASWF-Digital-Assets-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ASWF-Digital-Assets-1.0.json",
-      "referenceNumber": 166,
+      "referenceNumber": 380,
       "name": "ASWF Digital Assets License version 1.0",
       "licenseId": "ASWF-Digital-Assets-1.0",
       "seeAlso": [
@@ -601,7 +615,7 @@
       "reference": "https://spdx.org/licenses/ASWF-Digital-Assets-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ASWF-Digital-Assets-1.1.json",
-      "referenceNumber": 29,
+      "referenceNumber": 7,
       "name": "ASWF Digital Assets License 1.1",
       "licenseId": "ASWF-Digital-Assets-1.1",
       "seeAlso": [
@@ -613,7 +627,7 @@
       "reference": "https://spdx.org/licenses/Baekmuk.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Baekmuk.json",
-      "referenceNumber": 380,
+      "referenceNumber": 434,
       "name": "Baekmuk License",
       "licenseId": "Baekmuk",
       "seeAlso": [
@@ -625,7 +639,7 @@
       "reference": "https://spdx.org/licenses/Bahyph.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Bahyph.json",
-      "referenceNumber": 368,
+      "referenceNumber": 312,
       "name": "Bahyph License",
       "licenseId": "Bahyph",
       "seeAlso": [
@@ -637,7 +651,7 @@
       "reference": "https://spdx.org/licenses/Barr.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Barr.json",
-      "referenceNumber": 195,
+      "referenceNumber": 93,
       "name": "Barr License",
       "licenseId": "Barr",
       "seeAlso": [
@@ -649,7 +663,7 @@
       "reference": "https://spdx.org/licenses/bcrypt-Solar-Designer.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/bcrypt-Solar-Designer.json",
-      "referenceNumber": 478,
+      "referenceNumber": 624,
       "name": "bcrypt Solar Designer License",
       "licenseId": "bcrypt-Solar-Designer",
       "seeAlso": [
@@ -661,7 +675,7 @@
       "reference": "https://spdx.org/licenses/Beerware.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Beerware.json",
-      "referenceNumber": 616,
+      "referenceNumber": 429,
       "name": "Beerware License",
       "licenseId": "Beerware",
       "seeAlso": [
@@ -674,7 +688,7 @@
       "reference": "https://spdx.org/licenses/Bitstream-Charter.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Bitstream-Charter.json",
-      "referenceNumber": 455,
+      "referenceNumber": 530,
       "name": "Bitstream Charter Font License",
       "licenseId": "Bitstream-Charter",
       "seeAlso": [
@@ -687,7 +701,7 @@
       "reference": "https://spdx.org/licenses/Bitstream-Vera.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Bitstream-Vera.json",
-      "referenceNumber": 370,
+      "referenceNumber": 194,
       "name": "Bitstream Vera Font License",
       "licenseId": "Bitstream-Vera",
       "seeAlso": [
@@ -700,7 +714,7 @@
       "reference": "https://spdx.org/licenses/BitTorrent-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BitTorrent-1.0.json",
-      "referenceNumber": 106,
+      "referenceNumber": 669,
       "name": "BitTorrent Open Source License v1.0",
       "licenseId": "BitTorrent-1.0",
       "seeAlso": [
@@ -712,7 +726,7 @@
       "reference": "https://spdx.org/licenses/BitTorrent-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BitTorrent-1.1.json",
-      "referenceNumber": 541,
+      "referenceNumber": 583,
       "name": "BitTorrent Open Source License v1.1",
       "licenseId": "BitTorrent-1.1",
       "seeAlso": [
@@ -725,7 +739,7 @@
       "reference": "https://spdx.org/licenses/blessing.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/blessing.json",
-      "referenceNumber": 359,
+      "referenceNumber": 667,
       "name": "SQLite Blessing",
       "licenseId": "blessing",
       "seeAlso": [
@@ -738,7 +752,7 @@
       "reference": "https://spdx.org/licenses/BlueOak-1.0.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BlueOak-1.0.0.json",
-      "referenceNumber": 606,
+      "referenceNumber": 191,
       "name": "Blue Oak Model License 1.0.0",
       "licenseId": "BlueOak-1.0.0",
       "seeAlso": [
@@ -750,7 +764,7 @@
       "reference": "https://spdx.org/licenses/Boehm-GC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Boehm-GC.json",
-      "referenceNumber": 127,
+      "referenceNumber": 540,
       "name": "Boehm-Demers-Weiser GC License",
       "licenseId": "Boehm-GC",
       "seeAlso": [
@@ -761,10 +775,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/Boehm-GC-without-fee.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Boehm-GC-without-fee.json",
+      "referenceNumber": 606,
+      "name": "Boehm-Demers-Weiser GC License (without fee)",
+      "licenseId": "Boehm-GC-without-fee",
+      "seeAlso": [
+        "https://github.com/MariaDB/server/blob/11.6/libmysqld/lib_sql.cc"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/Borceux.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Borceux.json",
-      "referenceNumber": 571,
+      "referenceNumber": 500,
       "name": "Borceux license",
       "licenseId": "Borceux",
       "seeAlso": [
@@ -776,7 +802,7 @@
       "reference": "https://spdx.org/licenses/Brian-Gladman-2-Clause.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Brian-Gladman-2-Clause.json",
-      "referenceNumber": 416,
+      "referenceNumber": 582,
       "name": "Brian Gladman 2-Clause License",
       "licenseId": "Brian-Gladman-2-Clause",
       "seeAlso": [
@@ -789,7 +815,7 @@
       "reference": "https://spdx.org/licenses/Brian-Gladman-3-Clause.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Brian-Gladman-3-Clause.json",
-      "referenceNumber": 290,
+      "referenceNumber": 360,
       "name": "Brian Gladman 3-Clause License",
       "licenseId": "Brian-Gladman-3-Clause",
       "seeAlso": [
@@ -801,7 +827,7 @@
       "reference": "https://spdx.org/licenses/BSD-1-Clause.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-1-Clause.json",
-      "referenceNumber": 419,
+      "referenceNumber": 101,
       "name": "BSD 1-Clause License",
       "licenseId": "BSD-1-Clause",
       "seeAlso": [
@@ -813,7 +839,7 @@
       "reference": "https://spdx.org/licenses/BSD-2-Clause.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause.json",
-      "referenceNumber": 229,
+      "referenceNumber": 61,
       "name": "BSD 2-Clause \"Simplified\" License",
       "licenseId": "BSD-2-Clause",
       "seeAlso": [
@@ -826,7 +852,7 @@
       "reference": "https://spdx.org/licenses/BSD-2-Clause-Darwin.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-Darwin.json",
-      "referenceNumber": 296,
+      "referenceNumber": 300,
       "name": "BSD 2-Clause - Ian Darwin variant",
       "licenseId": "BSD-2-Clause-Darwin",
       "seeAlso": [
@@ -838,7 +864,7 @@
       "reference": "https://spdx.org/licenses/BSD-2-Clause-first-lines.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-first-lines.json",
-      "referenceNumber": 217,
+      "referenceNumber": 271,
       "name": "BSD 2-Clause - first lines requirement",
       "licenseId": "BSD-2-Clause-first-lines",
       "seeAlso": [
@@ -851,7 +877,7 @@
       "reference": "https://spdx.org/licenses/BSD-2-Clause-FreeBSD.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-FreeBSD.json",
-      "referenceNumber": 564,
+      "referenceNumber": 388,
       "name": "BSD 2-Clause FreeBSD License",
       "licenseId": "BSD-2-Clause-FreeBSD",
       "seeAlso": [
@@ -864,7 +890,7 @@
       "reference": "https://spdx.org/licenses/BSD-2-Clause-NetBSD.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-NetBSD.json",
-      "referenceNumber": 376,
+      "referenceNumber": 230,
       "name": "BSD 2-Clause NetBSD License",
       "licenseId": "BSD-2-Clause-NetBSD",
       "seeAlso": [
@@ -877,7 +903,7 @@
       "reference": "https://spdx.org/licenses/BSD-2-Clause-Patent.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-Patent.json",
-      "referenceNumber": 4,
+      "referenceNumber": 601,
       "name": "BSD-2-Clause Plus Patent License",
       "licenseId": "BSD-2-Clause-Patent",
       "seeAlso": [
@@ -889,7 +915,7 @@
       "reference": "https://spdx.org/licenses/BSD-2-Clause-Views.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-Views.json",
-      "referenceNumber": 514,
+      "referenceNumber": 568,
       "name": "BSD 2-Clause with views sentence",
       "licenseId": "BSD-2-Clause-Views",
       "seeAlso": [
@@ -903,7 +929,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause.json",
-      "referenceNumber": 584,
+      "referenceNumber": 258,
       "name": "BSD 3-Clause \"New\" or \"Revised\" License",
       "licenseId": "BSD-3-Clause",
       "seeAlso": [
@@ -917,7 +943,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-acpica.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-acpica.json",
-      "referenceNumber": 341,
+      "referenceNumber": 613,
       "name": "BSD 3-Clause acpica variant",
       "licenseId": "BSD-3-Clause-acpica",
       "seeAlso": [
@@ -929,7 +955,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-Attribution.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Attribution.json",
-      "referenceNumber": 71,
+      "referenceNumber": 511,
       "name": "BSD with attribution",
       "licenseId": "BSD-3-Clause-Attribution",
       "seeAlso": [
@@ -941,7 +967,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-Clear.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Clear.json",
-      "referenceNumber": 253,
+      "referenceNumber": 26,
       "name": "BSD 3-Clause Clear License",
       "licenseId": "BSD-3-Clause-Clear",
       "seeAlso": [
@@ -954,7 +980,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-flex.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-flex.json",
-      "referenceNumber": 52,
+      "referenceNumber": 99,
       "name": "BSD 3-Clause Flex variant",
       "licenseId": "BSD-3-Clause-flex",
       "seeAlso": [
@@ -966,7 +992,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-HP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-HP.json",
-      "referenceNumber": 215,
+      "referenceNumber": 346,
       "name": "Hewlett-Packard BSD variant license",
       "licenseId": "BSD-3-Clause-HP",
       "seeAlso": [
@@ -978,7 +1004,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-LBNL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-LBNL.json",
-      "referenceNumber": 301,
+      "referenceNumber": 243,
       "name": "Lawrence Berkeley National Labs BSD variant license",
       "licenseId": "BSD-3-Clause-LBNL",
       "seeAlso": [
@@ -990,7 +1016,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-Modification.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Modification.json",
-      "referenceNumber": 47,
+      "referenceNumber": 489,
       "name": "BSD 3-Clause Modification",
       "licenseId": "BSD-3-Clause-Modification",
       "seeAlso": [
@@ -1002,7 +1028,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-No-Military-License.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-No-Military-License.json",
-      "referenceNumber": 615,
+      "referenceNumber": 102,
       "name": "BSD 3-Clause No Military License",
       "licenseId": "BSD-3-Clause-No-Military-License",
       "seeAlso": [
@@ -1015,7 +1041,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License.json",
-      "referenceNumber": 647,
+      "referenceNumber": 545,
       "name": "BSD 3-Clause No Nuclear License",
       "licenseId": "BSD-3-Clause-No-Nuclear-License",
       "seeAlso": [
@@ -1027,7 +1053,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License-2014.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License-2014.json",
-      "referenceNumber": 377,
+      "referenceNumber": 185,
       "name": "BSD 3-Clause No Nuclear License 2014",
       "licenseId": "BSD-3-Clause-No-Nuclear-License-2014",
       "seeAlso": [
@@ -1039,7 +1065,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-Warranty.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-Warranty.json",
-      "referenceNumber": 54,
+      "referenceNumber": 465,
       "name": "BSD 3-Clause No Nuclear Warranty",
       "licenseId": "BSD-3-Clause-No-Nuclear-Warranty",
       "seeAlso": [
@@ -1051,7 +1077,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-Open-MPI.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Open-MPI.json",
-      "referenceNumber": 633,
+      "referenceNumber": 108,
       "name": "BSD 3-Clause Open MPI variant",
       "licenseId": "BSD-3-Clause-Open-MPI",
       "seeAlso": [
@@ -1064,7 +1090,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-Sun.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Sun.json",
-      "referenceNumber": 270,
+      "referenceNumber": 496,
       "name": "BSD 3-Clause Sun Microsystems",
       "licenseId": "BSD-3-Clause-Sun",
       "seeAlso": [
@@ -1076,7 +1102,7 @@
       "reference": "https://spdx.org/licenses/BSD-4-Clause.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-4-Clause.json",
-      "referenceNumber": 470,
+      "referenceNumber": 416,
       "name": "BSD 4-Clause \"Original\" or \"Old\" License",
       "licenseId": "BSD-4-Clause",
       "seeAlso": [
@@ -1089,7 +1115,7 @@
       "reference": "https://spdx.org/licenses/BSD-4-Clause-Shortened.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-4-Clause-Shortened.json",
-      "referenceNumber": 220,
+      "referenceNumber": 387,
       "name": "BSD 4 Clause Shortened",
       "licenseId": "BSD-4-Clause-Shortened",
       "seeAlso": [
@@ -1101,7 +1127,7 @@
       "reference": "https://spdx.org/licenses/BSD-4-Clause-UC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-4-Clause-UC.json",
-      "referenceNumber": 175,
+      "referenceNumber": 123,
       "name": "BSD-4-Clause (University of California-Specific)",
       "licenseId": "BSD-4-Clause-UC",
       "seeAlso": [
@@ -1113,7 +1139,7 @@
       "reference": "https://spdx.org/licenses/BSD-4.3RENO.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-4.3RENO.json",
-      "referenceNumber": 361,
+      "referenceNumber": 373,
       "name": "BSD 4.3 RENO License",
       "licenseId": "BSD-4.3RENO",
       "seeAlso": [
@@ -1126,7 +1152,7 @@
       "reference": "https://spdx.org/licenses/BSD-4.3TAHOE.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-4.3TAHOE.json",
-      "referenceNumber": 46,
+      "referenceNumber": 355,
       "name": "BSD 4.3 TAHOE License",
       "licenseId": "BSD-4.3TAHOE",
       "seeAlso": [
@@ -1139,7 +1165,7 @@
       "reference": "https://spdx.org/licenses/BSD-Advertising-Acknowledgement.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-Advertising-Acknowledgement.json",
-      "referenceNumber": 297,
+      "referenceNumber": 488,
       "name": "BSD Advertising Acknowledgement License",
       "licenseId": "BSD-Advertising-Acknowledgement",
       "seeAlso": [
@@ -1151,7 +1177,7 @@
       "reference": "https://spdx.org/licenses/BSD-Attribution-HPND-disclaimer.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-Attribution-HPND-disclaimer.json",
-      "referenceNumber": 86,
+      "referenceNumber": 69,
       "name": "BSD with Attribution and HPND disclaimer",
       "licenseId": "BSD-Attribution-HPND-disclaimer",
       "seeAlso": [
@@ -1163,7 +1189,7 @@
       "reference": "https://spdx.org/licenses/BSD-Inferno-Nettverk.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-Inferno-Nettverk.json",
-      "referenceNumber": 89,
+      "referenceNumber": 197,
       "name": "BSD-Inferno-Nettverk",
       "licenseId": "BSD-Inferno-Nettverk",
       "seeAlso": [
@@ -1175,7 +1201,7 @@
       "reference": "https://spdx.org/licenses/BSD-Protection.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-Protection.json",
-      "referenceNumber": 394,
+      "referenceNumber": 546,
       "name": "BSD Protection License",
       "licenseId": "BSD-Protection",
       "seeAlso": [
@@ -1187,7 +1213,7 @@
       "reference": "https://spdx.org/licenses/BSD-Source-beginning-file.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-Source-beginning-file.json",
-      "referenceNumber": 378,
+      "referenceNumber": 421,
       "name": "BSD Source Code Attribution - beginning of file variant",
       "licenseId": "BSD-Source-beginning-file",
       "seeAlso": [
@@ -1199,7 +1225,7 @@
       "reference": "https://spdx.org/licenses/BSD-Source-Code.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-Source-Code.json",
-      "referenceNumber": 605,
+      "referenceNumber": 214,
       "name": "BSD Source Code Attribution",
       "licenseId": "BSD-Source-Code",
       "seeAlso": [
@@ -1211,7 +1237,7 @@
       "reference": "https://spdx.org/licenses/BSD-Systemics.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-Systemics.json",
-      "referenceNumber": 327,
+      "referenceNumber": 160,
       "name": "Systemics BSD variant license",
       "licenseId": "BSD-Systemics",
       "seeAlso": [
@@ -1223,7 +1249,7 @@
       "reference": "https://spdx.org/licenses/BSD-Systemics-W3Works.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-Systemics-W3Works.json",
-      "referenceNumber": 427,
+      "referenceNumber": 652,
       "name": "Systemics W3Works BSD variant license",
       "licenseId": "BSD-Systemics-W3Works",
       "seeAlso": [
@@ -1235,7 +1261,7 @@
       "reference": "https://spdx.org/licenses/BSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSL-1.0.json",
-      "referenceNumber": 334,
+      "referenceNumber": 272,
       "name": "Boost Software License 1.0",
       "licenseId": "BSL-1.0",
       "seeAlso": [
@@ -1249,7 +1275,7 @@
       "reference": "https://spdx.org/licenses/BUSL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BUSL-1.1.json",
-      "referenceNumber": 285,
+      "referenceNumber": 318,
       "name": "Business Source License 1.1",
       "licenseId": "BUSL-1.1",
       "seeAlso": [
@@ -1261,7 +1287,7 @@
       "reference": "https://spdx.org/licenses/bzip2-1.0.5.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/bzip2-1.0.5.json",
-      "referenceNumber": 574,
+      "referenceNumber": 556,
       "name": "bzip2 and libbzip2 License v1.0.5",
       "licenseId": "bzip2-1.0.5",
       "seeAlso": [
@@ -1274,7 +1300,7 @@
       "reference": "https://spdx.org/licenses/bzip2-1.0.6.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/bzip2-1.0.6.json",
-      "referenceNumber": 534,
+      "referenceNumber": 638,
       "name": "bzip2 and libbzip2 License v1.0.6",
       "licenseId": "bzip2-1.0.6",
       "seeAlso": [
@@ -1288,7 +1314,7 @@
       "reference": "https://spdx.org/licenses/C-UDA-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/C-UDA-1.0.json",
-      "referenceNumber": 162,
+      "referenceNumber": 345,
       "name": "Computational Use of Data Agreement v1.0",
       "licenseId": "C-UDA-1.0",
       "seeAlso": [
@@ -1301,7 +1327,7 @@
       "reference": "https://spdx.org/licenses/CAL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CAL-1.0.json",
-      "referenceNumber": 99,
+      "referenceNumber": 137,
       "name": "Cryptographic Autonomy License 1.0",
       "licenseId": "CAL-1.0",
       "seeAlso": [
@@ -1314,7 +1340,7 @@
       "reference": "https://spdx.org/licenses/CAL-1.0-Combined-Work-Exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CAL-1.0-Combined-Work-Exception.json",
-      "referenceNumber": 333,
+      "referenceNumber": 660,
       "name": "Cryptographic Autonomy License 1.0 (Combined Work Exception)",
       "licenseId": "CAL-1.0-Combined-Work-Exception",
       "seeAlso": [
@@ -1327,7 +1353,7 @@
       "reference": "https://spdx.org/licenses/Caldera.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Caldera.json",
-      "referenceNumber": 528,
+      "referenceNumber": 323,
       "name": "Caldera License",
       "licenseId": "Caldera",
       "seeAlso": [
@@ -1339,7 +1365,7 @@
       "reference": "https://spdx.org/licenses/Caldera-no-preamble.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Caldera-no-preamble.json",
-      "referenceNumber": 233,
+      "referenceNumber": 630,
       "name": "Caldera License (without preamble)",
       "licenseId": "Caldera-no-preamble",
       "seeAlso": [
@@ -1351,7 +1377,7 @@
       "reference": "https://spdx.org/licenses/Catharon.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Catharon.json",
-      "referenceNumber": 337,
+      "referenceNumber": 397,
       "name": "Catharon License",
       "licenseId": "Catharon",
       "seeAlso": [
@@ -1363,7 +1389,7 @@
       "reference": "https://spdx.org/licenses/CATOSL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CATOSL-1.1.json",
-      "referenceNumber": 134,
+      "referenceNumber": 175,
       "name": "Computer Associates Trusted Open Source License 1.1",
       "licenseId": "CATOSL-1.1",
       "seeAlso": [
@@ -1375,7 +1401,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-1.0.json",
-      "referenceNumber": 415,
+      "referenceNumber": 232,
       "name": "Creative Commons Attribution 1.0 Generic",
       "licenseId": "CC-BY-1.0",
       "seeAlso": [
@@ -1387,7 +1413,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-2.0.json",
-      "referenceNumber": 428,
+      "referenceNumber": 473,
       "name": "Creative Commons Attribution 2.0 Generic",
       "licenseId": "CC-BY-2.0",
       "seeAlso": [
@@ -1399,7 +1425,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-2.5.json",
-      "referenceNumber": 573,
+      "referenceNumber": 521,
       "name": "Creative Commons Attribution 2.5 Generic",
       "licenseId": "CC-BY-2.5",
       "seeAlso": [
@@ -1411,7 +1437,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-2.5-AU.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-2.5-AU.json",
-      "referenceNumber": 388,
+      "referenceNumber": 459,
       "name": "Creative Commons Attribution 2.5 Australia",
       "licenseId": "CC-BY-2.5-AU",
       "seeAlso": [
@@ -1423,7 +1449,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0.json",
-      "referenceNumber": 132,
+      "referenceNumber": 107,
       "name": "Creative Commons Attribution 3.0 Unported",
       "licenseId": "CC-BY-3.0",
       "seeAlso": [
@@ -1435,7 +1461,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-3.0-AT.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-AT.json",
-      "referenceNumber": 25,
+      "referenceNumber": 130,
       "name": "Creative Commons Attribution 3.0 Austria",
       "licenseId": "CC-BY-3.0-AT",
       "seeAlso": [
@@ -1447,7 +1473,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-3.0-AU.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-AU.json",
-      "referenceNumber": 392,
+      "referenceNumber": 256,
       "name": "Creative Commons Attribution 3.0 Australia",
       "licenseId": "CC-BY-3.0-AU",
       "seeAlso": [
@@ -1459,7 +1485,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-3.0-DE.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-DE.json",
-      "referenceNumber": 21,
+      "referenceNumber": 91,
       "name": "Creative Commons Attribution 3.0 Germany",
       "licenseId": "CC-BY-3.0-DE",
       "seeAlso": [
@@ -1471,7 +1497,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-3.0-IGO.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-IGO.json",
-      "referenceNumber": 596,
+      "referenceNumber": 213,
       "name": "Creative Commons Attribution 3.0 IGO",
       "licenseId": "CC-BY-3.0-IGO",
       "seeAlso": [
@@ -1483,7 +1509,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-3.0-NL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-NL.json",
-      "referenceNumber": 157,
+      "referenceNumber": 402,
       "name": "Creative Commons Attribution 3.0 Netherlands",
       "licenseId": "CC-BY-3.0-NL",
       "seeAlso": [
@@ -1495,7 +1521,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-3.0-US.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-US.json",
-      "referenceNumber": 395,
+      "referenceNumber": 275,
       "name": "Creative Commons Attribution 3.0 United States",
       "licenseId": "CC-BY-3.0-US",
       "seeAlso": [
@@ -1507,7 +1533,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-4.0.json",
-      "referenceNumber": 435,
+      "referenceNumber": 494,
       "name": "Creative Commons Attribution 4.0 International",
       "licenseId": "CC-BY-4.0",
       "seeAlso": [
@@ -1520,7 +1546,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-1.0.json",
-      "referenceNumber": 641,
+      "referenceNumber": 414,
       "name": "Creative Commons Attribution Non Commercial 1.0 Generic",
       "licenseId": "CC-BY-NC-1.0",
       "seeAlso": [
@@ -1533,7 +1559,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-2.0.json",
-      "referenceNumber": 91,
+      "referenceNumber": 57,
       "name": "Creative Commons Attribution Non Commercial 2.0 Generic",
       "licenseId": "CC-BY-NC-2.0",
       "seeAlso": [
@@ -1546,7 +1572,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-2.5.json",
-      "referenceNumber": 465,
+      "referenceNumber": 332,
       "name": "Creative Commons Attribution Non Commercial 2.5 Generic",
       "licenseId": "CC-BY-NC-2.5",
       "seeAlso": [
@@ -1559,7 +1585,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-3.0.json",
-      "referenceNumber": 234,
+      "referenceNumber": 226,
       "name": "Creative Commons Attribution Non Commercial 3.0 Unported",
       "licenseId": "CC-BY-NC-3.0",
       "seeAlso": [
@@ -1572,7 +1598,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-3.0-DE.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-3.0-DE.json",
-      "referenceNumber": 354,
+      "referenceNumber": 204,
       "name": "Creative Commons Attribution Non Commercial 3.0 Germany",
       "licenseId": "CC-BY-NC-3.0-DE",
       "seeAlso": [
@@ -1584,7 +1610,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-4.0.json",
-      "referenceNumber": 53,
+      "referenceNumber": 464,
       "name": "Creative Commons Attribution Non Commercial 4.0 International",
       "licenseId": "CC-BY-NC-4.0",
       "seeAlso": [
@@ -1597,7 +1623,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-ND-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-1.0.json",
-      "referenceNumber": 88,
+      "referenceNumber": 190,
       "name": "Creative Commons Attribution Non Commercial No Derivatives 1.0 Generic",
       "licenseId": "CC-BY-NC-ND-1.0",
       "seeAlso": [
@@ -1609,7 +1635,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-ND-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-2.0.json",
-      "referenceNumber": 426,
+      "referenceNumber": 242,
       "name": "Creative Commons Attribution Non Commercial No Derivatives 2.0 Generic",
       "licenseId": "CC-BY-NC-ND-2.0",
       "seeAlso": [
@@ -1621,7 +1647,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-ND-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-2.5.json",
-      "referenceNumber": 441,
+      "referenceNumber": 358,
       "name": "Creative Commons Attribution Non Commercial No Derivatives 2.5 Generic",
       "licenseId": "CC-BY-NC-ND-2.5",
       "seeAlso": [
@@ -1633,7 +1659,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-ND-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-3.0.json",
-      "referenceNumber": 304,
+      "referenceNumber": 51,
       "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 Unported",
       "licenseId": "CC-BY-NC-ND-3.0",
       "seeAlso": [
@@ -1645,7 +1671,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-ND-3.0-DE.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-3.0-DE.json",
-      "referenceNumber": 121,
+      "referenceNumber": 676,
       "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 Germany",
       "licenseId": "CC-BY-NC-ND-3.0-DE",
       "seeAlso": [
@@ -1657,7 +1683,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-ND-3.0-IGO.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-3.0-IGO.json",
-      "referenceNumber": 171,
+      "referenceNumber": 109,
       "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 IGO",
       "licenseId": "CC-BY-NC-ND-3.0-IGO",
       "seeAlso": [
@@ -1669,7 +1695,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-ND-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-4.0.json",
-      "referenceNumber": 183,
+      "referenceNumber": 184,
       "name": "Creative Commons Attribution Non Commercial No Derivatives 4.0 International",
       "licenseId": "CC-BY-NC-ND-4.0",
       "seeAlso": [
@@ -1681,7 +1707,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-SA-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-1.0.json",
-      "referenceNumber": 501,
+      "referenceNumber": 650,
       "name": "Creative Commons Attribution Non Commercial Share Alike 1.0 Generic",
       "licenseId": "CC-BY-NC-SA-1.0",
       "seeAlso": [
@@ -1693,7 +1719,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-SA-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-2.0.json",
-      "referenceNumber": 358,
+      "referenceNumber": 2,
       "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 Generic",
       "licenseId": "CC-BY-NC-SA-2.0",
       "seeAlso": [
@@ -1705,7 +1731,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-DE.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-DE.json",
-      "referenceNumber": 260,
+      "referenceNumber": 310,
       "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 Germany",
       "licenseId": "CC-BY-NC-SA-2.0-DE",
       "seeAlso": [
@@ -1717,7 +1743,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-FR.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-FR.json",
-      "referenceNumber": 158,
+      "referenceNumber": 264,
       "name": "Creative Commons Attribution-NonCommercial-ShareAlike 2.0 France",
       "licenseId": "CC-BY-NC-SA-2.0-FR",
       "seeAlso": [
@@ -1729,7 +1755,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-UK.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-UK.json",
-      "referenceNumber": 33,
+      "referenceNumber": 70,
       "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 England and Wales",
       "licenseId": "CC-BY-NC-SA-2.0-UK",
       "seeAlso": [
@@ -1741,7 +1767,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-SA-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-2.5.json",
-      "referenceNumber": 222,
+      "referenceNumber": 148,
       "name": "Creative Commons Attribution Non Commercial Share Alike 2.5 Generic",
       "licenseId": "CC-BY-NC-SA-2.5",
       "seeAlso": [
@@ -1753,7 +1779,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-SA-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-3.0.json",
-      "referenceNumber": 255,
+      "referenceNumber": 572,
       "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 Unported",
       "licenseId": "CC-BY-NC-SA-3.0",
       "seeAlso": [
@@ -1765,7 +1791,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-SA-3.0-DE.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-3.0-DE.json",
-      "referenceNumber": 525,
+      "referenceNumber": 625,
       "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 Germany",
       "licenseId": "CC-BY-NC-SA-3.0-DE",
       "seeAlso": [
@@ -1777,7 +1803,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-SA-3.0-IGO.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-3.0-IGO.json",
-      "referenceNumber": 244,
+      "referenceNumber": 239,
       "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 IGO",
       "licenseId": "CC-BY-NC-SA-3.0-IGO",
       "seeAlso": [
@@ -1789,7 +1815,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-SA-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-4.0.json",
-      "referenceNumber": 513,
+      "referenceNumber": 437,
       "name": "Creative Commons Attribution Non Commercial Share Alike 4.0 International",
       "licenseId": "CC-BY-NC-SA-4.0",
       "seeAlso": [
@@ -1801,7 +1827,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-ND-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-1.0.json",
-      "referenceNumber": 474,
+      "referenceNumber": 337,
       "name": "Creative Commons Attribution No Derivatives 1.0 Generic",
       "licenseId": "CC-BY-ND-1.0",
       "seeAlso": [
@@ -1814,7 +1840,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-ND-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-2.0.json",
-      "referenceNumber": 356,
+      "referenceNumber": 293,
       "name": "Creative Commons Attribution No Derivatives 2.0 Generic",
       "licenseId": "CC-BY-ND-2.0",
       "seeAlso": [
@@ -1827,7 +1853,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-ND-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-2.5.json",
-      "referenceNumber": 259,
+      "referenceNumber": 674,
       "name": "Creative Commons Attribution No Derivatives 2.5 Generic",
       "licenseId": "CC-BY-ND-2.5",
       "seeAlso": [
@@ -1840,7 +1866,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-ND-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-3.0.json",
-      "referenceNumber": 527,
+      "referenceNumber": 616,
       "name": "Creative Commons Attribution No Derivatives 3.0 Unported",
       "licenseId": "CC-BY-ND-3.0",
       "seeAlso": [
@@ -1853,7 +1879,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-ND-3.0-DE.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-3.0-DE.json",
-      "referenceNumber": 214,
+      "referenceNumber": 386,
       "name": "Creative Commons Attribution No Derivatives 3.0 Germany",
       "licenseId": "CC-BY-ND-3.0-DE",
       "seeAlso": [
@@ -1865,7 +1891,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-ND-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-4.0.json",
-      "referenceNumber": 481,
+      "referenceNumber": 95,
       "name": "Creative Commons Attribution No Derivatives 4.0 International",
       "licenseId": "CC-BY-ND-4.0",
       "seeAlso": [
@@ -1878,7 +1904,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-SA-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-1.0.json",
-      "referenceNumber": 588,
+      "referenceNumber": 595,
       "name": "Creative Commons Attribution Share Alike 1.0 Generic",
       "licenseId": "CC-BY-SA-1.0",
       "seeAlso": [
@@ -1890,7 +1916,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-SA-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-2.0.json",
-      "referenceNumber": 180,
+      "referenceNumber": 534,
       "name": "Creative Commons Attribution Share Alike 2.0 Generic",
       "licenseId": "CC-BY-SA-2.0",
       "seeAlso": [
@@ -1902,7 +1928,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-SA-2.0-UK.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-2.0-UK.json",
-      "referenceNumber": 385,
+      "referenceNumber": 267,
       "name": "Creative Commons Attribution Share Alike 2.0 England and Wales",
       "licenseId": "CC-BY-SA-2.0-UK",
       "seeAlso": [
@@ -1914,7 +1940,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-SA-2.1-JP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-2.1-JP.json",
-      "referenceNumber": 17,
+      "referenceNumber": 18,
       "name": "Creative Commons Attribution Share Alike 2.1 Japan",
       "licenseId": "CC-BY-SA-2.1-JP",
       "seeAlso": [
@@ -1926,7 +1952,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-SA-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-2.5.json",
-      "referenceNumber": 607,
+      "referenceNumber": 617,
       "name": "Creative Commons Attribution Share Alike 2.5 Generic",
       "licenseId": "CC-BY-SA-2.5",
       "seeAlso": [
@@ -1938,7 +1964,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-SA-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-3.0.json",
-      "referenceNumber": 26,
+      "referenceNumber": 63,
       "name": "Creative Commons Attribution Share Alike 3.0 Unported",
       "licenseId": "CC-BY-SA-3.0",
       "seeAlso": [
@@ -1950,7 +1976,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-SA-3.0-AT.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-3.0-AT.json",
-      "referenceNumber": 398,
+      "referenceNumber": 532,
       "name": "Creative Commons Attribution Share Alike 3.0 Austria",
       "licenseId": "CC-BY-SA-3.0-AT",
       "seeAlso": [
@@ -1962,7 +1988,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-SA-3.0-DE.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-3.0-DE.json",
-      "referenceNumber": 120,
+      "referenceNumber": 182,
       "name": "Creative Commons Attribution Share Alike 3.0 Germany",
       "licenseId": "CC-BY-SA-3.0-DE",
       "seeAlso": [
@@ -1974,7 +2000,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-SA-3.0-IGO.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-3.0-IGO.json",
-      "referenceNumber": 519,
+      "referenceNumber": 627,
       "name": "Creative Commons Attribution-ShareAlike 3.0 IGO",
       "licenseId": "CC-BY-SA-3.0-IGO",
       "seeAlso": [
@@ -1986,7 +2012,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-SA-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-4.0.json",
-      "referenceNumber": 13,
+      "referenceNumber": 44,
       "name": "Creative Commons Attribution Share Alike 4.0 International",
       "licenseId": "CC-BY-SA-4.0",
       "seeAlso": [
@@ -1999,7 +2025,7 @@
       "reference": "https://spdx.org/licenses/CC-PDDC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-PDDC.json",
-      "referenceNumber": 169,
+      "referenceNumber": 602,
       "name": "Creative Commons Public Domain Dedication and Certification",
       "licenseId": "CC-PDDC",
       "seeAlso": [
@@ -2008,10 +2034,35 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/CC-PDM-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-PDM-1.0.json",
+      "referenceNumber": 565,
+      "name": "Creative    Commons Public Domain Mark 1.0 Universal",
+      "licenseId": "CC-PDM-1.0",
+      "seeAlso": [
+        "https://creativecommons.org/publicdomain/mark/1.0/",
+        "https://creativecommons.org/share-your-work/cclicenses/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-SA-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-SA-1.0.json",
+      "referenceNumber": 321,
+      "name": "Creative Commons Share Alike 1.0 Generic",
+      "licenseId": "CC-SA-1.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/sa/1.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/CC0-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC0-1.0.json",
-      "referenceNumber": 491,
+      "referenceNumber": 111,
       "name": "Creative Commons Zero v1.0 Universal",
       "licenseId": "CC0-1.0",
       "seeAlso": [
@@ -2024,7 +2075,7 @@
       "reference": "https://spdx.org/licenses/CDDL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CDDL-1.0.json",
-      "referenceNumber": 185,
+      "referenceNumber": 284,
       "name": "Common Development and Distribution License 1.0",
       "licenseId": "CDDL-1.0",
       "seeAlso": [
@@ -2037,7 +2088,7 @@
       "reference": "https://spdx.org/licenses/CDDL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CDDL-1.1.json",
-      "referenceNumber": 476,
+      "referenceNumber": 198,
       "name": "Common Development and Distribution License 1.1",
       "licenseId": "CDDL-1.1",
       "seeAlso": [
@@ -2050,7 +2101,7 @@
       "reference": "https://spdx.org/licenses/CDL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CDL-1.0.json",
-      "referenceNumber": 305,
+      "referenceNumber": 539,
       "name": "Common Documentation License 1.0",
       "licenseId": "CDL-1.0",
       "seeAlso": [
@@ -2064,7 +2115,7 @@
       "reference": "https://spdx.org/licenses/CDLA-Permissive-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CDLA-Permissive-1.0.json",
-      "referenceNumber": 386,
+      "referenceNumber": 524,
       "name": "Community Data License Agreement Permissive 1.0",
       "licenseId": "CDLA-Permissive-1.0",
       "seeAlso": [
@@ -2076,7 +2127,7 @@
       "reference": "https://spdx.org/licenses/CDLA-Permissive-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CDLA-Permissive-2.0.json",
-      "referenceNumber": 590,
+      "referenceNumber": 636,
       "name": "Community Data License Agreement Permissive 2.0",
       "licenseId": "CDLA-Permissive-2.0",
       "seeAlso": [
@@ -2088,7 +2139,7 @@
       "reference": "https://spdx.org/licenses/CDLA-Sharing-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CDLA-Sharing-1.0.json",
-      "referenceNumber": 190,
+      "referenceNumber": 161,
       "name": "Community Data License Agreement Sharing 1.0",
       "licenseId": "CDLA-Sharing-1.0",
       "seeAlso": [
@@ -2100,7 +2151,7 @@
       "reference": "https://spdx.org/licenses/CECILL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CECILL-1.0.json",
-      "referenceNumber": 625,
+      "referenceNumber": 66,
       "name": "CeCILL Free Software License Agreement v1.0",
       "licenseId": "CECILL-1.0",
       "seeAlso": [
@@ -2112,7 +2163,7 @@
       "reference": "https://spdx.org/licenses/CECILL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CECILL-1.1.json",
-      "referenceNumber": 326,
+      "referenceNumber": 343,
       "name": "CeCILL Free Software License Agreement v1.1",
       "licenseId": "CECILL-1.1",
       "seeAlso": [
@@ -2124,7 +2175,7 @@
       "reference": "https://spdx.org/licenses/CECILL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CECILL-2.0.json",
-      "referenceNumber": 463,
+      "referenceNumber": 113,
       "name": "CeCILL Free Software License Agreement v2.0",
       "licenseId": "CECILL-2.0",
       "seeAlso": [
@@ -2137,7 +2188,7 @@
       "reference": "https://spdx.org/licenses/CECILL-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CECILL-2.1.json",
-      "referenceNumber": 170,
+      "referenceNumber": 154,
       "name": "CeCILL Free Software License Agreement v2.1",
       "licenseId": "CECILL-2.1",
       "seeAlso": [
@@ -2149,7 +2200,7 @@
       "reference": "https://spdx.org/licenses/CECILL-B.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CECILL-B.json",
-      "referenceNumber": 196,
+      "referenceNumber": 657,
       "name": "CeCILL-B Free Software License Agreement",
       "licenseId": "CECILL-B",
       "seeAlso": [
@@ -2162,7 +2213,7 @@
       "reference": "https://spdx.org/licenses/CECILL-C.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CECILL-C.json",
-      "referenceNumber": 178,
+      "referenceNumber": 276,
       "name": "CeCILL-C Free Software License Agreement",
       "licenseId": "CECILL-C",
       "seeAlso": [
@@ -2175,7 +2226,7 @@
       "reference": "https://spdx.org/licenses/CERN-OHL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CERN-OHL-1.1.json",
-      "referenceNumber": 148,
+      "referenceNumber": 348,
       "name": "CERN Open Hardware Licence v1.1",
       "licenseId": "CERN-OHL-1.1",
       "seeAlso": [
@@ -2187,7 +2238,7 @@
       "reference": "https://spdx.org/licenses/CERN-OHL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CERN-OHL-1.2.json",
-      "referenceNumber": 651,
+      "referenceNumber": 143,
       "name": "CERN Open Hardware Licence v1.2",
       "licenseId": "CERN-OHL-1.2",
       "seeAlso": [
@@ -2199,7 +2250,7 @@
       "reference": "https://spdx.org/licenses/CERN-OHL-P-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CERN-OHL-P-2.0.json",
-      "referenceNumber": 543,
+      "referenceNumber": 422,
       "name": "CERN Open Hardware Licence Version 2 - Permissive",
       "licenseId": "CERN-OHL-P-2.0",
       "seeAlso": [
@@ -2211,7 +2262,7 @@
       "reference": "https://spdx.org/licenses/CERN-OHL-S-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CERN-OHL-S-2.0.json",
-      "referenceNumber": 396,
+      "referenceNumber": 306,
       "name": "CERN Open Hardware Licence Version 2 - Strongly Reciprocal",
       "licenseId": "CERN-OHL-S-2.0",
       "seeAlso": [
@@ -2223,7 +2274,7 @@
       "reference": "https://spdx.org/licenses/CERN-OHL-W-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CERN-OHL-W-2.0.json",
-      "referenceNumber": 614,
+      "referenceNumber": 268,
       "name": "CERN Open Hardware Licence Version 2 - Weakly Reciprocal",
       "licenseId": "CERN-OHL-W-2.0",
       "seeAlso": [
@@ -2235,7 +2286,7 @@
       "reference": "https://spdx.org/licenses/CFITSIO.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CFITSIO.json",
-      "referenceNumber": 568,
+      "referenceNumber": 598,
       "name": "CFITSIO License",
       "licenseId": "CFITSIO",
       "seeAlso": [
@@ -2248,7 +2299,7 @@
       "reference": "https://spdx.org/licenses/check-cvs.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/check-cvs.json",
-      "referenceNumber": 324,
+      "referenceNumber": 411,
       "name": "check-cvs License",
       "licenseId": "check-cvs",
       "seeAlso": [
@@ -2260,7 +2311,7 @@
       "reference": "https://spdx.org/licenses/checkmk.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/checkmk.json",
-      "referenceNumber": 464,
+      "referenceNumber": 13,
       "name": "Checkmk License",
       "licenseId": "checkmk",
       "seeAlso": [
@@ -2272,7 +2323,7 @@
       "reference": "https://spdx.org/licenses/ClArtistic.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ClArtistic.json",
-      "referenceNumber": 230,
+      "referenceNumber": 236,
       "name": "Clarified Artistic License",
       "licenseId": "ClArtistic",
       "seeAlso": [
@@ -2286,7 +2337,7 @@
       "reference": "https://spdx.org/licenses/Clips.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Clips.json",
-      "referenceNumber": 424,
+      "referenceNumber": 392,
       "name": "Clips License",
       "licenseId": "Clips",
       "seeAlso": [
@@ -2298,7 +2349,7 @@
       "reference": "https://spdx.org/licenses/CMU-Mach.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CMU-Mach.json",
-      "referenceNumber": 73,
+      "referenceNumber": 35,
       "name": "CMU Mach License",
       "licenseId": "CMU-Mach",
       "seeAlso": [
@@ -2310,7 +2361,7 @@
       "reference": "https://spdx.org/licenses/CMU-Mach-nodoc.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CMU-Mach-nodoc.json",
-      "referenceNumber": 8,
+      "referenceNumber": 255,
       "name": "CMU    Mach - no notices-in-documentation variant",
       "licenseId": "CMU-Mach-nodoc",
       "seeAlso": [
@@ -2323,7 +2374,7 @@
       "reference": "https://spdx.org/licenses/CNRI-Jython.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CNRI-Jython.json",
-      "referenceNumber": 293,
+      "referenceNumber": 270,
       "name": "CNRI Jython License",
       "licenseId": "CNRI-Jython",
       "seeAlso": [
@@ -2335,7 +2386,7 @@
       "reference": "https://spdx.org/licenses/CNRI-Python.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CNRI-Python.json",
-      "referenceNumber": 402,
+      "referenceNumber": 287,
       "name": "CNRI Python License",
       "licenseId": "CNRI-Python",
       "seeAlso": [
@@ -2347,7 +2398,7 @@
       "reference": "https://spdx.org/licenses/CNRI-Python-GPL-Compatible.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CNRI-Python-GPL-Compatible.json",
-      "referenceNumber": 224,
+      "referenceNumber": 646,
       "name": "CNRI Python Open Source GPL Compatible License Agreement",
       "licenseId": "CNRI-Python-GPL-Compatible",
       "seeAlso": [
@@ -2359,7 +2410,7 @@
       "reference": "https://spdx.org/licenses/COIL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/COIL-1.0.json",
-      "referenceNumber": 345,
+      "referenceNumber": 193,
       "name": "Copyfree Open Innovation License",
       "licenseId": "COIL-1.0",
       "seeAlso": [
@@ -2371,7 +2422,7 @@
       "reference": "https://spdx.org/licenses/Community-Spec-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Community-Spec-1.0.json",
-      "referenceNumber": 56,
+      "referenceNumber": 29,
       "name": "Community Specification License 1.0",
       "licenseId": "Community-Spec-1.0",
       "seeAlso": [
@@ -2383,7 +2434,7 @@
       "reference": "https://spdx.org/licenses/Condor-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Condor-1.1.json",
-      "referenceNumber": 77,
+      "referenceNumber": 274,
       "name": "Condor Public License v1.1",
       "licenseId": "Condor-1.1",
       "seeAlso": [
@@ -2397,7 +2448,7 @@
       "reference": "https://spdx.org/licenses/copyleft-next-0.3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/copyleft-next-0.3.0.json",
-      "referenceNumber": 322,
+      "referenceNumber": 308,
       "name": "copyleft-next 0.3.0",
       "licenseId": "copyleft-next-0.3.0",
       "seeAlso": [
@@ -2409,7 +2460,7 @@
       "reference": "https://spdx.org/licenses/copyleft-next-0.3.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/copyleft-next-0.3.1.json",
-      "referenceNumber": 403,
+      "referenceNumber": 302,
       "name": "copyleft-next 0.3.1",
       "licenseId": "copyleft-next-0.3.1",
       "seeAlso": [
@@ -2421,7 +2472,7 @@
       "reference": "https://spdx.org/licenses/Cornell-Lossless-JPEG.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Cornell-Lossless-JPEG.json",
-      "referenceNumber": 98,
+      "referenceNumber": 176,
       "name": "Cornell Lossless JPEG License",
       "licenseId": "Cornell-Lossless-JPEG",
       "seeAlso": [
@@ -2435,7 +2486,7 @@
       "reference": "https://spdx.org/licenses/CPAL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CPAL-1.0.json",
-      "referenceNumber": 548,
+      "referenceNumber": 301,
       "name": "Common Public Attribution License 1.0",
       "licenseId": "CPAL-1.0",
       "seeAlso": [
@@ -2448,7 +2499,7 @@
       "reference": "https://spdx.org/licenses/CPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CPL-1.0.json",
-      "referenceNumber": 114,
+      "referenceNumber": 41,
       "name": "Common Public License 1.0",
       "licenseId": "CPL-1.0",
       "seeAlso": [
@@ -2461,7 +2512,7 @@
       "reference": "https://spdx.org/licenses/CPOL-1.02.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CPOL-1.02.json",
-      "referenceNumber": 6,
+      "referenceNumber": 420,
       "name": "Code Project Open License 1.02",
       "licenseId": "CPOL-1.02",
       "seeAlso": [
@@ -2474,7 +2525,7 @@
       "reference": "https://spdx.org/licenses/Cronyx.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Cronyx.json",
-      "referenceNumber": 649,
+      "referenceNumber": 335,
       "name": "Cronyx License",
       "licenseId": "Cronyx",
       "seeAlso": [
@@ -2489,7 +2540,7 @@
       "reference": "https://spdx.org/licenses/Crossword.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Crossword.json",
-      "referenceNumber": 593,
+      "referenceNumber": 344,
       "name": "Crossword License",
       "licenseId": "Crossword",
       "seeAlso": [
@@ -2501,7 +2552,7 @@
       "reference": "https://spdx.org/licenses/CrystalStacker.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CrystalStacker.json",
-      "referenceNumber": 241,
+      "referenceNumber": 31,
       "name": "CrystalStacker License",
       "licenseId": "CrystalStacker",
       "seeAlso": [
@@ -2513,7 +2564,7 @@
       "reference": "https://spdx.org/licenses/CUA-OPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CUA-OPL-1.0.json",
-      "referenceNumber": 409,
+      "referenceNumber": 151,
       "name": "CUA Office Public License v1.0",
       "licenseId": "CUA-OPL-1.0",
       "seeAlso": [
@@ -2525,7 +2576,7 @@
       "reference": "https://spdx.org/licenses/Cube.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Cube.json",
-      "referenceNumber": 141,
+      "referenceNumber": 103,
       "name": "Cube License",
       "licenseId": "Cube",
       "seeAlso": [
@@ -2537,7 +2588,7 @@
       "reference": "https://spdx.org/licenses/curl.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/curl.json",
-      "referenceNumber": 602,
+      "referenceNumber": 587,
       "name": "curl License",
       "licenseId": "curl",
       "seeAlso": [
@@ -2549,7 +2600,7 @@
       "reference": "https://spdx.org/licenses/cve-tou.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/cve-tou.json",
-      "referenceNumber": 656,
+      "referenceNumber": 15,
       "name": "Common Vulnerability Enumeration ToU License",
       "licenseId": "cve-tou",
       "seeAlso": [
@@ -2561,7 +2612,7 @@
       "reference": "https://spdx.org/licenses/D-FSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/D-FSL-1.0.json",
-      "referenceNumber": 116,
+      "referenceNumber": 265,
       "name": "Deutsche Freie Software Lizenz",
       "licenseId": "D-FSL-1.0",
       "seeAlso": [
@@ -2580,7 +2631,7 @@
       "reference": "https://spdx.org/licenses/DEC-3-Clause.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/DEC-3-Clause.json",
-      "referenceNumber": 512,
+      "referenceNumber": 460,
       "name": "DEC 3-Clause License",
       "licenseId": "DEC-3-Clause",
       "seeAlso": [
@@ -2592,7 +2643,7 @@
       "reference": "https://spdx.org/licenses/diffmark.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/diffmark.json",
-      "referenceNumber": 480,
+      "referenceNumber": 277,
       "name": "diffmark license",
       "licenseId": "diffmark",
       "seeAlso": [
@@ -2604,7 +2655,7 @@
       "reference": "https://spdx.org/licenses/DL-DE-BY-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/DL-DE-BY-2.0.json",
-      "referenceNumber": 84,
+      "referenceNumber": 141,
       "name": "Data licence Germany – attribution – version 2.0",
       "licenseId": "DL-DE-BY-2.0",
       "seeAlso": [
@@ -2616,7 +2667,7 @@
       "reference": "https://spdx.org/licenses/DL-DE-ZERO-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/DL-DE-ZERO-2.0.json",
-      "referenceNumber": 522,
+      "referenceNumber": 470,
       "name": "Data licence Germany – zero – version 2.0",
       "licenseId": "DL-DE-ZERO-2.0",
       "seeAlso": [
@@ -2628,7 +2679,7 @@
       "reference": "https://spdx.org/licenses/DOC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/DOC.json",
-      "referenceNumber": 646,
+      "referenceNumber": 177,
       "name": "DOC License",
       "licenseId": "DOC",
       "seeAlso": [
@@ -2641,7 +2692,7 @@
       "reference": "https://spdx.org/licenses/DocBook-Schema.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/DocBook-Schema.json",
-      "referenceNumber": 153,
+      "referenceNumber": 305,
       "name": "DocBook Schema License",
       "licenseId": "DocBook-Schema",
       "seeAlso": [
@@ -2650,10 +2701,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/DocBook-Stylesheet.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/DocBook-Stylesheet.json",
+      "referenceNumber": 250,
+      "name": "DocBook Stylesheet License",
+      "licenseId": "DocBook-Stylesheet",
+      "seeAlso": [
+        "http://www.docbook.org/xml/5.0/docbook-5.0.zip"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/DocBook-XML.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/DocBook-XML.json",
-      "referenceNumber": 493,
+      "referenceNumber": 221,
       "name": "DocBook XML License",
       "licenseId": "DocBook-XML",
       "seeAlso": [
@@ -2665,7 +2728,7 @@
       "reference": "https://spdx.org/licenses/Dotseqn.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Dotseqn.json",
-      "referenceNumber": 533,
+      "referenceNumber": 456,
       "name": "Dotseqn License",
       "licenseId": "Dotseqn",
       "seeAlso": [
@@ -2677,7 +2740,7 @@
       "reference": "https://spdx.org/licenses/DRL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/DRL-1.0.json",
-      "referenceNumber": 410,
+      "referenceNumber": 331,
       "name": "Detection Rule License 1.0",
       "licenseId": "DRL-1.0",
       "seeAlso": [
@@ -2689,7 +2752,7 @@
       "reference": "https://spdx.org/licenses/DRL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/DRL-1.1.json",
-      "referenceNumber": 268,
+      "referenceNumber": 632,
       "name": "Detection Rule License 1.1",
       "licenseId": "DRL-1.1",
       "seeAlso": [
@@ -2701,7 +2764,7 @@
       "reference": "https://spdx.org/licenses/DSDP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/DSDP.json",
-      "referenceNumber": 164,
+      "referenceNumber": 0,
       "name": "DSDP License",
       "licenseId": "DSDP",
       "seeAlso": [
@@ -2713,7 +2776,7 @@
       "reference": "https://spdx.org/licenses/dtoa.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/dtoa.json",
-      "referenceNumber": 263,
+      "referenceNumber": 124,
       "name": "David M. Gay dtoa License",
       "licenseId": "dtoa",
       "seeAlso": [
@@ -2726,7 +2789,7 @@
       "reference": "https://spdx.org/licenses/dvipdfm.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/dvipdfm.json",
-      "referenceNumber": 61,
+      "referenceNumber": 299,
       "name": "dvipdfm License",
       "licenseId": "dvipdfm",
       "seeAlso": [
@@ -2738,7 +2801,7 @@
       "reference": "https://spdx.org/licenses/ECL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ECL-1.0.json",
-      "referenceNumber": 264,
+      "referenceNumber": 38,
       "name": "Educational Community License v1.0",
       "licenseId": "ECL-1.0",
       "seeAlso": [
@@ -2750,7 +2813,7 @@
       "reference": "https://spdx.org/licenses/ECL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ECL-2.0.json",
-      "referenceNumber": 363,
+      "referenceNumber": 174,
       "name": "Educational Community License v2.0",
       "licenseId": "ECL-2.0",
       "seeAlso": [
@@ -2763,7 +2826,7 @@
       "reference": "https://spdx.org/licenses/eCos-2.0.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/eCos-2.0.json",
-      "referenceNumber": 298,
+      "referenceNumber": 8,
       "name": "eCos license version 2.0",
       "licenseId": "eCos-2.0",
       "seeAlso": [
@@ -2776,7 +2839,7 @@
       "reference": "https://spdx.org/licenses/EFL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/EFL-1.0.json",
-      "referenceNumber": 137,
+      "referenceNumber": 201,
       "name": "Eiffel Forum License v1.0",
       "licenseId": "EFL-1.0",
       "seeAlso": [
@@ -2789,7 +2852,7 @@
       "reference": "https://spdx.org/licenses/EFL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/EFL-2.0.json",
-      "referenceNumber": 447,
+      "referenceNumber": 525,
       "name": "Eiffel Forum License v2.0",
       "licenseId": "EFL-2.0",
       "seeAlso": [
@@ -2803,7 +2866,7 @@
       "reference": "https://spdx.org/licenses/eGenix.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/eGenix.json",
-      "referenceNumber": 348,
+      "referenceNumber": 134,
       "name": "eGenix.com Public License 1.1.0",
       "licenseId": "eGenix",
       "seeAlso": [
@@ -2816,7 +2879,7 @@
       "reference": "https://spdx.org/licenses/Elastic-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Elastic-2.0.json",
-      "referenceNumber": 404,
+      "referenceNumber": 40,
       "name": "Elastic License 2.0",
       "licenseId": "Elastic-2.0",
       "seeAlso": [
@@ -2829,7 +2892,7 @@
       "reference": "https://spdx.org/licenses/Entessa.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Entessa.json",
-      "referenceNumber": 198,
+      "referenceNumber": 202,
       "name": "Entessa Public License v1.0",
       "licenseId": "Entessa",
       "seeAlso": [
@@ -2841,7 +2904,7 @@
       "reference": "https://spdx.org/licenses/EPICS.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/EPICS.json",
-      "referenceNumber": 532,
+      "referenceNumber": 165,
       "name": "EPICS Open License",
       "licenseId": "EPICS",
       "seeAlso": [
@@ -2853,7 +2916,7 @@
       "reference": "https://spdx.org/licenses/EPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/EPL-1.0.json",
-      "referenceNumber": 115,
+      "referenceNumber": 89,
       "name": "Eclipse Public License 1.0",
       "licenseId": "EPL-1.0",
       "seeAlso": [
@@ -2867,7 +2930,7 @@
       "reference": "https://spdx.org/licenses/EPL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/EPL-2.0.json",
-      "referenceNumber": 282,
+      "referenceNumber": 378,
       "name": "Eclipse Public License 2.0",
       "licenseId": "EPL-2.0",
       "seeAlso": [
@@ -2881,7 +2944,7 @@
       "reference": "https://spdx.org/licenses/ErlPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ErlPL-1.1.json",
-      "referenceNumber": 530,
+      "referenceNumber": 590,
       "name": "Erlang Public License v1.1",
       "licenseId": "ErlPL-1.1",
       "seeAlso": [
@@ -2893,7 +2956,7 @@
       "reference": "https://spdx.org/licenses/etalab-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/etalab-2.0.json",
-      "referenceNumber": 129,
+      "referenceNumber": 596,
       "name": "Etalab Open License 2.0",
       "licenseId": "etalab-2.0",
       "seeAlso": [
@@ -2906,7 +2969,7 @@
       "reference": "https://spdx.org/licenses/EUDatagrid.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/EUDatagrid.json",
-      "referenceNumber": 393,
+      "referenceNumber": 119,
       "name": "EU DataGrid Software License",
       "licenseId": "EUDatagrid",
       "seeAlso": [
@@ -2920,7 +2983,7 @@
       "reference": "https://spdx.org/licenses/EUPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/EUPL-1.0.json",
-      "referenceNumber": 389,
+      "referenceNumber": 187,
       "name": "European Union Public License 1.0",
       "licenseId": "EUPL-1.0",
       "seeAlso": [
@@ -2933,7 +2996,7 @@
       "reference": "https://spdx.org/licenses/EUPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/EUPL-1.1.json",
-      "referenceNumber": 503,
+      "referenceNumber": 474,
       "name": "European Union Public License 1.1",
       "licenseId": "EUPL-1.1",
       "seeAlso": [
@@ -2948,7 +3011,7 @@
       "reference": "https://spdx.org/licenses/EUPL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/EUPL-1.2.json",
-      "referenceNumber": 12,
+      "referenceNumber": 398,
       "name": "European Union Public License 1.2",
       "licenseId": "EUPL-1.2",
       "seeAlso": [
@@ -2966,7 +3029,7 @@
       "reference": "https://spdx.org/licenses/Eurosym.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Eurosym.json",
-      "referenceNumber": 621,
+      "referenceNumber": 319,
       "name": "Eurosym License",
       "licenseId": "Eurosym",
       "seeAlso": [
@@ -2978,7 +3041,7 @@
       "reference": "https://spdx.org/licenses/Fair.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Fair.json",
-      "referenceNumber": 258,
+      "referenceNumber": 245,
       "name": "Fair License",
       "licenseId": "Fair",
       "seeAlso": [
@@ -2991,7 +3054,7 @@
       "reference": "https://spdx.org/licenses/FBM.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FBM.json",
-      "referenceNumber": 626,
+      "referenceNumber": 235,
       "name": "Fuzzy Bitmap License",
       "licenseId": "FBM",
       "seeAlso": [
@@ -3003,7 +3066,7 @@
       "reference": "https://spdx.org/licenses/FDK-AAC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FDK-AAC.json",
-      "referenceNumber": 344,
+      "referenceNumber": 294,
       "name": "Fraunhofer FDK AAC Codec Library",
       "licenseId": "FDK-AAC",
       "seeAlso": [
@@ -3016,7 +3079,7 @@
       "reference": "https://spdx.org/licenses/Ferguson-Twofish.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Ferguson-Twofish.json",
-      "referenceNumber": 362,
+      "referenceNumber": 338,
       "name": "Ferguson Twofish License",
       "licenseId": "Ferguson-Twofish",
       "seeAlso": [
@@ -3028,7 +3091,7 @@
       "reference": "https://spdx.org/licenses/Frameworx-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Frameworx-1.0.json",
-      "referenceNumber": 188,
+      "referenceNumber": 229,
       "name": "Frameworx Open License 1.0",
       "licenseId": "Frameworx-1.0",
       "seeAlso": [
@@ -3040,7 +3103,7 @@
       "reference": "https://spdx.org/licenses/FreeBSD-DOC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FreeBSD-DOC.json",
-      "referenceNumber": 151,
+      "referenceNumber": 254,
       "name": "FreeBSD Documentation License",
       "licenseId": "FreeBSD-DOC",
       "seeAlso": [
@@ -3052,7 +3115,7 @@
       "reference": "https://spdx.org/licenses/FreeImage.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FreeImage.json",
-      "referenceNumber": 232,
+      "referenceNumber": 260,
       "name": "FreeImage Public License v1.0",
       "licenseId": "FreeImage",
       "seeAlso": [
@@ -3064,7 +3127,7 @@
       "reference": "https://spdx.org/licenses/FSFAP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FSFAP.json",
-      "referenceNumber": 436,
+      "referenceNumber": 116,
       "name": "FSF All Permissive License",
       "licenseId": "FSFAP",
       "seeAlso": [
@@ -3077,7 +3140,7 @@
       "reference": "https://spdx.org/licenses/FSFAP-no-warranty-disclaimer.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FSFAP-no-warranty-disclaimer.json",
-      "referenceNumber": 547,
+      "referenceNumber": 579,
       "name": "FSF All Permissive License (without Warranty)",
       "licenseId": "FSFAP-no-warranty-disclaimer",
       "seeAlso": [
@@ -3089,7 +3152,7 @@
       "reference": "https://spdx.org/licenses/FSFUL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FSFUL.json",
-      "referenceNumber": 2,
+      "referenceNumber": 578,
       "name": "FSF Unlimited License",
       "licenseId": "FSFUL",
       "seeAlso": [
@@ -3101,7 +3164,7 @@
       "reference": "https://spdx.org/licenses/FSFULLR.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FSFULLR.json",
-      "referenceNumber": 508,
+      "referenceNumber": 52,
       "name": "FSF Unlimited License (with License Retention)",
       "licenseId": "FSFULLR",
       "seeAlso": [
@@ -3113,7 +3176,7 @@
       "reference": "https://spdx.org/licenses/FSFULLRWD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FSFULLRWD.json",
-      "referenceNumber": 640,
+      "referenceNumber": 199,
       "name": "FSF Unlimited License (With License Retention and Warranty Disclaimer)",
       "licenseId": "FSFULLRWD",
       "seeAlso": [
@@ -3125,7 +3188,7 @@
       "reference": "https://spdx.org/licenses/FTL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FTL.json",
-      "referenceNumber": 249,
+      "referenceNumber": 304,
       "name": "Freetype Project License",
       "licenseId": "FTL",
       "seeAlso": [
@@ -3140,7 +3203,7 @@
       "reference": "https://spdx.org/licenses/Furuseth.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Furuseth.json",
-      "referenceNumber": 273,
+      "referenceNumber": 563,
       "name": "Furuseth License",
       "licenseId": "Furuseth",
       "seeAlso": [
@@ -3152,7 +3215,7 @@
       "reference": "https://spdx.org/licenses/fwlw.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/fwlw.json",
-      "referenceNumber": 50,
+      "referenceNumber": 81,
       "name": "fwlw License",
       "licenseId": "fwlw",
       "seeAlso": [
@@ -3164,7 +3227,7 @@
       "reference": "https://spdx.org/licenses/GCR-docs.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GCR-docs.json",
-      "referenceNumber": 272,
+      "referenceNumber": 135,
       "name": "Gnome GCR Documentation License",
       "licenseId": "GCR-docs",
       "seeAlso": [
@@ -3176,7 +3239,7 @@
       "reference": "https://spdx.org/licenses/GD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GD.json",
-      "referenceNumber": 624,
+      "referenceNumber": 333,
       "name": "GD License",
       "licenseId": "GD",
       "seeAlso": [
@@ -3185,10 +3248,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/generic-xts.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/generic-xts.json",
+      "referenceNumber": 476,
+      "name": "Generic XTS License",
+      "licenseId": "generic-xts",
+      "seeAlso": [
+        "https://github.com/mhogomchungu/zuluCrypt/blob/master/external_libraries/tcplay/generic_xts.c"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/GFDL-1.1.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.1.json",
-      "referenceNumber": 177,
+      "referenceNumber": 279,
       "name": "GNU Free Documentation License v1.1",
       "licenseId": "GFDL-1.1",
       "seeAlso": [
@@ -3201,7 +3276,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.1-invariants-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-invariants-only.json",
-      "referenceNumber": 216,
+      "referenceNumber": 452,
       "name": "GNU Free Documentation License v1.1 only - invariants",
       "licenseId": "GFDL-1.1-invariants-only",
       "seeAlso": [
@@ -3213,7 +3288,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.1-invariants-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-invariants-or-later.json",
-      "referenceNumber": 57,
+      "referenceNumber": 153,
       "name": "GNU Free Documentation License v1.1 or later - invariants",
       "licenseId": "GFDL-1.1-invariants-or-later",
       "seeAlso": [
@@ -3225,7 +3300,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.1-no-invariants-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-no-invariants-only.json",
-      "referenceNumber": 38,
+      "referenceNumber": 215,
       "name": "GNU Free Documentation License v1.1 only - no invariants",
       "licenseId": "GFDL-1.1-no-invariants-only",
       "seeAlso": [
@@ -3237,7 +3312,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.1-no-invariants-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-no-invariants-or-later.json",
-      "referenceNumber": 289,
+      "referenceNumber": 626,
       "name": "GNU Free Documentation License v1.1 or later - no invariants",
       "licenseId": "GFDL-1.1-no-invariants-or-later",
       "seeAlso": [
@@ -3249,7 +3324,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.1-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-only.json",
-      "referenceNumber": 654,
+      "referenceNumber": 610,
       "name": "GNU Free Documentation License v1.1 only",
       "licenseId": "GFDL-1.1-only",
       "seeAlso": [
@@ -3262,7 +3337,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.1-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-or-later.json",
-      "referenceNumber": 569,
+      "referenceNumber": 162,
       "name": "GNU Free Documentation License v1.1 or later",
       "licenseId": "GFDL-1.1-or-later",
       "seeAlso": [
@@ -3275,7 +3350,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.2.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.2.json",
-      "referenceNumber": 235,
+      "referenceNumber": 643,
       "name": "GNU Free Documentation License v1.2",
       "licenseId": "GFDL-1.2",
       "seeAlso": [
@@ -3288,7 +3363,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.2-invariants-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-invariants-only.json",
-      "referenceNumber": 461,
+      "referenceNumber": 200,
       "name": "GNU Free Documentation License v1.2 only - invariants",
       "licenseId": "GFDL-1.2-invariants-only",
       "seeAlso": [
@@ -3300,7 +3375,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.2-invariants-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-invariants-or-later.json",
-      "referenceNumber": 391,
+      "referenceNumber": 357,
       "name": "GNU Free Documentation License v1.2 or later - invariants",
       "licenseId": "GFDL-1.2-invariants-or-later",
       "seeAlso": [
@@ -3312,7 +3387,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.2-no-invariants-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-no-invariants-only.json",
-      "referenceNumber": 187,
+      "referenceNumber": 42,
       "name": "GNU Free Documentation License v1.2 only - no invariants",
       "licenseId": "GFDL-1.2-no-invariants-only",
       "seeAlso": [
@@ -3324,7 +3399,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.2-no-invariants-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-no-invariants-or-later.json",
-      "referenceNumber": 240,
+      "referenceNumber": 329,
       "name": "GNU Free Documentation License v1.2 or later - no invariants",
       "licenseId": "GFDL-1.2-no-invariants-or-later",
       "seeAlso": [
@@ -3336,7 +3411,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.2-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-only.json",
-      "referenceNumber": 302,
+      "referenceNumber": 663,
       "name": "GNU Free Documentation License v1.2 only",
       "licenseId": "GFDL-1.2-only",
       "seeAlso": [
@@ -3349,7 +3424,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.2-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-or-later.json",
-      "referenceNumber": 562,
+      "referenceNumber": 436,
       "name": "GNU Free Documentation License v1.2 or later",
       "licenseId": "GFDL-1.2-or-later",
       "seeAlso": [
@@ -3362,7 +3437,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.3.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.3.json",
-      "referenceNumber": 60,
+      "referenceNumber": 379,
       "name": "GNU Free Documentation License v1.3",
       "licenseId": "GFDL-1.3",
       "seeAlso": [
@@ -3375,7 +3450,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.3-invariants-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-invariants-only.json",
-      "referenceNumber": 184,
+      "referenceNumber": 555,
       "name": "GNU Free Documentation License v1.3 only - invariants",
       "licenseId": "GFDL-1.3-invariants-only",
       "seeAlso": [
@@ -3387,7 +3462,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.3-invariants-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-invariants-or-later.json",
-      "referenceNumber": 346,
+      "referenceNumber": 504,
       "name": "GNU Free Documentation License v1.3 or later - invariants",
       "licenseId": "GFDL-1.3-invariants-or-later",
       "seeAlso": [
@@ -3399,7 +3474,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.3-no-invariants-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-no-invariants-only.json",
-      "referenceNumber": 59,
+      "referenceNumber": 5,
       "name": "GNU Free Documentation License v1.3 only - no invariants",
       "licenseId": "GFDL-1.3-no-invariants-only",
       "seeAlso": [
@@ -3411,7 +3486,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.3-no-invariants-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-no-invariants-or-later.json",
-      "referenceNumber": 281,
+      "referenceNumber": 528,
       "name": "GNU Free Documentation License v1.3 or later - no invariants",
       "licenseId": "GFDL-1.3-no-invariants-or-later",
       "seeAlso": [
@@ -3423,7 +3498,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.3-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-only.json",
-      "referenceNumber": 642,
+      "referenceNumber": 311,
       "name": "GNU Free Documentation License v1.3 only",
       "licenseId": "GFDL-1.3-only",
       "seeAlso": [
@@ -3436,7 +3511,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.3-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-or-later.json",
-      "referenceNumber": 494,
+      "referenceNumber": 142,
       "name": "GNU Free Documentation License v1.3 or later",
       "licenseId": "GFDL-1.3-or-later",
       "seeAlso": [
@@ -3449,7 +3524,7 @@
       "reference": "https://spdx.org/licenses/Giftware.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Giftware.json",
-      "referenceNumber": 618,
+      "referenceNumber": 656,
       "name": "Giftware License",
       "licenseId": "Giftware",
       "seeAlso": [
@@ -3461,7 +3536,7 @@
       "reference": "https://spdx.org/licenses/GL2PS.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GL2PS.json",
-      "referenceNumber": 231,
+      "referenceNumber": 639,
       "name": "GL2PS License",
       "licenseId": "GL2PS",
       "seeAlso": [
@@ -3473,7 +3548,7 @@
       "reference": "https://spdx.org/licenses/Glide.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Glide.json",
-      "referenceNumber": 620,
+      "referenceNumber": 203,
       "name": "3dfx Glide License",
       "licenseId": "Glide",
       "seeAlso": [
@@ -3485,7 +3560,7 @@
       "reference": "https://spdx.org/licenses/Glulxe.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Glulxe.json",
-      "referenceNumber": 429,
+      "referenceNumber": 483,
       "name": "Glulxe License",
       "licenseId": "Glulxe",
       "seeAlso": [
@@ -3497,7 +3572,7 @@
       "reference": "https://spdx.org/licenses/GLWTPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GLWTPL.json",
-      "referenceNumber": 154,
+      "referenceNumber": 9,
       "name": "Good Luck With That Public License",
       "licenseId": "GLWTPL",
       "seeAlso": [
@@ -3509,7 +3584,7 @@
       "reference": "https://spdx.org/licenses/gnuplot.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/gnuplot.json",
-      "referenceNumber": 271,
+      "referenceNumber": 389,
       "name": "gnuplot License",
       "licenseId": "gnuplot",
       "seeAlso": [
@@ -3522,7 +3597,7 @@
       "reference": "https://spdx.org/licenses/GPL-1.0.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-1.0.json",
-      "referenceNumber": 365,
+      "referenceNumber": 227,
       "name": "GNU General Public License v1.0 only",
       "licenseId": "GPL-1.0",
       "seeAlso": [
@@ -3534,7 +3609,7 @@
       "reference": "https://spdx.org/licenses/GPL-1.0+.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-1.0+.json",
-      "referenceNumber": 66,
+      "referenceNumber": 297,
       "name": "GNU General Public License v1.0 or later",
       "licenseId": "GPL-1.0+",
       "seeAlso": [
@@ -3546,7 +3621,7 @@
       "reference": "https://spdx.org/licenses/GPL-1.0-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GPL-1.0-only.json",
-      "referenceNumber": 563,
+      "referenceNumber": 353,
       "name": "GNU General Public License v1.0 only",
       "licenseId": "GPL-1.0-only",
       "seeAlso": [
@@ -3558,7 +3633,7 @@
       "reference": "https://spdx.org/licenses/GPL-1.0-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GPL-1.0-or-later.json",
-      "referenceNumber": 558,
+      "referenceNumber": 376,
       "name": "GNU General Public License v1.0 or later",
       "licenseId": "GPL-1.0-or-later",
       "seeAlso": [
@@ -3570,7 +3645,7 @@
       "reference": "https://spdx.org/licenses/GPL-2.0.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-2.0.json",
-      "referenceNumber": 613,
+      "referenceNumber": 188,
       "name": "GNU General Public License v2.0 only",
       "licenseId": "GPL-2.0",
       "seeAlso": [
@@ -3584,7 +3659,7 @@
       "reference": "https://spdx.org/licenses/GPL-2.0+.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-2.0+.json",
-      "referenceNumber": 83,
+      "referenceNumber": 600,
       "name": "GNU General Public License v2.0 or later",
       "licenseId": "GPL-2.0+",
       "seeAlso": [
@@ -3598,7 +3673,7 @@
       "reference": "https://spdx.org/licenses/GPL-2.0-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GPL-2.0-only.json",
-      "referenceNumber": 483,
+      "referenceNumber": 172,
       "name": "GNU General Public License v2.0 only",
       "licenseId": "GPL-2.0-only",
       "seeAlso": [
@@ -3613,7 +3688,7 @@
       "reference": "https://spdx.org/licenses/GPL-2.0-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GPL-2.0-or-later.json",
-      "referenceNumber": 349,
+      "referenceNumber": 424,
       "name": "GNU General Public License v2.0 or later",
       "licenseId": "GPL-2.0-or-later",
       "seeAlso": [
@@ -3627,7 +3702,7 @@
       "reference": "https://spdx.org/licenses/GPL-2.0-with-autoconf-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-autoconf-exception.json",
-      "referenceNumber": 475,
+      "referenceNumber": 629,
       "name": "GNU General Public License v2.0 w/Autoconf exception",
       "licenseId": "GPL-2.0-with-autoconf-exception",
       "seeAlso": [
@@ -3639,7 +3714,7 @@
       "reference": "https://spdx.org/licenses/GPL-2.0-with-bison-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-bison-exception.json",
-      "referenceNumber": 492,
+      "referenceNumber": 37,
       "name": "GNU General Public License v2.0 w/Bison exception",
       "licenseId": "GPL-2.0-with-bison-exception",
       "seeAlso": [
@@ -3651,7 +3726,7 @@
       "reference": "https://spdx.org/licenses/GPL-2.0-with-classpath-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-classpath-exception.json",
-      "referenceNumber": 144,
+      "referenceNumber": 410,
       "name": "GNU General Public License v2.0 w/Classpath exception",
       "licenseId": "GPL-2.0-with-classpath-exception",
       "seeAlso": [
@@ -3663,7 +3738,7 @@
       "reference": "https://spdx.org/licenses/GPL-2.0-with-font-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-font-exception.json",
-      "referenceNumber": 579,
+      "referenceNumber": 548,
       "name": "GNU General Public License v2.0 w/Font exception",
       "licenseId": "GPL-2.0-with-font-exception",
       "seeAlso": [
@@ -3675,7 +3750,7 @@
       "reference": "https://spdx.org/licenses/GPL-2.0-with-GCC-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-GCC-exception.json",
-      "referenceNumber": 449,
+      "referenceNumber": 492,
       "name": "GNU General Public License v2.0 w/GCC Runtime Library exception",
       "licenseId": "GPL-2.0-with-GCC-exception",
       "seeAlso": [
@@ -3687,7 +3762,7 @@
       "reference": "https://spdx.org/licenses/GPL-3.0.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-3.0.json",
-      "referenceNumber": 434,
+      "referenceNumber": 671,
       "name": "GNU General Public License v3.0 only",
       "licenseId": "GPL-3.0",
       "seeAlso": [
@@ -3701,7 +3776,7 @@
       "reference": "https://spdx.org/licenses/GPL-3.0+.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-3.0+.json",
-      "referenceNumber": 586,
+      "referenceNumber": 501,
       "name": "GNU General Public License v3.0 or later",
       "licenseId": "GPL-3.0+",
       "seeAlso": [
@@ -3715,7 +3790,7 @@
       "reference": "https://spdx.org/licenses/GPL-3.0-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GPL-3.0-only.json",
-      "referenceNumber": 42,
+      "referenceNumber": 584,
       "name": "GNU General Public License v3.0 only",
       "licenseId": "GPL-3.0-only",
       "seeAlso": [
@@ -3729,7 +3804,7 @@
       "reference": "https://spdx.org/licenses/GPL-3.0-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GPL-3.0-or-later.json",
-      "referenceNumber": 269,
+      "referenceNumber": 448,
       "name": "GNU General Public License v3.0 or later",
       "licenseId": "GPL-3.0-or-later",
       "seeAlso": [
@@ -3743,7 +3818,7 @@
       "reference": "https://spdx.org/licenses/GPL-3.0-with-autoconf-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-3.0-with-autoconf-exception.json",
-      "referenceNumber": 200,
+      "referenceNumber": 659,
       "name": "GNU General Public License v3.0 w/Autoconf exception",
       "licenseId": "GPL-3.0-with-autoconf-exception",
       "seeAlso": [
@@ -3755,7 +3830,7 @@
       "reference": "https://spdx.org/licenses/GPL-3.0-with-GCC-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-3.0-with-GCC-exception.json",
-      "referenceNumber": 546,
+      "referenceNumber": 173,
       "name": "GNU General Public License v3.0 w/GCC Runtime Library exception",
       "licenseId": "GPL-3.0-with-GCC-exception",
       "seeAlso": [
@@ -3767,7 +3842,7 @@
       "reference": "https://spdx.org/licenses/Graphics-Gems.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Graphics-Gems.json",
-      "referenceNumber": 437,
+      "referenceNumber": 55,
       "name": "Graphics Gems License",
       "licenseId": "Graphics-Gems",
       "seeAlso": [
@@ -3779,7 +3854,7 @@
       "reference": "https://spdx.org/licenses/gSOAP-1.3b.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/gSOAP-1.3b.json",
-      "referenceNumber": 658,
+      "referenceNumber": 315,
       "name": "gSOAP Public License v1.3b",
       "licenseId": "gSOAP-1.3b",
       "seeAlso": [
@@ -3791,7 +3866,7 @@
       "reference": "https://spdx.org/licenses/gtkbook.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/gtkbook.json",
-      "referenceNumber": 397,
+      "referenceNumber": 361,
       "name": "gtkbook License",
       "licenseId": "gtkbook",
       "seeAlso": [
@@ -3804,7 +3879,7 @@
       "reference": "https://spdx.org/licenses/Gutmann.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Gutmann.json",
-      "referenceNumber": 103,
+      "referenceNumber": 146,
       "name": "Gutmann License",
       "licenseId": "Gutmann",
       "seeAlso": [
@@ -3816,7 +3891,7 @@
       "reference": "https://spdx.org/licenses/HaskellReport.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HaskellReport.json",
-      "referenceNumber": 357,
+      "referenceNumber": 592,
       "name": "Haskell Language Report License",
       "licenseId": "HaskellReport",
       "seeAlso": [
@@ -3828,7 +3903,7 @@
       "reference": "https://spdx.org/licenses/hdparm.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/hdparm.json",
-      "referenceNumber": 351,
+      "referenceNumber": 139,
       "name": "hdparm License",
       "licenseId": "hdparm",
       "seeAlso": [
@@ -3840,7 +3915,7 @@
       "reference": "https://spdx.org/licenses/HIDAPI.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HIDAPI.json",
-      "referenceNumber": 318,
+      "referenceNumber": 637,
       "name": "HIDAPI License",
       "licenseId": "HIDAPI",
       "seeAlso": [
@@ -3852,7 +3927,7 @@
       "reference": "https://spdx.org/licenses/Hippocratic-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Hippocratic-2.1.json",
-      "referenceNumber": 425,
+      "referenceNumber": 282,
       "name": "Hippocratic License 2.1",
       "licenseId": "Hippocratic-2.1",
       "seeAlso": [
@@ -3865,7 +3940,7 @@
       "reference": "https://spdx.org/licenses/HP-1986.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HP-1986.json",
-      "referenceNumber": 477,
+      "referenceNumber": 156,
       "name": "Hewlett-Packard 1986 License",
       "licenseId": "HP-1986",
       "seeAlso": [
@@ -3877,7 +3952,7 @@
       "reference": "https://spdx.org/licenses/HP-1989.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HP-1989.json",
-      "referenceNumber": 653,
+      "referenceNumber": 210,
       "name": "Hewlett-Packard 1989 License",
       "licenseId": "HP-1989",
       "seeAlso": [
@@ -3889,7 +3964,7 @@
       "reference": "https://spdx.org/licenses/HPND.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND.json",
-      "referenceNumber": 75,
+      "referenceNumber": 382,
       "name": "Historical Permission Notice and Disclaimer",
       "licenseId": "HPND",
       "seeAlso": [
@@ -3903,7 +3978,7 @@
       "reference": "https://spdx.org/licenses/HPND-DEC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-DEC.json",
-      "referenceNumber": 597,
+      "referenceNumber": 457,
       "name": "Historical Permission Notice and Disclaimer - DEC variant",
       "licenseId": "HPND-DEC",
       "seeAlso": [
@@ -3915,7 +3990,7 @@
       "reference": "https://spdx.org/licenses/HPND-doc.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-doc.json",
-      "referenceNumber": 384,
+      "referenceNumber": 441,
       "name": "Historical Permission Notice and Disclaimer - documentation variant",
       "licenseId": "HPND-doc",
       "seeAlso": [
@@ -3928,7 +4003,7 @@
       "reference": "https://spdx.org/licenses/HPND-doc-sell.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-doc-sell.json",
-      "referenceNumber": 648,
+      "referenceNumber": 679,
       "name": "Historical Permission Notice and Disclaimer - documentation sell variant",
       "licenseId": "HPND-doc-sell",
       "seeAlso": [
@@ -3941,7 +4016,7 @@
       "reference": "https://spdx.org/licenses/HPND-export-US.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-export-US.json",
-      "referenceNumber": 551,
+      "referenceNumber": 157,
       "name": "HPND with US Government export control warning",
       "licenseId": "HPND-export-US",
       "seeAlso": [
@@ -3953,7 +4028,7 @@
       "reference": "https://spdx.org/licenses/HPND-export-US-acknowledgement.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-export-US-acknowledgement.json",
-      "referenceNumber": 661,
+      "referenceNumber": 56,
       "name": "HPND with US Government export control warning and acknowledgment",
       "licenseId": "HPND-export-US-acknowledgement",
       "seeAlso": [
@@ -3966,7 +4041,7 @@
       "reference": "https://spdx.org/licenses/HPND-export-US-modify.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-export-US-modify.json",
-      "referenceNumber": 119,
+      "referenceNumber": 475,
       "name": "HPND with US Government export control warning and modification rqmt",
       "licenseId": "HPND-export-US-modify",
       "seeAlso": [
@@ -3979,7 +4054,7 @@
       "reference": "https://spdx.org/licenses/HPND-export2-US.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-export2-US.json",
-      "referenceNumber": 450,
+      "referenceNumber": 621,
       "name": "HPND with US Government export control and 2 disclaimers",
       "licenseId": "HPND-export2-US",
       "seeAlso": [
@@ -3992,7 +4067,7 @@
       "reference": "https://spdx.org/licenses/HPND-Fenneberg-Livingston.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-Fenneberg-Livingston.json",
-      "referenceNumber": 643,
+      "referenceNumber": 407,
       "name": "Historical Permission Notice and Disclaimer - Fenneberg-Livingston variant",
       "licenseId": "HPND-Fenneberg-Livingston",
       "seeAlso": [
@@ -4005,7 +4080,7 @@
       "reference": "https://spdx.org/licenses/HPND-INRIA-IMAG.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-INRIA-IMAG.json",
-      "referenceNumber": 583,
+      "referenceNumber": 611,
       "name": "Historical Permission Notice and Disclaimer    - INRIA-IMAG variant",
       "licenseId": "HPND-INRIA-IMAG",
       "seeAlso": [
@@ -4017,7 +4092,7 @@
       "reference": "https://spdx.org/licenses/HPND-Intel.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-Intel.json",
-      "referenceNumber": 20,
+      "referenceNumber": 86,
       "name": "Historical Permission Notice and Disclaimer - Intel variant",
       "licenseId": "HPND-Intel",
       "seeAlso": [
@@ -4029,7 +4104,7 @@
       "reference": "https://spdx.org/licenses/HPND-Kevlin-Henney.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-Kevlin-Henney.json",
-      "referenceNumber": 637,
+      "referenceNumber": 278,
       "name": "Historical Permission Notice and Disclaimer - Kevlin Henney variant",
       "licenseId": "HPND-Kevlin-Henney",
       "seeAlso": [
@@ -4041,7 +4116,7 @@
       "reference": "https://spdx.org/licenses/HPND-Markus-Kuhn.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-Markus-Kuhn.json",
-      "referenceNumber": 172,
+      "referenceNumber": 445,
       "name": "Historical Permission Notice and Disclaimer - Markus Kuhn variant",
       "licenseId": "HPND-Markus-Kuhn",
       "seeAlso": [
@@ -4054,7 +4129,7 @@
       "reference": "https://spdx.org/licenses/HPND-merchantability-variant.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-merchantability-variant.json",
-      "referenceNumber": 572,
+      "referenceNumber": 207,
       "name": "Historical Permission Notice and Disclaimer - merchantability variant",
       "licenseId": "HPND-merchantability-variant",
       "seeAlso": [
@@ -4066,7 +4141,7 @@
       "reference": "https://spdx.org/licenses/HPND-MIT-disclaimer.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-MIT-disclaimer.json",
-      "referenceNumber": 609,
+      "referenceNumber": 455,
       "name": "Historical Permission Notice and Disclaimer with MIT disclaimer",
       "licenseId": "HPND-MIT-disclaimer",
       "seeAlso": [
@@ -4078,7 +4153,7 @@
       "reference": "https://spdx.org/licenses/HPND-Netrek.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-Netrek.json",
-      "referenceNumber": 126,
+      "referenceNumber": 608,
       "name": "Historical Permission Notice and Disclaimer - Netrek variant",
       "licenseId": "HPND-Netrek",
       "seeAlso": [],
@@ -4088,7 +4163,7 @@
       "reference": "https://spdx.org/licenses/HPND-Pbmplus.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-Pbmplus.json",
-      "referenceNumber": 242,
+      "referenceNumber": 675,
       "name": "Historical Permission Notice and Disclaimer - Pbmplus variant",
       "licenseId": "HPND-Pbmplus",
       "seeAlso": [
@@ -4100,7 +4175,7 @@
       "reference": "https://spdx.org/licenses/HPND-sell-MIT-disclaimer-xserver.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-sell-MIT-disclaimer-xserver.json",
-      "referenceNumber": 160,
+      "referenceNumber": 649,
       "name": "Historical Permission Notice and Disclaimer - sell xserver variant with MIT disclaimer",
       "licenseId": "HPND-sell-MIT-disclaimer-xserver",
       "seeAlso": [
@@ -4112,7 +4187,7 @@
       "reference": "https://spdx.org/licenses/HPND-sell-regexpr.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-sell-regexpr.json",
-      "referenceNumber": 44,
+      "referenceNumber": 527,
       "name": "Historical Permission Notice and Disclaimer - sell regexpr variant",
       "licenseId": "HPND-sell-regexpr",
       "seeAlso": [
@@ -4124,11 +4199,12 @@
       "reference": "https://spdx.org/licenses/HPND-sell-variant.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-sell-variant.json",
-      "referenceNumber": 485,
+      "referenceNumber": 231,
       "name": "Historical Permission Notice and Disclaimer - sell variant",
       "licenseId": "HPND-sell-variant",
       "seeAlso": [
-        "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/net/sunrpc/auth_gss/gss_generic_token.c?h\u003dv4.19"
+        "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/net/sunrpc/auth_gss/gss_generic_token.c?h\u003dv4.19",
+        "https://github.com/kfish/xsel/blob/master/COPYING"
       ],
       "isOsiApproved": false
     },
@@ -4136,7 +4212,7 @@
       "reference": "https://spdx.org/licenses/HPND-sell-variant-MIT-disclaimer.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-sell-variant-MIT-disclaimer.json",
-      "referenceNumber": 430,
+      "referenceNumber": 75,
       "name": "HPND sell variant with MIT disclaimer",
       "licenseId": "HPND-sell-variant-MIT-disclaimer",
       "seeAlso": [
@@ -4148,7 +4224,7 @@
       "reference": "https://spdx.org/licenses/HPND-sell-variant-MIT-disclaimer-rev.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-sell-variant-MIT-disclaimer-rev.json",
-      "referenceNumber": 10,
+      "referenceNumber": 661,
       "name": "HPND sell variant with MIT disclaimer - reverse",
       "licenseId": "HPND-sell-variant-MIT-disclaimer-rev",
       "seeAlso": [
@@ -4160,7 +4236,7 @@
       "reference": "https://spdx.org/licenses/HPND-UC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-UC.json",
-      "referenceNumber": 423,
+      "referenceNumber": 466,
       "name": "Historical Permission Notice and Disclaimer - University of California variant",
       "licenseId": "HPND-UC",
       "seeAlso": [
@@ -4172,7 +4248,7 @@
       "reference": "https://spdx.org/licenses/HPND-UC-export-US.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-UC-export-US.json",
-      "referenceNumber": 82,
+      "referenceNumber": 90,
       "name": "Historical Permission Notice and Disclaimer - University of California, US export warning",
       "licenseId": "HPND-UC-export-US",
       "seeAlso": [
@@ -4184,7 +4260,7 @@
       "reference": "https://spdx.org/licenses/HTMLTIDY.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HTMLTIDY.json",
-      "referenceNumber": 439,
+      "referenceNumber": 78,
       "name": "HTML Tidy License",
       "licenseId": "HTMLTIDY",
       "seeAlso": [
@@ -4196,7 +4272,7 @@
       "reference": "https://spdx.org/licenses/IBM-pibs.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/IBM-pibs.json",
-      "referenceNumber": 604,
+      "referenceNumber": 417,
       "name": "IBM PowerPC Initialization and Boot Software",
       "licenseId": "IBM-pibs",
       "seeAlso": [
@@ -4208,7 +4284,7 @@
       "reference": "https://spdx.org/licenses/ICU.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ICU.json",
-      "referenceNumber": 375,
+      "referenceNumber": 520,
       "name": "ICU License",
       "licenseId": "ICU",
       "seeAlso": [
@@ -4220,7 +4296,7 @@
       "reference": "https://spdx.org/licenses/IEC-Code-Components-EULA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/IEC-Code-Components-EULA.json",
-      "referenceNumber": 18,
+      "referenceNumber": 211,
       "name": "IEC    Code Components End-user licence agreement",
       "licenseId": "IEC-Code-Components-EULA",
       "seeAlso": [
@@ -4234,7 +4310,7 @@
       "reference": "https://spdx.org/licenses/IJG.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/IJG.json",
-      "referenceNumber": 374,
+      "referenceNumber": 672,
       "name": "Independent JPEG Group License",
       "licenseId": "IJG",
       "seeAlso": [
@@ -4247,7 +4323,7 @@
       "reference": "https://spdx.org/licenses/IJG-short.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/IJG-short.json",
-      "referenceNumber": 152,
+      "referenceNumber": 493,
       "name": "Independent JPEG Group License - short",
       "licenseId": "IJG-short",
       "seeAlso": [
@@ -4259,7 +4335,7 @@
       "reference": "https://spdx.org/licenses/ImageMagick.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ImageMagick.json",
-      "referenceNumber": 608,
+      "referenceNumber": 581,
       "name": "ImageMagick License",
       "licenseId": "ImageMagick",
       "seeAlso": [
@@ -4271,7 +4347,7 @@
       "reference": "https://spdx.org/licenses/iMatix.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/iMatix.json",
-      "referenceNumber": 645,
+      "referenceNumber": 129,
       "name": "iMatix Standard Function Library Agreement",
       "licenseId": "iMatix",
       "seeAlso": [
@@ -4284,7 +4360,7 @@
       "reference": "https://spdx.org/licenses/Imlib2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Imlib2.json",
-      "referenceNumber": 96,
+      "referenceNumber": 365,
       "name": "Imlib2 License",
       "licenseId": "Imlib2",
       "seeAlso": [
@@ -4298,7 +4374,7 @@
       "reference": "https://spdx.org/licenses/Info-ZIP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Info-ZIP.json",
-      "referenceNumber": 451,
+      "referenceNumber": 10,
       "name": "Info-ZIP License",
       "licenseId": "Info-ZIP",
       "seeAlso": [
@@ -4310,7 +4386,7 @@
       "reference": "https://spdx.org/licenses/Inner-Net-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Inner-Net-2.0.json",
-      "referenceNumber": 58,
+      "referenceNumber": 352,
       "name": "Inner Net License v2.0",
       "licenseId": "Inner-Net-2.0",
       "seeAlso": [
@@ -4320,10 +4396,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/InnoSetup.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/InnoSetup.json",
+      "referenceNumber": 19,
+      "name": "Inno Setup License",
+      "licenseId": "InnoSetup",
+      "seeAlso": [
+        "https://github.com/jrsoftware/issrc/blob/HEAD/license.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/Intel.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Intel.json",
-      "referenceNumber": 316,
+      "referenceNumber": 462,
       "name": "Intel Open Source License",
       "licenseId": "Intel",
       "seeAlso": [
@@ -4336,7 +4424,7 @@
       "reference": "https://spdx.org/licenses/Intel-ACPI.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Intel-ACPI.json",
-      "referenceNumber": 309,
+      "referenceNumber": 509,
       "name": "Intel ACPI Software License Agreement",
       "licenseId": "Intel-ACPI",
       "seeAlso": [
@@ -4348,7 +4436,7 @@
       "reference": "https://spdx.org/licenses/Interbase-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Interbase-1.0.json",
-      "referenceNumber": 665,
+      "referenceNumber": 569,
       "name": "Interbase Public License v1.0",
       "licenseId": "Interbase-1.0",
       "seeAlso": [
@@ -4360,7 +4448,7 @@
       "reference": "https://spdx.org/licenses/IPA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/IPA.json",
-      "referenceNumber": 237,
+      "referenceNumber": 49,
       "name": "IPA Font License",
       "licenseId": "IPA",
       "seeAlso": [
@@ -4373,7 +4461,7 @@
       "reference": "https://spdx.org/licenses/IPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/IPL-1.0.json",
-      "referenceNumber": 443,
+      "referenceNumber": 20,
       "name": "IBM Public License v1.0",
       "licenseId": "IPL-1.0",
       "seeAlso": [
@@ -4386,7 +4474,7 @@
       "reference": "https://spdx.org/licenses/ISC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ISC.json",
-      "referenceNumber": 131,
+      "referenceNumber": 593,
       "name": "ISC License",
       "licenseId": "ISC",
       "seeAlso": [
@@ -4401,7 +4489,7 @@
       "reference": "https://spdx.org/licenses/ISC-Veillard.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ISC-Veillard.json",
-      "referenceNumber": 554,
+      "referenceNumber": 401,
       "name": "ISC Veillard variant",
       "licenseId": "ISC-Veillard",
       "seeAlso": [
@@ -4415,7 +4503,7 @@
       "reference": "https://spdx.org/licenses/Jam.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Jam.json",
-      "referenceNumber": 338,
+      "referenceNumber": 409,
       "name": "Jam License",
       "licenseId": "Jam",
       "seeAlso": [
@@ -4428,7 +4516,7 @@
       "reference": "https://spdx.org/licenses/JasPer-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/JasPer-2.0.json",
-      "referenceNumber": 591,
+      "referenceNumber": 316,
       "name": "JasPer License",
       "licenseId": "JasPer-2.0",
       "seeAlso": [
@@ -4440,7 +4528,7 @@
       "reference": "https://spdx.org/licenses/JPL-image.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/JPL-image.json",
-      "referenceNumber": 343,
+      "referenceNumber": 195,
       "name": "JPL Image Use Policy",
       "licenseId": "JPL-image",
       "seeAlso": [
@@ -4452,7 +4540,7 @@
       "reference": "https://spdx.org/licenses/JPNIC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/JPNIC.json",
-      "referenceNumber": 117,
+      "referenceNumber": 22,
       "name": "Japan Network Information Center License",
       "licenseId": "JPNIC",
       "seeAlso": [
@@ -4464,7 +4552,7 @@
       "reference": "https://spdx.org/licenses/JSON.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/JSON.json",
-      "referenceNumber": 174,
+      "referenceNumber": 662,
       "name": "JSON License",
       "licenseId": "JSON",
       "seeAlso": [
@@ -4477,7 +4565,7 @@
       "reference": "https://spdx.org/licenses/Kastrup.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Kastrup.json",
-      "referenceNumber": 181,
+      "referenceNumber": 468,
       "name": "Kastrup License",
       "licenseId": "Kastrup",
       "seeAlso": [
@@ -4489,7 +4577,7 @@
       "reference": "https://spdx.org/licenses/Kazlib.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Kazlib.json",
-      "referenceNumber": 197,
+      "referenceNumber": 71,
       "name": "Kazlib License",
       "licenseId": "Kazlib",
       "seeAlso": [
@@ -4501,7 +4589,7 @@
       "reference": "https://spdx.org/licenses/Knuth-CTAN.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Knuth-CTAN.json",
-      "referenceNumber": 22,
+      "referenceNumber": 505,
       "name": "Knuth CTAN License",
       "licenseId": "Knuth-CTAN",
       "seeAlso": [
@@ -4513,7 +4601,7 @@
       "reference": "https://spdx.org/licenses/LAL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LAL-1.2.json",
-      "referenceNumber": 261,
+      "referenceNumber": 484,
       "name": "Licence Art Libre 1.2",
       "licenseId": "LAL-1.2",
       "seeAlso": [
@@ -4525,7 +4613,7 @@
       "reference": "https://spdx.org/licenses/LAL-1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LAL-1.3.json",
-      "referenceNumber": 526,
+      "referenceNumber": 363,
       "name": "Licence Art Libre 1.3",
       "licenseId": "LAL-1.3",
       "seeAlso": [
@@ -4537,7 +4625,7 @@
       "reference": "https://spdx.org/licenses/Latex2e.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Latex2e.json",
-      "referenceNumber": 3,
+      "referenceNumber": 83,
       "name": "Latex2e License",
       "licenseId": "Latex2e",
       "seeAlso": [
@@ -4549,7 +4637,7 @@
       "reference": "https://spdx.org/licenses/Latex2e-translated-notice.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Latex2e-translated-notice.json",
-      "referenceNumber": 104,
+      "referenceNumber": 48,
       "name": "Latex2e with translated notice permission",
       "licenseId": "Latex2e-translated-notice",
       "seeAlso": [
@@ -4561,7 +4649,7 @@
       "reference": "https://spdx.org/licenses/Leptonica.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Leptonica.json",
-      "referenceNumber": 221,
+      "referenceNumber": 391,
       "name": "Leptonica License",
       "licenseId": "Leptonica",
       "seeAlso": [
@@ -4573,7 +4661,7 @@
       "reference": "https://spdx.org/licenses/LGPL-2.0.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/LGPL-2.0.json",
-      "referenceNumber": 81,
+      "referenceNumber": 570,
       "name": "GNU Library General Public License v2 only",
       "licenseId": "LGPL-2.0",
       "seeAlso": [
@@ -4585,7 +4673,7 @@
       "reference": "https://spdx.org/licenses/LGPL-2.0+.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/LGPL-2.0+.json",
-      "referenceNumber": 265,
+      "referenceNumber": 412,
       "name": "GNU Library General Public License v2 or later",
       "licenseId": "LGPL-2.0+",
       "seeAlso": [
@@ -4597,7 +4685,7 @@
       "reference": "https://spdx.org/licenses/LGPL-2.0-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LGPL-2.0-only.json",
-      "referenceNumber": 517,
+      "referenceNumber": 458,
       "name": "GNU Library General Public License v2 only",
       "licenseId": "LGPL-2.0-only",
       "seeAlso": [
@@ -4609,7 +4697,7 @@
       "reference": "https://spdx.org/licenses/LGPL-2.0-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LGPL-2.0-or-later.json",
-      "referenceNumber": 458,
+      "referenceNumber": 168,
       "name": "GNU Library General Public License v2 or later",
       "licenseId": "LGPL-2.0-or-later",
       "seeAlso": [
@@ -4621,7 +4709,7 @@
       "reference": "https://spdx.org/licenses/LGPL-2.1.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/LGPL-2.1.json",
-      "referenceNumber": 659,
+      "referenceNumber": 224,
       "name": "GNU Lesser General Public License v2.1 only",
       "licenseId": "LGPL-2.1",
       "seeAlso": [
@@ -4635,7 +4723,7 @@
       "reference": "https://spdx.org/licenses/LGPL-2.1+.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/LGPL-2.1+.json",
-      "referenceNumber": 69,
+      "referenceNumber": 566,
       "name": "GNU Lesser General Public License v2.1 or later",
       "licenseId": "LGPL-2.1+",
       "seeAlso": [
@@ -4649,7 +4737,7 @@
       "reference": "https://spdx.org/licenses/LGPL-2.1-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LGPL-2.1-only.json",
-      "referenceNumber": 524,
+      "referenceNumber": 59,
       "name": "GNU Lesser General Public License v2.1 only",
       "licenseId": "LGPL-2.1-only",
       "seeAlso": [
@@ -4663,7 +4751,7 @@
       "reference": "https://spdx.org/licenses/LGPL-2.1-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LGPL-2.1-or-later.json",
-      "referenceNumber": 336,
+      "referenceNumber": 97,
       "name": "GNU Lesser General Public License v2.1 or later",
       "licenseId": "LGPL-2.1-or-later",
       "seeAlso": [
@@ -4677,7 +4765,7 @@
       "reference": "https://spdx.org/licenses/LGPL-3.0.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/LGPL-3.0.json",
-      "referenceNumber": 381,
+      "referenceNumber": 372,
       "name": "GNU Lesser General Public License v3.0 only",
       "licenseId": "LGPL-3.0",
       "seeAlso": [
@@ -4692,7 +4780,7 @@
       "reference": "https://spdx.org/licenses/LGPL-3.0+.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/LGPL-3.0+.json",
-      "referenceNumber": 303,
+      "referenceNumber": 405,
       "name": "GNU Lesser General Public License v3.0 or later",
       "licenseId": "LGPL-3.0+",
       "seeAlso": [
@@ -4707,7 +4795,7 @@
       "reference": "https://spdx.org/licenses/LGPL-3.0-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LGPL-3.0-only.json",
-      "referenceNumber": 225,
+      "referenceNumber": 571,
       "name": "GNU Lesser General Public License v3.0 only",
       "licenseId": "LGPL-3.0-only",
       "seeAlso": [
@@ -4722,7 +4810,7 @@
       "reference": "https://spdx.org/licenses/LGPL-3.0-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LGPL-3.0-or-later.json",
-      "referenceNumber": 411,
+      "referenceNumber": 313,
       "name": "GNU Lesser General Public License v3.0 or later",
       "licenseId": "LGPL-3.0-or-later",
       "seeAlso": [
@@ -4737,7 +4825,7 @@
       "reference": "https://spdx.org/licenses/LGPLLR.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LGPLLR.json",
-      "referenceNumber": 87,
+      "referenceNumber": 76,
       "name": "Lesser General Public License For Linguistic Resources",
       "licenseId": "LGPLLR",
       "seeAlso": [
@@ -4749,7 +4837,7 @@
       "reference": "https://spdx.org/licenses/Libpng.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Libpng.json",
-      "referenceNumber": 531,
+      "referenceNumber": 648,
       "name": "libpng License",
       "licenseId": "Libpng",
       "seeAlso": [
@@ -4761,7 +4849,7 @@
       "reference": "https://spdx.org/licenses/libpng-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/libpng-2.0.json",
-      "referenceNumber": 149,
+      "referenceNumber": 390,
       "name": "PNG Reference Library version 2",
       "licenseId": "libpng-2.0",
       "seeAlso": [
@@ -4773,7 +4861,7 @@
       "reference": "https://spdx.org/licenses/libselinux-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/libselinux-1.0.json",
-      "referenceNumber": 320,
+      "referenceNumber": 406,
       "name": "libselinux public domain notice",
       "licenseId": "libselinux-1.0",
       "seeAlso": [
@@ -4785,7 +4873,7 @@
       "reference": "https://spdx.org/licenses/libtiff.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/libtiff.json",
-      "referenceNumber": 24,
+      "referenceNumber": 589,
       "name": "libtiff License",
       "licenseId": "libtiff",
       "seeAlso": [
@@ -4797,7 +4885,7 @@
       "reference": "https://spdx.org/licenses/libutil-David-Nugent.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/libutil-David-Nugent.json",
-      "referenceNumber": 662,
+      "referenceNumber": 218,
       "name": "libutil David Nugent License",
       "licenseId": "libutil-David-Nugent",
       "seeAlso": [
@@ -4810,7 +4898,7 @@
       "reference": "https://spdx.org/licenses/LiLiQ-P-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LiLiQ-P-1.1.json",
-      "referenceNumber": 150,
+      "referenceNumber": 289,
       "name": "Licence Libre du Québec – Permissive version 1.1",
       "licenseId": "LiLiQ-P-1.1",
       "seeAlso": [
@@ -4823,7 +4911,7 @@
       "reference": "https://spdx.org/licenses/LiLiQ-R-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LiLiQ-R-1.1.json",
-      "referenceNumber": 203,
+      "referenceNumber": 354,
       "name": "Licence Libre du Québec – Réciprocité version 1.1",
       "licenseId": "LiLiQ-R-1.1",
       "seeAlso": [
@@ -4836,7 +4924,7 @@
       "reference": "https://spdx.org/licenses/LiLiQ-Rplus-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LiLiQ-Rplus-1.1.json",
-      "referenceNumber": 314,
+      "referenceNumber": 222,
       "name": "Licence Libre du Québec – Réciprocité forte version 1.1",
       "licenseId": "LiLiQ-Rplus-1.1",
       "seeAlso": [
@@ -4849,7 +4937,7 @@
       "reference": "https://spdx.org/licenses/Linux-man-pages-1-para.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Linux-man-pages-1-para.json",
-      "referenceNumber": 577,
+      "referenceNumber": 419,
       "name": "Linux man-pages - 1 paragraph",
       "licenseId": "Linux-man-pages-1-para",
       "seeAlso": [
@@ -4861,7 +4949,7 @@
       "reference": "https://spdx.org/licenses/Linux-man-pages-copyleft.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Linux-man-pages-copyleft.json",
-      "referenceNumber": 213,
+      "referenceNumber": 585,
       "name": "Linux man-pages Copyleft",
       "licenseId": "Linux-man-pages-copyleft",
       "seeAlso": [
@@ -4873,7 +4961,7 @@
       "reference": "https://spdx.org/licenses/Linux-man-pages-copyleft-2-para.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Linux-man-pages-copyleft-2-para.json",
-      "referenceNumber": 352,
+      "referenceNumber": 633,
       "name": "Linux man-pages Copyleft - 2 paragraphs",
       "licenseId": "Linux-man-pages-copyleft-2-para",
       "seeAlso": [
@@ -4886,7 +4974,7 @@
       "reference": "https://spdx.org/licenses/Linux-man-pages-copyleft-var.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Linux-man-pages-copyleft-var.json",
-      "referenceNumber": 186,
+      "referenceNumber": 480,
       "name": "Linux man-pages Copyleft Variant",
       "licenseId": "Linux-man-pages-copyleft-var",
       "seeAlso": [
@@ -4898,7 +4986,7 @@
       "reference": "https://spdx.org/licenses/Linux-OpenIB.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Linux-OpenIB.json",
-      "referenceNumber": 278,
+      "referenceNumber": 383,
       "name": "Linux Kernel Variant of OpenIB.org license",
       "licenseId": "Linux-OpenIB",
       "seeAlso": [
@@ -4910,7 +4998,7 @@
       "reference": "https://spdx.org/licenses/LOOP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LOOP.json",
-      "referenceNumber": 521,
+      "referenceNumber": 132,
       "name": "Common Lisp LOOP License",
       "licenseId": "LOOP",
       "seeAlso": [
@@ -4927,7 +5015,7 @@
       "reference": "https://spdx.org/licenses/LPD-document.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LPD-document.json",
-      "referenceNumber": 561,
+      "referenceNumber": 341,
       "name": "LPD Documentation License",
       "licenseId": "LPD-document",
       "seeAlso": [
@@ -4940,7 +5028,7 @@
       "reference": "https://spdx.org/licenses/LPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LPL-1.0.json",
-      "referenceNumber": 267,
+      "referenceNumber": 537,
       "name": "Lucent Public License Version 1.0",
       "licenseId": "LPL-1.0",
       "seeAlso": [
@@ -4952,7 +5040,7 @@
       "reference": "https://spdx.org/licenses/LPL-1.02.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LPL-1.02.json",
-      "referenceNumber": 122,
+      "referenceNumber": 269,
       "name": "Lucent Public License v1.02",
       "licenseId": "LPL-1.02",
       "seeAlso": [
@@ -4966,7 +5054,7 @@
       "reference": "https://spdx.org/licenses/LPPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LPPL-1.0.json",
-      "referenceNumber": 133,
+      "referenceNumber": 653,
       "name": "LaTeX Project Public License v1.0",
       "licenseId": "LPPL-1.0",
       "seeAlso": [
@@ -4978,7 +5066,7 @@
       "reference": "https://spdx.org/licenses/LPPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LPPL-1.1.json",
-      "referenceNumber": 284,
+      "referenceNumber": 538,
       "name": "LaTeX Project Public License v1.1",
       "licenseId": "LPPL-1.1",
       "seeAlso": [
@@ -4990,7 +5078,7 @@
       "reference": "https://spdx.org/licenses/LPPL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LPPL-1.2.json",
-      "referenceNumber": 407,
+      "referenceNumber": 104,
       "name": "LaTeX Project Public License v1.2",
       "licenseId": "LPPL-1.2",
       "seeAlso": [
@@ -5003,7 +5091,7 @@
       "reference": "https://spdx.org/licenses/LPPL-1.3a.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LPPL-1.3a.json",
-      "referenceNumber": 510,
+      "referenceNumber": 523,
       "name": "LaTeX Project Public License v1.3a",
       "licenseId": "LPPL-1.3a",
       "seeAlso": [
@@ -5016,7 +5104,7 @@
       "reference": "https://spdx.org/licenses/LPPL-1.3c.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LPPL-1.3c.json",
-      "referenceNumber": 300,
+      "referenceNumber": 11,
       "name": "LaTeX Project Public License v1.3c",
       "licenseId": "LPPL-1.3c",
       "seeAlso": [
@@ -5029,7 +5117,7 @@
       "reference": "https://spdx.org/licenses/lsof.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/lsof.json",
-      "referenceNumber": 76,
+      "referenceNumber": 259,
       "name": "lsof License",
       "licenseId": "lsof",
       "seeAlso": [
@@ -5041,7 +5129,7 @@
       "reference": "https://spdx.org/licenses/Lucida-Bitmap-Fonts.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Lucida-Bitmap-Fonts.json",
-      "referenceNumber": 383,
+      "referenceNumber": 330,
       "name": "Lucida Bitmap Fonts License",
       "licenseId": "Lucida-Bitmap-Fonts",
       "seeAlso": [
@@ -5053,7 +5141,7 @@
       "reference": "https://spdx.org/licenses/LZMA-SDK-9.11-to-9.20.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LZMA-SDK-9.11-to-9.20.json",
-      "referenceNumber": 239,
+      "referenceNumber": 273,
       "name": "LZMA SDK License (versions 9.11 to 9.20)",
       "licenseId": "LZMA-SDK-9.11-to-9.20",
       "seeAlso": [
@@ -5066,7 +5154,7 @@
       "reference": "https://spdx.org/licenses/LZMA-SDK-9.22.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LZMA-SDK-9.22.json",
-      "referenceNumber": 600,
+      "referenceNumber": 446,
       "name": "LZMA SDK License (versions 9.22 and beyond)",
       "licenseId": "LZMA-SDK-9.22",
       "seeAlso": [
@@ -5079,7 +5167,7 @@
       "reference": "https://spdx.org/licenses/Mackerras-3-Clause.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Mackerras-3-Clause.json",
-      "referenceNumber": 540,
+      "referenceNumber": 503,
       "name": "Mackerras 3-Clause License",
       "licenseId": "Mackerras-3-Clause",
       "seeAlso": [
@@ -5091,7 +5179,7 @@
       "reference": "https://spdx.org/licenses/Mackerras-3-Clause-acknowledgment.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Mackerras-3-Clause-acknowledgment.json",
-      "referenceNumber": 176,
+      "referenceNumber": 564,
       "name": "Mackerras 3-Clause - acknowledgment variant",
       "licenseId": "Mackerras-3-Clause-acknowledgment",
       "seeAlso": [
@@ -5103,7 +5191,7 @@
       "reference": "https://spdx.org/licenses/magaz.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/magaz.json",
-      "referenceNumber": 93,
+      "referenceNumber": 217,
       "name": "magaz License",
       "licenseId": "magaz",
       "seeAlso": [
@@ -5115,7 +5203,7 @@
       "reference": "https://spdx.org/licenses/mailprio.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/mailprio.json",
-      "referenceNumber": 292,
+      "referenceNumber": 62,
       "name": "mailprio License",
       "licenseId": "mailprio",
       "seeAlso": [
@@ -5127,7 +5215,7 @@
       "reference": "https://spdx.org/licenses/MakeIndex.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MakeIndex.json",
-      "referenceNumber": 552,
+      "referenceNumber": 291,
       "name": "MakeIndex License",
       "licenseId": "MakeIndex",
       "seeAlso": [
@@ -5139,7 +5227,7 @@
       "reference": "https://spdx.org/licenses/Martin-Birgmeier.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Martin-Birgmeier.json",
-      "referenceNumber": 364,
+      "referenceNumber": 186,
       "name": "Martin Birgmeier License",
       "licenseId": "Martin-Birgmeier",
       "seeAlso": [
@@ -5151,7 +5239,7 @@
       "reference": "https://spdx.org/licenses/McPhee-slideshow.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/McPhee-slideshow.json",
-      "referenceNumber": 511,
+      "referenceNumber": 189,
       "name": "McPhee Slideshow License",
       "licenseId": "McPhee-slideshow",
       "seeAlso": [
@@ -5163,7 +5251,7 @@
       "reference": "https://spdx.org/licenses/metamail.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/metamail.json",
-      "referenceNumber": 325,
+      "referenceNumber": 512,
       "name": "metamail License",
       "licenseId": "metamail",
       "seeAlso": [
@@ -5175,7 +5263,7 @@
       "reference": "https://spdx.org/licenses/Minpack.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Minpack.json",
-      "referenceNumber": 634,
+      "referenceNumber": 609,
       "name": "Minpack License",
       "licenseId": "Minpack",
       "seeAlso": [
@@ -5185,10 +5273,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/MIPS.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MIPS.json",
+      "referenceNumber": 550,
+      "name": "MIPS License",
+      "licenseId": "MIPS",
+      "seeAlso": [
+        "https://sourceware.org/cgit/binutils-gdb/tree/include/coff/sym.h#n11"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/MirOS.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MirOS.json",
-      "referenceNumber": 202,
+      "referenceNumber": 16,
       "name": "The MirOS Licence",
       "licenseId": "MirOS",
       "seeAlso": [
@@ -5200,7 +5300,7 @@
       "reference": "https://spdx.org/licenses/MIT.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT.json",
-      "referenceNumber": 601,
+      "referenceNumber": 144,
       "name": "MIT License",
       "licenseId": "MIT",
       "seeAlso": [
@@ -5213,7 +5313,7 @@
       "reference": "https://spdx.org/licenses/MIT-0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-0.json",
-      "referenceNumber": 587,
+      "referenceNumber": 127,
       "name": "MIT No Attribution",
       "licenseId": "MIT-0",
       "seeAlso": [
@@ -5227,7 +5327,7 @@
       "reference": "https://spdx.org/licenses/MIT-advertising.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-advertising.json",
-      "referenceNumber": 39,
+      "referenceNumber": 246,
       "name": "Enlightenment License (e16)",
       "licenseId": "MIT-advertising",
       "seeAlso": [
@@ -5236,10 +5336,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/MIT-Click.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MIT-Click.json",
+      "referenceNumber": 374,
+      "name": "MIT Click License",
+      "licenseId": "MIT-Click",
+      "seeAlso": [
+        "https://github.com/kohler/t1utils/blob/master/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/MIT-CMU.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-CMU.json",
-      "referenceNumber": 36,
+      "referenceNumber": 469,
       "name": "CMU License",
       "licenseId": "MIT-CMU",
       "seeAlso": [
@@ -5252,7 +5364,7 @@
       "reference": "https://spdx.org/licenses/MIT-enna.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-enna.json",
-      "referenceNumber": 207,
+      "referenceNumber": 196,
       "name": "enna License",
       "licenseId": "MIT-enna",
       "seeAlso": [
@@ -5264,7 +5376,7 @@
       "reference": "https://spdx.org/licenses/MIT-feh.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-feh.json",
-      "referenceNumber": 146,
+      "referenceNumber": 223,
       "name": "feh License",
       "licenseId": "MIT-feh",
       "seeAlso": [
@@ -5276,7 +5388,7 @@
       "reference": "https://spdx.org/licenses/MIT-Festival.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-Festival.json",
-      "referenceNumber": 431,
+      "referenceNumber": 167,
       "name": "MIT Festival Variant",
       "licenseId": "MIT-Festival",
       "seeAlso": [
@@ -5289,7 +5401,7 @@
       "reference": "https://spdx.org/licenses/MIT-Khronos-old.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-Khronos-old.json",
-      "referenceNumber": 68,
+      "referenceNumber": 340,
       "name": "MIT Khronos - old variant",
       "licenseId": "MIT-Khronos-old",
       "seeAlso": [
@@ -5301,7 +5413,7 @@
       "reference": "https://spdx.org/licenses/MIT-Modern-Variant.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-Modern-Variant.json",
-      "referenceNumber": 92,
+      "referenceNumber": 573,
       "name": "MIT License Modern Variant",
       "licenseId": "MIT-Modern-Variant",
       "seeAlso": [
@@ -5315,7 +5427,7 @@
       "reference": "https://spdx.org/licenses/MIT-open-group.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-open-group.json",
-      "referenceNumber": 520,
+      "referenceNumber": 552,
       "name": "MIT Open Group variant",
       "licenseId": "MIT-open-group",
       "seeAlso": [
@@ -5330,7 +5442,7 @@
       "reference": "https://spdx.org/licenses/MIT-testregex.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-testregex.json",
-      "referenceNumber": 578,
+      "referenceNumber": 133,
       "name": "MIT testregex Variant",
       "licenseId": "MIT-testregex",
       "seeAlso": [
@@ -5342,7 +5454,7 @@
       "reference": "https://spdx.org/licenses/MIT-Wu.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-Wu.json",
-      "referenceNumber": 156,
+      "referenceNumber": 467,
       "name": "MIT Tom Wu Variant",
       "licenseId": "MIT-Wu",
       "seeAlso": [
@@ -5354,7 +5466,7 @@
       "reference": "https://spdx.org/licenses/MITNFA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MITNFA.json",
-      "referenceNumber": 650,
+      "referenceNumber": 588,
       "name": "MIT +no-false-attribs license",
       "licenseId": "MITNFA",
       "seeAlso": [
@@ -5366,7 +5478,7 @@
       "reference": "https://spdx.org/licenses/MMIXware.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MMIXware.json",
-      "referenceNumber": 444,
+      "referenceNumber": 54,
       "name": "MMIXware License",
       "licenseId": "MMIXware",
       "seeAlso": [
@@ -5378,7 +5490,7 @@
       "reference": "https://spdx.org/licenses/Motosoto.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Motosoto.json",
-      "referenceNumber": 31,
+      "referenceNumber": 208,
       "name": "Motosoto License",
       "licenseId": "Motosoto",
       "seeAlso": [
@@ -5390,7 +5502,7 @@
       "reference": "https://spdx.org/licenses/MPEG-SSG.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MPEG-SSG.json",
-      "referenceNumber": 323,
+      "referenceNumber": 597,
       "name": "MPEG Software Simulation",
       "licenseId": "MPEG-SSG",
       "seeAlso": [
@@ -5402,7 +5514,7 @@
       "reference": "https://spdx.org/licenses/mpi-permissive.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/mpi-permissive.json",
-      "referenceNumber": 459,
+      "referenceNumber": 482,
       "name": "mpi Permissive License",
       "licenseId": "mpi-permissive",
       "seeAlso": [
@@ -5414,7 +5526,7 @@
       "reference": "https://spdx.org/licenses/mpich2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/mpich2.json",
-      "referenceNumber": 448,
+      "referenceNumber": 118,
       "name": "mpich2 License",
       "licenseId": "mpich2",
       "seeAlso": [
@@ -5426,7 +5538,7 @@
       "reference": "https://spdx.org/licenses/MPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MPL-1.0.json",
-      "referenceNumber": 248,
+      "referenceNumber": 32,
       "name": "Mozilla Public License 1.0",
       "licenseId": "MPL-1.0",
       "seeAlso": [
@@ -5439,7 +5551,7 @@
       "reference": "https://spdx.org/licenses/MPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MPL-1.1.json",
-      "referenceNumber": 219,
+      "referenceNumber": 25,
       "name": "Mozilla Public License 1.1",
       "licenseId": "MPL-1.1",
       "seeAlso": [
@@ -5453,7 +5565,7 @@
       "reference": "https://spdx.org/licenses/MPL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MPL-2.0.json",
-      "referenceNumber": 147,
+      "referenceNumber": 249,
       "name": "Mozilla Public License 2.0",
       "licenseId": "MPL-2.0",
       "seeAlso": [
@@ -5467,7 +5579,7 @@
       "reference": "https://spdx.org/licenses/MPL-2.0-no-copyleft-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MPL-2.0-no-copyleft-exception.json",
-      "referenceNumber": 529,
+      "referenceNumber": 350,
       "name": "Mozilla Public License 2.0 (no copyleft exception)",
       "licenseId": "MPL-2.0-no-copyleft-exception",
       "seeAlso": [
@@ -5480,7 +5592,7 @@
       "reference": "https://spdx.org/licenses/mplus.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/mplus.json",
-      "referenceNumber": 553,
+      "referenceNumber": 85,
       "name": "mplus Font License",
       "licenseId": "mplus",
       "seeAlso": [
@@ -5492,7 +5604,7 @@
       "reference": "https://spdx.org/licenses/MS-LPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MS-LPL.json",
-      "referenceNumber": 412,
+      "referenceNumber": 370,
       "name": "Microsoft Limited Public License",
       "licenseId": "MS-LPL",
       "seeAlso": [
@@ -5506,7 +5618,7 @@
       "reference": "https://spdx.org/licenses/MS-PL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MS-PL.json",
-      "referenceNumber": 360,
+      "referenceNumber": 430,
       "name": "Microsoft Public License",
       "licenseId": "MS-PL",
       "seeAlso": [
@@ -5520,7 +5632,7 @@
       "reference": "https://spdx.org/licenses/MS-RL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MS-RL.json",
-      "referenceNumber": 212,
+      "referenceNumber": 285,
       "name": "Microsoft Reciprocal License",
       "licenseId": "MS-RL",
       "seeAlso": [
@@ -5534,7 +5646,7 @@
       "reference": "https://spdx.org/licenses/MTLL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MTLL.json",
-      "referenceNumber": 610,
+      "referenceNumber": 620,
       "name": "Matrix Template Library License",
       "licenseId": "MTLL",
       "seeAlso": [
@@ -5546,7 +5658,7 @@
       "reference": "https://spdx.org/licenses/MulanPSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MulanPSL-1.0.json",
-      "referenceNumber": 236,
+      "referenceNumber": 599,
       "name": "Mulan Permissive Software License, Version 1",
       "licenseId": "MulanPSL-1.0",
       "seeAlso": [
@@ -5559,7 +5671,7 @@
       "reference": "https://spdx.org/licenses/MulanPSL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MulanPSL-2.0.json",
-      "referenceNumber": 523,
+      "referenceNumber": 327,
       "name": "Mulan Permissive Software License, Version 2",
       "licenseId": "MulanPSL-2.0",
       "seeAlso": [
@@ -5571,7 +5683,7 @@
       "reference": "https://spdx.org/licenses/Multics.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Multics.json",
-      "referenceNumber": 462,
+      "referenceNumber": 427,
       "name": "Multics License",
       "licenseId": "Multics",
       "seeAlso": [
@@ -5583,7 +5695,7 @@
       "reference": "https://spdx.org/licenses/Mup.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Mup.json",
-      "referenceNumber": 515,
+      "referenceNumber": 371,
       "name": "Mup License",
       "licenseId": "Mup",
       "seeAlso": [
@@ -5595,7 +5707,7 @@
       "reference": "https://spdx.org/licenses/NAIST-2003.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NAIST-2003.json",
-      "referenceNumber": 118,
+      "referenceNumber": 220,
       "name": "Nara Institute of Science and Technology License (2003)",
       "licenseId": "NAIST-2003",
       "seeAlso": [
@@ -5608,7 +5720,7 @@
       "reference": "https://spdx.org/licenses/NASA-1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NASA-1.3.json",
-      "referenceNumber": 488,
+      "referenceNumber": 486,
       "name": "NASA Open Source Agreement 1.3",
       "licenseId": "NASA-1.3",
       "seeAlso": [
@@ -5622,7 +5734,7 @@
       "reference": "https://spdx.org/licenses/Naumen.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Naumen.json",
-      "referenceNumber": 400,
+      "referenceNumber": 594,
       "name": "Naumen Public License",
       "licenseId": "Naumen",
       "seeAlso": [
@@ -5634,7 +5746,7 @@
       "reference": "https://spdx.org/licenses/NBPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NBPL-1.0.json",
-      "referenceNumber": 168,
+      "referenceNumber": 240,
       "name": "Net Boolean Public License v1",
       "licenseId": "NBPL-1.0",
       "seeAlso": [
@@ -5646,7 +5758,7 @@
       "reference": "https://spdx.org/licenses/NCBI-PD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NCBI-PD.json",
-      "referenceNumber": 599,
+      "referenceNumber": 395,
       "name": "NCBI Public Domain Notice",
       "licenseId": "NCBI-PD",
       "seeAlso": [
@@ -5662,7 +5774,7 @@
       "reference": "https://spdx.org/licenses/NCGL-UK-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NCGL-UK-2.0.json",
-      "referenceNumber": 130,
+      "referenceNumber": 212,
       "name": "Non-Commercial Government Licence",
       "licenseId": "NCGL-UK-2.0",
       "seeAlso": [
@@ -5674,7 +5786,7 @@
       "reference": "https://spdx.org/licenses/NCL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NCL.json",
-      "referenceNumber": 516,
+      "referenceNumber": 152,
       "name": "NCL Source Code License",
       "licenseId": "NCL",
       "seeAlso": [
@@ -5686,7 +5798,7 @@
       "reference": "https://spdx.org/licenses/NCSA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NCSA.json",
-      "referenceNumber": 652,
+      "referenceNumber": 478,
       "name": "University of Illinois/NCSA Open Source License",
       "licenseId": "NCSA",
       "seeAlso": [
@@ -5700,7 +5812,7 @@
       "reference": "https://spdx.org/licenses/Net-SNMP.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/Net-SNMP.json",
-      "referenceNumber": 469,
+      "referenceNumber": 440,
       "name": "Net-SNMP License",
       "licenseId": "Net-SNMP",
       "seeAlso": [
@@ -5712,7 +5824,7 @@
       "reference": "https://spdx.org/licenses/NetCDF.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NetCDF.json",
-      "referenceNumber": 189,
+      "referenceNumber": 303,
       "name": "NetCDF license",
       "licenseId": "NetCDF",
       "seeAlso": [
@@ -5724,7 +5836,7 @@
       "reference": "https://spdx.org/licenses/Newsletr.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Newsletr.json",
-      "referenceNumber": 499,
+      "referenceNumber": 163,
       "name": "Newsletr License",
       "licenseId": "Newsletr",
       "seeAlso": [
@@ -5736,7 +5848,7 @@
       "reference": "https://spdx.org/licenses/NGPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NGPL.json",
-      "referenceNumber": 167,
+      "referenceNumber": 115,
       "name": "Nethack General Public License",
       "licenseId": "NGPL",
       "seeAlso": [
@@ -5748,7 +5860,7 @@
       "reference": "https://spdx.org/licenses/NICTA-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NICTA-1.0.json",
-      "referenceNumber": 486,
+      "referenceNumber": 536,
       "name": "NICTA Public Software License, Version 1.0",
       "licenseId": "NICTA-1.0",
       "seeAlso": [
@@ -5760,7 +5872,7 @@
       "reference": "https://spdx.org/licenses/NIST-PD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NIST-PD.json",
-      "referenceNumber": 194,
+      "referenceNumber": 1,
       "name": "NIST Public Domain Notice",
       "licenseId": "NIST-PD",
       "seeAlso": [
@@ -5773,7 +5885,7 @@
       "reference": "https://spdx.org/licenses/NIST-PD-fallback.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NIST-PD-fallback.json",
-      "referenceNumber": 223,
+      "referenceNumber": 463,
       "name": "NIST Public Domain Notice with license fallback",
       "licenseId": "NIST-PD-fallback",
       "seeAlso": [
@@ -5786,7 +5898,7 @@
       "reference": "https://spdx.org/licenses/NIST-Software.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NIST-Software.json",
-      "referenceNumber": 251,
+      "referenceNumber": 471,
       "name": "NIST Software License",
       "licenseId": "NIST-Software",
       "seeAlso": [
@@ -5798,7 +5910,7 @@
       "reference": "https://spdx.org/licenses/NLOD-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NLOD-1.0.json",
-      "referenceNumber": 294,
+      "referenceNumber": 3,
       "name": "Norwegian Licence for Open Government Data (NLOD) 1.0",
       "licenseId": "NLOD-1.0",
       "seeAlso": [
@@ -5810,7 +5922,7 @@
       "reference": "https://spdx.org/licenses/NLOD-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NLOD-2.0.json",
-      "referenceNumber": 566,
+      "referenceNumber": 60,
       "name": "Norwegian Licence for Open Government Data (NLOD) 2.0",
       "licenseId": "NLOD-2.0",
       "seeAlso": [
@@ -5822,7 +5934,7 @@
       "reference": "https://spdx.org/licenses/NLPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NLPL.json",
-      "referenceNumber": 367,
+      "referenceNumber": 477,
       "name": "No Limit Public License",
       "licenseId": "NLPL",
       "seeAlso": [
@@ -5834,7 +5946,7 @@
       "reference": "https://spdx.org/licenses/Nokia.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Nokia.json",
-      "referenceNumber": 145,
+      "referenceNumber": 678,
       "name": "Nokia Open Source License",
       "licenseId": "Nokia",
       "seeAlso": [
@@ -5847,7 +5959,7 @@
       "reference": "https://spdx.org/licenses/NOSL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NOSL.json",
-      "referenceNumber": 254,
+      "referenceNumber": 80,
       "name": "Netizen Open Source License",
       "licenseId": "NOSL",
       "seeAlso": [
@@ -5860,7 +5972,7 @@
       "reference": "https://spdx.org/licenses/Noweb.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Noweb.json",
-      "referenceNumber": 30,
+      "referenceNumber": 64,
       "name": "Noweb License",
       "licenseId": "Noweb",
       "seeAlso": [
@@ -5872,7 +5984,7 @@
       "reference": "https://spdx.org/licenses/NPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NPL-1.0.json",
-      "referenceNumber": 211,
+      "referenceNumber": 112,
       "name": "Netscape Public License v1.0",
       "licenseId": "NPL-1.0",
       "seeAlso": [
@@ -5885,7 +5997,7 @@
       "reference": "https://spdx.org/licenses/NPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NPL-1.1.json",
-      "referenceNumber": 595,
+      "referenceNumber": 491,
       "name": "Netscape Public License v1.1",
       "licenseId": "NPL-1.1",
       "seeAlso": [
@@ -5898,7 +6010,7 @@
       "reference": "https://spdx.org/licenses/NPOSL-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NPOSL-3.0.json",
-      "referenceNumber": 664,
+      "referenceNumber": 507,
       "name": "Non-Profit Open Software License 3.0",
       "licenseId": "NPOSL-3.0",
       "seeAlso": [
@@ -5910,7 +6022,7 @@
       "reference": "https://spdx.org/licenses/NRL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NRL.json",
-      "referenceNumber": 113,
+      "referenceNumber": 442,
       "name": "NRL License",
       "licenseId": "NRL",
       "seeAlso": [
@@ -5922,7 +6034,7 @@
       "reference": "https://spdx.org/licenses/NTP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NTP.json",
-      "referenceNumber": 390,
+      "referenceNumber": 228,
       "name": "NTP License",
       "licenseId": "NTP",
       "seeAlso": [
@@ -5934,7 +6046,7 @@
       "reference": "https://spdx.org/licenses/NTP-0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NTP-0.json",
-      "referenceNumber": 64,
+      "referenceNumber": 586,
       "name": "NTP No Attribution",
       "licenseId": "NTP-0",
       "seeAlso": [
@@ -5946,7 +6058,7 @@
       "reference": "https://spdx.org/licenses/Nunit.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/Nunit.json",
-      "referenceNumber": 27,
+      "referenceNumber": 605,
       "name": "Nunit License",
       "licenseId": "Nunit",
       "seeAlso": [
@@ -5959,7 +6071,7 @@
       "reference": "https://spdx.org/licenses/O-UDA-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/O-UDA-1.0.json",
-      "referenceNumber": 161,
+      "referenceNumber": 84,
       "name": "Open Use of Data Agreement v1.0",
       "licenseId": "O-UDA-1.0",
       "seeAlso": [
@@ -5972,7 +6084,7 @@
       "reference": "https://spdx.org/licenses/OAR.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OAR.json",
-      "referenceNumber": 100,
+      "referenceNumber": 77,
       "name": "OAR License",
       "licenseId": "OAR",
       "seeAlso": [
@@ -5984,7 +6096,7 @@
       "reference": "https://spdx.org/licenses/OCCT-PL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OCCT-PL.json",
-      "referenceNumber": 408,
+      "referenceNumber": 547,
       "name": "Open CASCADE Technology Public License",
       "licenseId": "OCCT-PL",
       "seeAlso": [
@@ -5996,7 +6108,7 @@
       "reference": "https://spdx.org/licenses/OCLC-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OCLC-2.0.json",
-      "referenceNumber": 468,
+      "referenceNumber": 179,
       "name": "OCLC Research Public License 2.0",
       "licenseId": "OCLC-2.0",
       "seeAlso": [
@@ -6009,7 +6121,7 @@
       "reference": "https://spdx.org/licenses/ODbL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ODbL-1.0.json",
-      "referenceNumber": 611,
+      "referenceNumber": 615,
       "name": "Open Data Commons Open Database License v1.0",
       "licenseId": "ODbL-1.0",
       "seeAlso": [
@@ -6023,7 +6135,7 @@
       "reference": "https://spdx.org/licenses/ODC-By-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ODC-By-1.0.json",
-      "referenceNumber": 15,
+      "referenceNumber": 192,
       "name": "Open Data Commons Attribution License v1.0",
       "licenseId": "ODC-By-1.0",
       "seeAlso": [
@@ -6035,7 +6147,7 @@
       "reference": "https://spdx.org/licenses/OFFIS.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OFFIS.json",
-      "referenceNumber": 418,
+      "referenceNumber": 423,
       "name": "OFFIS License",
       "licenseId": "OFFIS",
       "seeAlso": [
@@ -6047,7 +6159,7 @@
       "reference": "https://spdx.org/licenses/OFL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OFL-1.0.json",
-      "referenceNumber": 603,
+      "referenceNumber": 98,
       "name": "SIL Open Font License 1.0",
       "licenseId": "OFL-1.0",
       "seeAlso": [
@@ -6060,7 +6172,7 @@
       "reference": "https://spdx.org/licenses/OFL-1.0-no-RFN.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OFL-1.0-no-RFN.json",
-      "referenceNumber": 545,
+      "referenceNumber": 362,
       "name": "SIL Open Font License 1.0 with no Reserved Font Name",
       "licenseId": "OFL-1.0-no-RFN",
       "seeAlso": [
@@ -6072,7 +6184,7 @@
       "reference": "https://spdx.org/licenses/OFL-1.0-RFN.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OFL-1.0-RFN.json",
-      "referenceNumber": 446,
+      "referenceNumber": 622,
       "name": "SIL Open Font License 1.0 with Reserved Font Name",
       "licenseId": "OFL-1.0-RFN",
       "seeAlso": [
@@ -6084,7 +6196,7 @@
       "reference": "https://spdx.org/licenses/OFL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OFL-1.1.json",
-      "referenceNumber": 0,
+      "referenceNumber": 433,
       "name": "SIL Open Font License 1.1",
       "licenseId": "OFL-1.1",
       "seeAlso": [
@@ -6098,7 +6210,7 @@
       "reference": "https://spdx.org/licenses/OFL-1.1-no-RFN.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OFL-1.1-no-RFN.json",
-      "referenceNumber": 110,
+      "referenceNumber": 562,
       "name": "SIL Open Font License 1.1 with no Reserved Font Name",
       "licenseId": "OFL-1.1-no-RFN",
       "seeAlso": [
@@ -6111,7 +6223,7 @@
       "reference": "https://spdx.org/licenses/OFL-1.1-RFN.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OFL-1.1-RFN.json",
-      "referenceNumber": 90,
+      "referenceNumber": 88,
       "name": "SIL Open Font License 1.1 with Reserved Font Name",
       "licenseId": "OFL-1.1-RFN",
       "seeAlso": [
@@ -6124,7 +6236,7 @@
       "reference": "https://spdx.org/licenses/OGC-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OGC-1.0.json",
-      "referenceNumber": 504,
+      "referenceNumber": 533,
       "name": "OGC Software License, Version 1.0",
       "licenseId": "OGC-1.0",
       "seeAlso": [
@@ -6136,7 +6248,7 @@
       "reference": "https://spdx.org/licenses/OGDL-Taiwan-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OGDL-Taiwan-1.0.json",
-      "referenceNumber": 23,
+      "referenceNumber": 247,
       "name": "Taiwan Open Government Data License, version 1.0",
       "licenseId": "OGDL-Taiwan-1.0",
       "seeAlso": [
@@ -6148,7 +6260,7 @@
       "reference": "https://spdx.org/licenses/OGL-Canada-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OGL-Canada-2.0.json",
-      "referenceNumber": 40,
+      "referenceNumber": 673,
       "name": "Open Government Licence - Canada",
       "licenseId": "OGL-Canada-2.0",
       "seeAlso": [
@@ -6160,7 +6272,7 @@
       "reference": "https://spdx.org/licenses/OGL-UK-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OGL-UK-1.0.json",
-      "referenceNumber": 497,
+      "referenceNumber": 171,
       "name": "Open Government Licence v1.0",
       "licenseId": "OGL-UK-1.0",
       "seeAlso": [
@@ -6172,7 +6284,7 @@
       "reference": "https://spdx.org/licenses/OGL-UK-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OGL-UK-2.0.json",
-      "referenceNumber": 556,
+      "referenceNumber": 400,
       "name": "Open Government Licence v2.0",
       "licenseId": "OGL-UK-2.0",
       "seeAlso": [
@@ -6184,7 +6296,7 @@
       "reference": "https://spdx.org/licenses/OGL-UK-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OGL-UK-3.0.json",
-      "referenceNumber": 585,
+      "referenceNumber": 385,
       "name": "Open Government Licence v3.0",
       "licenseId": "OGL-UK-3.0",
       "seeAlso": [
@@ -6196,7 +6308,7 @@
       "reference": "https://spdx.org/licenses/OGTSL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OGTSL.json",
-      "referenceNumber": 97,
+      "referenceNumber": 614,
       "name": "Open Group Test Suite License",
       "licenseId": "OGTSL",
       "seeAlso": [
@@ -6209,7 +6321,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-1.1.json",
-      "referenceNumber": 420,
+      "referenceNumber": 209,
       "name": "Open LDAP Public License v1.1",
       "licenseId": "OLDAP-1.1",
       "seeAlso": [
@@ -6221,7 +6333,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-1.2.json",
-      "referenceNumber": 487,
+      "referenceNumber": 33,
       "name": "Open LDAP Public License v1.2",
       "licenseId": "OLDAP-1.2",
       "seeAlso": [
@@ -6233,7 +6345,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-1.3.json",
-      "referenceNumber": 627,
+      "referenceNumber": 58,
       "name": "Open LDAP Public License v1.3",
       "licenseId": "OLDAP-1.3",
       "seeAlso": [
@@ -6245,7 +6357,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-1.4.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-1.4.json",
-      "referenceNumber": 45,
+      "referenceNumber": 508,
       "name": "Open LDAP Public License v1.4",
       "licenseId": "OLDAP-1.4",
       "seeAlso": [
@@ -6257,7 +6369,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.0.json",
-      "referenceNumber": 537,
+      "referenceNumber": 261,
       "name": "Open LDAP Public License v2.0 (or possibly 2.0A and 2.0B)",
       "licenseId": "OLDAP-2.0",
       "seeAlso": [
@@ -6269,7 +6381,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.0.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.0.1.json",
-      "referenceNumber": 179,
+      "referenceNumber": 634,
       "name": "Open LDAP Public License v2.0.1",
       "licenseId": "OLDAP-2.0.1",
       "seeAlso": [
@@ -6281,7 +6393,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.1.json",
-      "referenceNumber": 342,
+      "referenceNumber": 94,
       "name": "Open LDAP Public License v2.1",
       "licenseId": "OLDAP-2.1",
       "seeAlso": [
@@ -6293,7 +6405,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.2.json",
-      "referenceNumber": 347,
+      "referenceNumber": 369,
       "name": "Open LDAP Public License v2.2",
       "licenseId": "OLDAP-2.2",
       "seeAlso": [
@@ -6305,7 +6417,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.2.1.json",
-      "referenceNumber": 208,
+      "referenceNumber": 542,
       "name": "Open LDAP Public License v2.2.1",
       "licenseId": "OLDAP-2.2.1",
       "seeAlso": [
@@ -6317,7 +6429,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.2.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.2.2.json",
-      "referenceNumber": 312,
+      "referenceNumber": 105,
       "name": "Open LDAP Public License 2.2.2",
       "licenseId": "OLDAP-2.2.2",
       "seeAlso": [
@@ -6329,7 +6441,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.3.json",
-      "referenceNumber": 276,
+      "referenceNumber": 288,
       "name": "Open LDAP Public License v2.3",
       "licenseId": "OLDAP-2.3",
       "seeAlso": [
@@ -6342,7 +6454,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.4.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.4.json",
-      "referenceNumber": 108,
+      "referenceNumber": 359,
       "name": "Open LDAP Public License v2.4",
       "licenseId": "OLDAP-2.4",
       "seeAlso": [
@@ -6354,7 +6466,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.5.json",
-      "referenceNumber": 518,
+      "referenceNumber": 181,
       "name": "Open LDAP Public License v2.5",
       "licenseId": "OLDAP-2.5",
       "seeAlso": [
@@ -6366,7 +6478,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.6.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.6.json",
-      "referenceNumber": 275,
+      "referenceNumber": 544,
       "name": "Open LDAP Public License v2.6",
       "licenseId": "OLDAP-2.6",
       "seeAlso": [
@@ -6378,7 +6490,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.7.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.7.json",
-      "referenceNumber": 79,
+      "referenceNumber": 618,
       "name": "Open LDAP Public License v2.7",
       "licenseId": "OLDAP-2.7",
       "seeAlso": [
@@ -6391,7 +6503,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.8.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.8.json",
-      "referenceNumber": 72,
+      "referenceNumber": 14,
       "name": "Open LDAP Public License v2.8",
       "licenseId": "OLDAP-2.8",
       "seeAlso": [
@@ -6403,7 +6515,7 @@
       "reference": "https://spdx.org/licenses/OLFL-1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLFL-1.3.json",
-      "referenceNumber": 204,
+      "referenceNumber": 351,
       "name": "Open Logistics Foundation License Version 1.3",
       "licenseId": "OLFL-1.3",
       "seeAlso": [
@@ -6416,7 +6528,7 @@
       "reference": "https://spdx.org/licenses/OML.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OML.json",
-      "referenceNumber": 505,
+      "referenceNumber": 453,
       "name": "Open Market License",
       "licenseId": "OML",
       "seeAlso": [
@@ -6428,7 +6540,7 @@
       "reference": "https://spdx.org/licenses/OpenPBS-2.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OpenPBS-2.3.json",
-      "referenceNumber": 159,
+      "referenceNumber": 140,
       "name": "OpenPBS v2.3 Software License",
       "licenseId": "OpenPBS-2.3",
       "seeAlso": [
@@ -6441,7 +6553,7 @@
       "reference": "https://spdx.org/licenses/OpenSSL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OpenSSL.json",
-      "referenceNumber": 445,
+      "referenceNumber": 393,
       "name": "OpenSSL License",
       "licenseId": "OpenSSL",
       "seeAlso": [
@@ -6454,7 +6566,7 @@
       "reference": "https://spdx.org/licenses/OpenSSL-standalone.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OpenSSL-standalone.json",
-      "referenceNumber": 635,
+      "referenceNumber": 449,
       "name": "OpenSSL License - standalone",
       "licenseId": "OpenSSL-standalone",
       "seeAlso": [
@@ -6467,7 +6579,7 @@
       "reference": "https://spdx.org/licenses/OpenVision.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OpenVision.json",
-      "referenceNumber": 589,
+      "referenceNumber": 23,
       "name": "OpenVision License",
       "licenseId": "OpenVision",
       "seeAlso": [
@@ -6481,7 +6593,7 @@
       "reference": "https://spdx.org/licenses/OPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OPL-1.0.json",
-      "referenceNumber": 80,
+      "referenceNumber": 43,
       "name": "Open Public License v1.0",
       "licenseId": "OPL-1.0",
       "seeAlso": [
@@ -6495,7 +6607,7 @@
       "reference": "https://spdx.org/licenses/OPL-UK-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OPL-UK-3.0.json",
-      "referenceNumber": 19,
+      "referenceNumber": 248,
       "name": "United    Kingdom Open Parliament Licence v3.0",
       "licenseId": "OPL-UK-3.0",
       "seeAlso": [
@@ -6507,7 +6619,7 @@
       "reference": "https://spdx.org/licenses/OPUBL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OPUBL-1.0.json",
-      "referenceNumber": 266,
+      "referenceNumber": 241,
       "name": "Open Publication License v1.0",
       "licenseId": "OPUBL-1.0",
       "seeAlso": [
@@ -6521,7 +6633,7 @@
       "reference": "https://spdx.org/licenses/OSET-PL-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OSET-PL-2.1.json",
-      "referenceNumber": 307,
+      "referenceNumber": 658,
       "name": "OSET Public License version 2.1",
       "licenseId": "OSET-PL-2.1",
       "seeAlso": [
@@ -6534,7 +6646,7 @@
       "reference": "https://spdx.org/licenses/OSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OSL-1.0.json",
-      "referenceNumber": 306,
+      "referenceNumber": 554,
       "name": "Open Software License 1.0",
       "licenseId": "OSL-1.0",
       "seeAlso": [
@@ -6547,7 +6659,7 @@
       "reference": "https://spdx.org/licenses/OSL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OSL-1.1.json",
-      "referenceNumber": 111,
+      "referenceNumber": 481,
       "name": "Open Software License 1.1",
       "licenseId": "OSL-1.1",
       "seeAlso": [
@@ -6560,7 +6672,7 @@
       "reference": "https://spdx.org/licenses/OSL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OSL-2.0.json",
-      "referenceNumber": 457,
+      "referenceNumber": 377,
       "name": "Open Software License 2.0",
       "licenseId": "OSL-2.0",
       "seeAlso": [
@@ -6573,7 +6685,7 @@
       "reference": "https://spdx.org/licenses/OSL-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OSL-2.1.json",
-      "referenceNumber": 247,
+      "referenceNumber": 368,
       "name": "Open Software License 2.1",
       "licenseId": "OSL-2.1",
       "seeAlso": [
@@ -6587,7 +6699,7 @@
       "reference": "https://spdx.org/licenses/OSL-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OSL-3.0.json",
-      "referenceNumber": 432,
+      "referenceNumber": 30,
       "name": "Open Software License 3.0",
       "licenseId": "OSL-3.0",
       "seeAlso": [
@@ -6601,7 +6713,7 @@
       "reference": "https://spdx.org/licenses/PADL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/PADL.json",
-      "referenceNumber": 43,
+      "referenceNumber": 535,
       "name": "PADL License",
       "licenseId": "PADL",
       "seeAlso": [
@@ -6613,7 +6725,7 @@
       "reference": "https://spdx.org/licenses/Parity-6.0.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Parity-6.0.0.json",
-      "referenceNumber": 49,
+      "referenceNumber": 17,
       "name": "The Parity Public License 6.0.0",
       "licenseId": "Parity-6.0.0",
       "seeAlso": [
@@ -6625,7 +6737,7 @@
       "reference": "https://spdx.org/licenses/Parity-7.0.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Parity-7.0.0.json",
-      "referenceNumber": 482,
+      "referenceNumber": 324,
       "name": "The Parity Public License 7.0.0",
       "licenseId": "Parity-7.0.0",
       "seeAlso": [
@@ -6637,7 +6749,7 @@
       "reference": "https://spdx.org/licenses/PDDL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/PDDL-1.0.json",
-      "referenceNumber": 210,
+      "referenceNumber": 149,
       "name": "Open Data Commons Public Domain Dedication \u0026 License 1.0",
       "licenseId": "PDDL-1.0",
       "seeAlso": [
@@ -6650,7 +6762,7 @@
       "reference": "https://spdx.org/licenses/PHP-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/PHP-3.0.json",
-      "referenceNumber": 580,
+      "referenceNumber": 138,
       "name": "PHP License v3.0",
       "licenseId": "PHP-3.0",
       "seeAlso": [
@@ -6663,7 +6775,7 @@
       "reference": "https://spdx.org/licenses/PHP-3.01.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/PHP-3.01.json",
-      "referenceNumber": 594,
+      "referenceNumber": 666,
       "name": "PHP License v3.01",
       "licenseId": "PHP-3.01",
       "seeAlso": [
@@ -6676,7 +6788,7 @@
       "reference": "https://spdx.org/licenses/Pixar.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Pixar.json",
-      "referenceNumber": 619,
+      "referenceNumber": 607,
       "name": "Pixar License",
       "licenseId": "Pixar",
       "seeAlso": [
@@ -6690,7 +6802,7 @@
       "reference": "https://spdx.org/licenses/pkgconf.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/pkgconf.json",
-      "referenceNumber": 16,
+      "referenceNumber": 664,
       "name": "pkgconf License",
       "licenseId": "pkgconf",
       "seeAlso": [
@@ -6702,7 +6814,7 @@
       "reference": "https://spdx.org/licenses/Plexus.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Plexus.json",
-      "referenceNumber": 442,
+      "referenceNumber": 39,
       "name": "Plexus Classworlds License",
       "licenseId": "Plexus",
       "seeAlso": [
@@ -6714,7 +6826,7 @@
       "reference": "https://spdx.org/licenses/pnmstitch.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/pnmstitch.json",
-      "referenceNumber": 502,
+      "referenceNumber": 266,
       "name": "pnmstitch License",
       "licenseId": "pnmstitch",
       "seeAlso": [
@@ -6726,7 +6838,7 @@
       "reference": "https://spdx.org/licenses/PolyForm-Noncommercial-1.0.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/PolyForm-Noncommercial-1.0.0.json",
-      "referenceNumber": 575,
+      "referenceNumber": 561,
       "name": "PolyForm Noncommercial License 1.0.0",
       "licenseId": "PolyForm-Noncommercial-1.0.0",
       "seeAlso": [
@@ -6738,7 +6850,7 @@
       "reference": "https://spdx.org/licenses/PolyForm-Small-Business-1.0.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/PolyForm-Small-Business-1.0.0.json",
-      "referenceNumber": 9,
+      "referenceNumber": 155,
       "name": "PolyForm Small Business License 1.0.0",
       "licenseId": "PolyForm-Small-Business-1.0.0",
       "seeAlso": [
@@ -6750,7 +6862,7 @@
       "reference": "https://spdx.org/licenses/PostgreSQL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/PostgreSQL.json",
-      "referenceNumber": 94,
+      "referenceNumber": 645,
       "name": "PostgreSQL License",
       "licenseId": "PostgreSQL",
       "seeAlso": [
@@ -6763,7 +6875,7 @@
       "reference": "https://spdx.org/licenses/PPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/PPL.json",
-      "referenceNumber": 454,
+      "referenceNumber": 87,
       "name": "Peer Production License",
       "licenseId": "PPL",
       "seeAlso": [
@@ -6777,11 +6889,12 @@
       "reference": "https://spdx.org/licenses/PSF-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/PSF-2.0.json",
-      "referenceNumber": 62,
+      "referenceNumber": 479,
       "name": "Python Software Foundation License 2.0",
       "licenseId": "PSF-2.0",
       "seeAlso": [
-        "https://opensource.org/licenses/Python-2.0"
+        "https://opensource.org/licenses/Python-2.0",
+        "https://matplotlib.org/stable/project/license.html"
       ],
       "isOsiApproved": false
     },
@@ -6789,7 +6902,7 @@
       "reference": "https://spdx.org/licenses/psfrag.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/psfrag.json",
-      "referenceNumber": 279,
+      "referenceNumber": 100,
       "name": "psfrag License",
       "licenseId": "psfrag",
       "seeAlso": [
@@ -6801,7 +6914,7 @@
       "reference": "https://spdx.org/licenses/psutils.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/psutils.json",
-      "referenceNumber": 387,
+      "referenceNumber": 50,
       "name": "psutils License",
       "licenseId": "psutils",
       "seeAlso": [
@@ -6813,7 +6926,7 @@
       "reference": "https://spdx.org/licenses/Python-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Python-2.0.json",
-      "referenceNumber": 498,
+      "referenceNumber": 651,
       "name": "Python License 2.0",
       "licenseId": "Python-2.0",
       "seeAlso": [
@@ -6826,7 +6939,7 @@
       "reference": "https://spdx.org/licenses/Python-2.0.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Python-2.0.1.json",
-      "referenceNumber": 453,
+      "referenceNumber": 290,
       "name": "Python License 2.0.1",
       "licenseId": "Python-2.0.1",
       "seeAlso": [
@@ -6840,7 +6953,7 @@
       "reference": "https://spdx.org/licenses/python-ldap.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/python-ldap.json",
-      "referenceNumber": 422,
+      "referenceNumber": 531,
       "name": "Python ldap License",
       "licenseId": "python-ldap",
       "seeAlso": [
@@ -6852,7 +6965,7 @@
       "reference": "https://spdx.org/licenses/Qhull.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Qhull.json",
-      "referenceNumber": 123,
+      "referenceNumber": 435,
       "name": "Qhull License",
       "licenseId": "Qhull",
       "seeAlso": [
@@ -6864,7 +6977,7 @@
       "reference": "https://spdx.org/licenses/QPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/QPL-1.0.json",
-      "referenceNumber": 329,
+      "referenceNumber": 169,
       "name": "Q Public License 1.0",
       "licenseId": "QPL-1.0",
       "seeAlso": [
@@ -6879,7 +6992,7 @@
       "reference": "https://spdx.org/licenses/QPL-1.0-INRIA-2004.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/QPL-1.0-INRIA-2004.json",
-      "referenceNumber": 479,
+      "referenceNumber": 461,
       "name": "Q Public License 1.0 - INRIA 2004 variant",
       "licenseId": "QPL-1.0-INRIA-2004",
       "seeAlso": [
@@ -6891,7 +7004,7 @@
       "reference": "https://spdx.org/licenses/radvd.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/radvd.json",
-      "referenceNumber": 182,
+      "referenceNumber": 425,
       "name": "radvd License",
       "licenseId": "radvd",
       "seeAlso": [
@@ -6903,7 +7016,7 @@
       "reference": "https://spdx.org/licenses/Rdisc.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Rdisc.json",
-      "referenceNumber": 101,
+      "referenceNumber": 74,
       "name": "Rdisc License",
       "licenseId": "Rdisc",
       "seeAlso": [
@@ -6915,7 +7028,7 @@
       "reference": "https://spdx.org/licenses/RHeCos-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/RHeCos-1.1.json",
-      "referenceNumber": 373,
+      "referenceNumber": 4,
       "name": "Red Hat eCos Public License v1.1",
       "licenseId": "RHeCos-1.1",
       "seeAlso": [
@@ -6928,7 +7041,7 @@
       "reference": "https://spdx.org/licenses/RPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/RPL-1.1.json",
-      "referenceNumber": 369,
+      "referenceNumber": 281,
       "name": "Reciprocal Public License 1.1",
       "licenseId": "RPL-1.1",
       "seeAlso": [
@@ -6940,7 +7053,7 @@
       "reference": "https://spdx.org/licenses/RPL-1.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/RPL-1.5.json",
-      "referenceNumber": 102,
+      "referenceNumber": 677,
       "name": "Reciprocal Public License 1.5",
       "licenseId": "RPL-1.5",
       "seeAlso": [
@@ -6952,7 +7065,7 @@
       "reference": "https://spdx.org/licenses/RPSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/RPSL-1.0.json",
-      "referenceNumber": 663,
+      "referenceNumber": 668,
       "name": "RealNetworks Public Source License v1.0",
       "licenseId": "RPSL-1.0",
       "seeAlso": [
@@ -6966,7 +7079,7 @@
       "reference": "https://spdx.org/licenses/RSA-MD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/RSA-MD.json",
-      "referenceNumber": 139,
+      "referenceNumber": 178,
       "name": "RSA Message-Digest License",
       "licenseId": "RSA-MD",
       "seeAlso": [
@@ -6978,7 +7091,7 @@
       "reference": "https://spdx.org/licenses/RSCPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/RSCPL.json",
-      "referenceNumber": 405,
+      "referenceNumber": 6,
       "name": "Ricoh Source Code Public License",
       "licenseId": "RSCPL",
       "seeAlso": [
@@ -6991,7 +7104,7 @@
       "reference": "https://spdx.org/licenses/Ruby.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Ruby.json",
-      "referenceNumber": 192,
+      "referenceNumber": 244,
       "name": "Ruby License",
       "licenseId": "Ruby",
       "seeAlso": [
@@ -7004,7 +7117,7 @@
       "reference": "https://spdx.org/licenses/Ruby-pty.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Ruby-pty.json",
-      "referenceNumber": 473,
+      "referenceNumber": 558,
       "name": "Ruby pty extension license",
       "licenseId": "Ruby-pty",
       "seeAlso": [
@@ -7018,7 +7131,7 @@
       "reference": "https://spdx.org/licenses/SAX-PD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SAX-PD.json",
-      "referenceNumber": 205,
+      "referenceNumber": 166,
       "name": "Sax Public Domain Notice",
       "licenseId": "SAX-PD",
       "seeAlso": [
@@ -7030,7 +7143,7 @@
       "reference": "https://spdx.org/licenses/SAX-PD-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SAX-PD-2.0.json",
-      "referenceNumber": 209,
+      "referenceNumber": 497,
       "name": "Sax Public Domain Notice 2.0",
       "licenseId": "SAX-PD-2.0",
       "seeAlso": [
@@ -7042,7 +7155,7 @@
       "reference": "https://spdx.org/licenses/Saxpath.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Saxpath.json",
-      "referenceNumber": 67,
+      "referenceNumber": 298,
       "name": "Saxpath License",
       "licenseId": "Saxpath",
       "seeAlso": [
@@ -7054,7 +7167,7 @@
       "reference": "https://spdx.org/licenses/SCEA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SCEA.json",
-      "referenceNumber": 617,
+      "referenceNumber": 518,
       "name": "SCEA Shared Source License",
       "licenseId": "SCEA",
       "seeAlso": [
@@ -7066,7 +7179,7 @@
       "reference": "https://spdx.org/licenses/SchemeReport.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SchemeReport.json",
-      "referenceNumber": 472,
+      "referenceNumber": 339,
       "name": "Scheme Language Report License",
       "licenseId": "SchemeReport",
       "seeAlso": [],
@@ -7076,7 +7189,7 @@
       "reference": "https://spdx.org/licenses/Sendmail.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Sendmail.json",
-      "referenceNumber": 135,
+      "referenceNumber": 394,
       "name": "Sendmail License",
       "licenseId": "Sendmail",
       "seeAlso": [
@@ -7089,7 +7202,7 @@
       "reference": "https://spdx.org/licenses/Sendmail-8.23.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Sendmail-8.23.json",
-      "referenceNumber": 226,
+      "referenceNumber": 34,
       "name": "Sendmail License 8.23",
       "licenseId": "Sendmail-8.23",
       "seeAlso": [
@@ -7099,10 +7212,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/Sendmail-Open-Source-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Sendmail-Open-Source-1.1.json",
+      "referenceNumber": 317,
+      "name": "Sendmail Open Source License v1.1",
+      "licenseId": "Sendmail-Open-Source-1.1",
+      "seeAlso": [
+        "https://github.com/trusteddomainproject/OpenDMARC/blob/master/LICENSE.Sendmail"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/SGI-B-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SGI-B-1.0.json",
-      "referenceNumber": 631,
+      "referenceNumber": 515,
       "name": "SGI Free Software License B v1.0",
       "licenseId": "SGI-B-1.0",
       "seeAlso": [
@@ -7114,7 +7239,7 @@
       "reference": "https://spdx.org/licenses/SGI-B-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SGI-B-1.1.json",
-      "referenceNumber": 48,
+      "referenceNumber": 46,
       "name": "SGI Free Software License B v1.1",
       "licenseId": "SGI-B-1.1",
       "seeAlso": [
@@ -7126,7 +7251,7 @@
       "reference": "https://spdx.org/licenses/SGI-B-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SGI-B-2.0.json",
-      "referenceNumber": 193,
+      "referenceNumber": 551,
       "name": "SGI Free Software License B v2.0",
       "licenseId": "SGI-B-2.0",
       "seeAlso": [
@@ -7139,7 +7264,7 @@
       "reference": "https://spdx.org/licenses/SGI-OpenGL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SGI-OpenGL.json",
-      "referenceNumber": 565,
+      "referenceNumber": 73,
       "name": "SGI OpenGL License",
       "licenseId": "SGI-OpenGL",
       "seeAlso": [
@@ -7151,7 +7276,7 @@
       "reference": "https://spdx.org/licenses/SGP4.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SGP4.json",
-      "referenceNumber": 291,
+      "referenceNumber": 24,
       "name": "SGP4 Permission Notice",
       "licenseId": "SGP4",
       "seeAlso": [
@@ -7163,7 +7288,7 @@
       "reference": "https://spdx.org/licenses/SHL-0.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SHL-0.5.json",
-      "referenceNumber": 623,
+      "referenceNumber": 159,
       "name": "Solderpad Hardware License v0.5",
       "licenseId": "SHL-0.5",
       "seeAlso": [
@@ -7175,7 +7300,7 @@
       "reference": "https://spdx.org/licenses/SHL-0.51.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SHL-0.51.json",
-      "referenceNumber": 34,
+      "referenceNumber": 522,
       "name": "Solderpad Hardware License, Version 0.51",
       "licenseId": "SHL-0.51",
       "seeAlso": [
@@ -7187,7 +7312,7 @@
       "reference": "https://spdx.org/licenses/SimPL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SimPL-2.0.json",
-      "referenceNumber": 630,
+      "referenceNumber": 560,
       "name": "Simple Public License 2.0",
       "licenseId": "SimPL-2.0",
       "seeAlso": [
@@ -7199,7 +7324,7 @@
       "reference": "https://spdx.org/licenses/SISSL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SISSL.json",
-      "referenceNumber": 655,
+      "referenceNumber": 349,
       "name": "Sun Industry Standards Source License v1.1",
       "licenseId": "SISSL",
       "seeAlso": [
@@ -7213,7 +7338,7 @@
       "reference": "https://spdx.org/licenses/SISSL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SISSL-1.2.json",
-      "referenceNumber": 401,
+      "referenceNumber": 670,
       "name": "Sun Industry Standards Source License v1.2",
       "licenseId": "SISSL-1.2",
       "seeAlso": [
@@ -7225,7 +7350,7 @@
       "reference": "https://spdx.org/licenses/SL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SL.json",
-      "referenceNumber": 632,
+      "referenceNumber": 295,
       "name": "SL License",
       "licenseId": "SL",
       "seeAlso": [
@@ -7237,7 +7362,7 @@
       "reference": "https://spdx.org/licenses/Sleepycat.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Sleepycat.json",
-      "referenceNumber": 283,
+      "referenceNumber": 120,
       "name": "Sleepycat License",
       "licenseId": "Sleepycat",
       "seeAlso": [
@@ -7247,10 +7372,22 @@
       "isFsfLibre": true
     },
     {
+      "reference": "https://spdx.org/licenses/SMAIL-GPL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SMAIL-GPL.json",
+      "referenceNumber": 485,
+      "name": "SMAIL General Public License",
+      "licenseId": "SMAIL-GPL",
+      "seeAlso": [
+        "https://sources.debian.org/copyright/license/debianutils/4.11.2/"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/SMLNJ.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SMLNJ.json",
-      "referenceNumber": 413,
+      "referenceNumber": 506,
       "name": "Standard ML of New Jersey License",
       "licenseId": "SMLNJ",
       "seeAlso": [
@@ -7263,7 +7400,7 @@
       "reference": "https://spdx.org/licenses/SMPPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SMPPL.json",
-      "referenceNumber": 321,
+      "referenceNumber": 325,
       "name": "Secure Messaging Protocol Public License",
       "licenseId": "SMPPL",
       "seeAlso": [
@@ -7275,7 +7412,7 @@
       "reference": "https://spdx.org/licenses/SNIA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SNIA.json",
-      "referenceNumber": 41,
+      "referenceNumber": 92,
       "name": "SNIA Public License 1.1",
       "licenseId": "SNIA",
       "seeAlso": [
@@ -7287,7 +7424,7 @@
       "reference": "https://spdx.org/licenses/snprintf.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/snprintf.json",
-      "referenceNumber": 507,
+      "referenceNumber": 604,
       "name": "snprintf License",
       "licenseId": "snprintf",
       "seeAlso": [
@@ -7299,7 +7436,7 @@
       "reference": "https://spdx.org/licenses/softSurfer.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/softSurfer.json",
-      "referenceNumber": 496,
+      "referenceNumber": 96,
       "name": "softSurfer License",
       "licenseId": "softSurfer",
       "seeAlso": [
@@ -7312,7 +7449,7 @@
       "reference": "https://spdx.org/licenses/Soundex.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Soundex.json",
-      "referenceNumber": 1,
+      "referenceNumber": 65,
       "name": "Soundex License",
       "licenseId": "Soundex",
       "seeAlso": [
@@ -7324,7 +7461,7 @@
       "reference": "https://spdx.org/licenses/Spencer-86.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Spencer-86.json",
-      "referenceNumber": 257,
+      "referenceNumber": 21,
       "name": "Spencer License 86",
       "licenseId": "Spencer-86",
       "seeAlso": [
@@ -7336,7 +7473,7 @@
       "reference": "https://spdx.org/licenses/Spencer-94.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Spencer-94.json",
-      "referenceNumber": 228,
+      "referenceNumber": 472,
       "name": "Spencer License 94",
       "licenseId": "Spencer-94",
       "seeAlso": [
@@ -7349,7 +7486,7 @@
       "reference": "https://spdx.org/licenses/Spencer-99.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Spencer-99.json",
-      "referenceNumber": 287,
+      "referenceNumber": 432,
       "name": "Spencer License 99",
       "licenseId": "Spencer-99",
       "seeAlso": [
@@ -7361,7 +7498,7 @@
       "reference": "https://spdx.org/licenses/SPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SPL-1.0.json",
-      "referenceNumber": 576,
+      "referenceNumber": 487,
       "name": "Sun Public License v1.0",
       "licenseId": "SPL-1.0",
       "seeAlso": [
@@ -7374,7 +7511,7 @@
       "reference": "https://spdx.org/licenses/ssh-keyscan.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ssh-keyscan.json",
-      "referenceNumber": 78,
+      "referenceNumber": 431,
       "name": "ssh-keyscan License",
       "licenseId": "ssh-keyscan",
       "seeAlso": [
@@ -7386,7 +7523,7 @@
       "reference": "https://spdx.org/licenses/SSH-OpenSSH.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SSH-OpenSSH.json",
-      "referenceNumber": 536,
+      "referenceNumber": 68,
       "name": "SSH OpenSSH license",
       "licenseId": "SSH-OpenSSH",
       "seeAlso": [
@@ -7398,7 +7535,7 @@
       "reference": "https://spdx.org/licenses/SSH-short.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SSH-short.json",
-      "referenceNumber": 438,
+      "referenceNumber": 170,
       "name": "SSH short notice",
       "licenseId": "SSH-short",
       "seeAlso": [
@@ -7412,7 +7549,7 @@
       "reference": "https://spdx.org/licenses/SSLeay-standalone.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SSLeay-standalone.json",
-      "referenceNumber": 421,
+      "referenceNumber": 53,
       "name": "SSLeay License - standalone",
       "licenseId": "SSLeay-standalone",
       "seeAlso": [
@@ -7424,7 +7561,7 @@
       "reference": "https://spdx.org/licenses/SSPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SSPL-1.0.json",
-      "referenceNumber": 295,
+      "referenceNumber": 631,
       "name": "Server Side Public License, v 1",
       "licenseId": "SSPL-1.0",
       "seeAlso": [
@@ -7436,7 +7573,7 @@
       "reference": "https://spdx.org/licenses/StandardML-NJ.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/StandardML-NJ.json",
-      "referenceNumber": 201,
+      "referenceNumber": 280,
       "name": "Standard ML of New Jersey License",
       "licenseId": "StandardML-NJ",
       "seeAlso": [
@@ -7449,7 +7586,7 @@
       "reference": "https://spdx.org/licenses/SugarCRM-1.1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SugarCRM-1.1.3.json",
-      "referenceNumber": 11,
+      "referenceNumber": 128,
       "name": "SugarCRM Public License v1.1.3",
       "licenseId": "SugarCRM-1.1.3",
       "seeAlso": [
@@ -7461,7 +7598,7 @@
       "reference": "https://spdx.org/licenses/Sun-PPP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Sun-PPP.json",
-      "referenceNumber": 313,
+      "referenceNumber": 541,
       "name": "Sun PPP License",
       "licenseId": "Sun-PPP",
       "seeAlso": [
@@ -7473,7 +7610,7 @@
       "reference": "https://spdx.org/licenses/Sun-PPP-2000.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Sun-PPP-2000.json",
-      "referenceNumber": 489,
+      "referenceNumber": 514,
       "name": "Sun PPP License (2000)",
       "licenseId": "Sun-PPP-2000",
       "seeAlso": [
@@ -7485,7 +7622,7 @@
       "reference": "https://spdx.org/licenses/SunPro.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SunPro.json",
-      "referenceNumber": 440,
+      "referenceNumber": 237,
       "name": "SunPro License",
       "licenseId": "SunPro",
       "seeAlso": [
@@ -7498,7 +7635,7 @@
       "reference": "https://spdx.org/licenses/SWL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SWL.json",
-      "referenceNumber": 331,
+      "referenceNumber": 655,
       "name": "Scheme Widget Library (SWL) Software License Agreement",
       "licenseId": "SWL",
       "seeAlso": [
@@ -7510,7 +7647,7 @@
       "reference": "https://spdx.org/licenses/swrule.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/swrule.json",
-      "referenceNumber": 206,
+      "referenceNumber": 283,
       "name": "swrule License",
       "licenseId": "swrule",
       "seeAlso": [
@@ -7522,7 +7659,7 @@
       "reference": "https://spdx.org/licenses/Symlinks.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Symlinks.json",
-      "referenceNumber": 136,
+      "referenceNumber": 557,
       "name": "Symlinks License",
       "licenseId": "Symlinks",
       "seeAlso": [
@@ -7534,7 +7671,7 @@
       "reference": "https://spdx.org/licenses/TAPR-OHL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TAPR-OHL-1.0.json",
-      "referenceNumber": 317,
+      "referenceNumber": 252,
       "name": "TAPR Open Hardware License v1.0",
       "licenseId": "TAPR-OHL-1.0",
       "seeAlso": [
@@ -7546,7 +7683,7 @@
       "reference": "https://spdx.org/licenses/TCL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TCL.json",
-      "referenceNumber": 644,
+      "referenceNumber": 576,
       "name": "TCL/TK License",
       "licenseId": "TCL",
       "seeAlso": [
@@ -7559,7 +7696,7 @@
       "reference": "https://spdx.org/licenses/TCP-wrappers.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TCP-wrappers.json",
-      "referenceNumber": 245,
+      "referenceNumber": 126,
       "name": "TCP Wrappers License",
       "licenseId": "TCP-wrappers",
       "seeAlso": [
@@ -7571,7 +7708,7 @@
       "reference": "https://spdx.org/licenses/TermReadKey.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TermReadKey.json",
-      "referenceNumber": 37,
+      "referenceNumber": 642,
       "name": "TermReadKey License",
       "licenseId": "TermReadKey",
       "seeAlso": [
@@ -7583,7 +7720,7 @@
       "reference": "https://spdx.org/licenses/TGPPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TGPPL-1.0.json",
-      "referenceNumber": 112,
+      "referenceNumber": 603,
       "name": "Transitive Grace Period Public Licence 1.0",
       "licenseId": "TGPPL-1.0",
       "seeAlso": [
@@ -7593,10 +7730,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/ThirdEye.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ThirdEye.json",
+      "referenceNumber": 320,
+      "name": "ThirdEye License",
+      "licenseId": "ThirdEye",
+      "seeAlso": [
+        "https://sourceware.org/cgit/binutils-gdb/tree/include/coff/symconst.h#n11"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/threeparttable.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/threeparttable.json",
-      "referenceNumber": 319,
+      "referenceNumber": 364,
       "name": "threeparttable License",
       "licenseId": "threeparttable",
       "seeAlso": [
@@ -7608,7 +7757,7 @@
       "reference": "https://spdx.org/licenses/TMate.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TMate.json",
-      "referenceNumber": 509,
+      "referenceNumber": 164,
       "name": "TMate Open Source License",
       "licenseId": "TMate",
       "seeAlso": [
@@ -7620,7 +7769,7 @@
       "reference": "https://spdx.org/licenses/TORQUE-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TORQUE-1.1.json",
-      "referenceNumber": 105,
+      "referenceNumber": 498,
       "name": "TORQUE v2.5+ Software License v1.1",
       "licenseId": "TORQUE-1.1",
       "seeAlso": [
@@ -7632,7 +7781,7 @@
       "reference": "https://spdx.org/licenses/TOSL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TOSL.json",
-      "referenceNumber": 107,
+      "referenceNumber": 640,
       "name": "Trusster Open Source License",
       "licenseId": "TOSL",
       "seeAlso": [
@@ -7644,7 +7793,7 @@
       "reference": "https://spdx.org/licenses/TPDL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TPDL.json",
-      "referenceNumber": 124,
+      "referenceNumber": 443,
       "name": "Time::ParseDate License",
       "licenseId": "TPDL",
       "seeAlso": [
@@ -7656,7 +7805,7 @@
       "reference": "https://spdx.org/licenses/TPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TPL-1.0.json",
-      "referenceNumber": 490,
+      "referenceNumber": 251,
       "name": "THOR Public License 1.0",
       "licenseId": "TPL-1.0",
       "seeAlso": [
@@ -7665,10 +7814,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/TrustedQSL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/TrustedQSL.json",
+      "referenceNumber": 396,
+      "name": "TrustedQSL License",
+      "licenseId": "TrustedQSL",
+      "seeAlso": [
+        "https://sourceforge.net/p/trustedqsl/tqsl/ci/master/tree/LICENSE.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/TTWL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TTWL.json",
-      "referenceNumber": 35,
+      "referenceNumber": 106,
       "name": "Text-Tabs+Wrap License",
       "licenseId": "TTWL",
       "seeAlso": [
@@ -7681,7 +7842,7 @@
       "reference": "https://spdx.org/licenses/TTYP0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TTYP0.json",
-      "referenceNumber": 542,
+      "referenceNumber": 336,
       "name": "TTYP0 License",
       "licenseId": "TTYP0",
       "seeAlso": [
@@ -7693,7 +7854,7 @@
       "reference": "https://spdx.org/licenses/TU-Berlin-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TU-Berlin-1.0.json",
-      "referenceNumber": 372,
+      "referenceNumber": 296,
       "name": "Technische Universitaet Berlin License 1.0",
       "licenseId": "TU-Berlin-1.0",
       "seeAlso": [
@@ -7705,7 +7866,7 @@
       "reference": "https://spdx.org/licenses/TU-Berlin-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TU-Berlin-2.0.json",
-      "referenceNumber": 246,
+      "referenceNumber": 499,
       "name": "Technische Universitaet Berlin License 2.0",
       "licenseId": "TU-Berlin-2.0",
       "seeAlso": [
@@ -7717,7 +7878,7 @@
       "reference": "https://spdx.org/licenses/Ubuntu-font-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Ubuntu-font-1.0.json",
-      "referenceNumber": 191,
+      "referenceNumber": 72,
       "name": "Ubuntu Font Licence v1.0",
       "licenseId": "Ubuntu-font-1.0",
       "seeAlso": [
@@ -7730,7 +7891,7 @@
       "reference": "https://spdx.org/licenses/UCAR.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/UCAR.json",
-      "referenceNumber": 452,
+      "referenceNumber": 559,
       "name": "UCAR License",
       "licenseId": "UCAR",
       "seeAlso": [
@@ -7742,7 +7903,7 @@
       "reference": "https://spdx.org/licenses/UCL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/UCL-1.0.json",
-      "referenceNumber": 550,
+      "referenceNumber": 619,
       "name": "Upstream Compatibility License v1.0",
       "licenseId": "UCL-1.0",
       "seeAlso": [
@@ -7754,7 +7915,7 @@
       "reference": "https://spdx.org/licenses/ulem.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ulem.json",
-      "referenceNumber": 399,
+      "referenceNumber": 495,
       "name": "ulem License",
       "licenseId": "ulem",
       "seeAlso": [
@@ -7766,7 +7927,7 @@
       "reference": "https://spdx.org/licenses/UMich-Merit.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/UMich-Merit.json",
-      "referenceNumber": 581,
+      "referenceNumber": 225,
       "name": "Michigan/Merit Networks License",
       "licenseId": "UMich-Merit",
       "seeAlso": [
@@ -7778,7 +7939,7 @@
       "reference": "https://spdx.org/licenses/Unicode-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Unicode-3.0.json",
-      "referenceNumber": 262,
+      "referenceNumber": 447,
       "name": "Unicode License v3",
       "licenseId": "Unicode-3.0",
       "seeAlso": [
@@ -7790,7 +7951,7 @@
       "reference": "https://spdx.org/licenses/Unicode-DFS-2015.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Unicode-DFS-2015.json",
-      "referenceNumber": 328,
+      "referenceNumber": 125,
       "name": "Unicode License Agreement - Data Files and Software (2015)",
       "licenseId": "Unicode-DFS-2015",
       "seeAlso": [
@@ -7802,7 +7963,7 @@
       "reference": "https://spdx.org/licenses/Unicode-DFS-2016.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Unicode-DFS-2016.json",
-      "referenceNumber": 484,
+      "referenceNumber": 665,
       "name": "Unicode License Agreement - Data Files and Software (2016)",
       "licenseId": "Unicode-DFS-2016",
       "seeAlso": [
@@ -7816,7 +7977,7 @@
       "reference": "https://spdx.org/licenses/Unicode-TOU.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Unicode-TOU.json",
-      "referenceNumber": 628,
+      "referenceNumber": 574,
       "name": "Unicode Terms of Use",
       "licenseId": "Unicode-TOU",
       "seeAlso": [
@@ -7829,7 +7990,7 @@
       "reference": "https://spdx.org/licenses/UnixCrypt.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/UnixCrypt.json",
-      "referenceNumber": 95,
+      "referenceNumber": 253,
       "name": "UnixCrypt License",
       "licenseId": "UnixCrypt",
       "seeAlso": [
@@ -7843,7 +8004,7 @@
       "reference": "https://spdx.org/licenses/Unlicense.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Unlicense.json",
-      "referenceNumber": 218,
+      "referenceNumber": 150,
       "name": "The Unlicense",
       "licenseId": "Unlicense",
       "seeAlso": [
@@ -7856,7 +8017,7 @@
       "reference": "https://spdx.org/licenses/UPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/UPL-1.0.json",
-      "referenceNumber": 5,
+      "referenceNumber": 342,
       "name": "Universal Permissive License v1.0",
       "licenseId": "UPL-1.0",
       "seeAlso": [
@@ -7869,7 +8030,7 @@
       "reference": "https://spdx.org/licenses/URT-RLE.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/URT-RLE.json",
-      "referenceNumber": 165,
+      "referenceNumber": 526,
       "name": "Utah Raster Toolkit Run Length Encoded License",
       "licenseId": "URT-RLE",
       "seeAlso": [
@@ -7882,7 +8043,7 @@
       "reference": "https://spdx.org/licenses/Vim.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Vim.json",
-      "referenceNumber": 549,
+      "referenceNumber": 28,
       "name": "Vim License",
       "licenseId": "Vim",
       "seeAlso": [
@@ -7895,7 +8056,7 @@
       "reference": "https://spdx.org/licenses/VOSTROM.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/VOSTROM.json",
-      "referenceNumber": 544,
+      "referenceNumber": 439,
       "name": "VOSTROM Public License for Open Source",
       "licenseId": "VOSTROM",
       "seeAlso": [
@@ -7907,7 +8068,7 @@
       "reference": "https://spdx.org/licenses/VSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/VSL-1.0.json",
-      "referenceNumber": 109,
+      "referenceNumber": 238,
       "name": "Vovida Software License v1.0",
       "licenseId": "VSL-1.0",
       "seeAlso": [
@@ -7919,7 +8080,7 @@
       "reference": "https://spdx.org/licenses/W3C.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/W3C.json",
-      "referenceNumber": 28,
+      "referenceNumber": 216,
       "name": "W3C Software Notice and License (2002-12-31)",
       "licenseId": "W3C",
       "seeAlso": [
@@ -7933,7 +8094,7 @@
       "reference": "https://spdx.org/licenses/W3C-19980720.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/W3C-19980720.json",
-      "referenceNumber": 629,
+      "referenceNumber": 206,
       "name": "W3C Software Notice and License (1998-07-20)",
       "licenseId": "W3C-19980720",
       "seeAlso": [
@@ -7945,7 +8106,7 @@
       "reference": "https://spdx.org/licenses/W3C-20150513.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/W3C-20150513.json",
-      "referenceNumber": 315,
+      "referenceNumber": 375,
       "name": "W3C Software Notice and Document License (2015-05-13)",
       "licenseId": "W3C-20150513",
       "seeAlso": [
@@ -7959,7 +8120,7 @@
       "reference": "https://spdx.org/licenses/w3m.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/w3m.json",
-      "referenceNumber": 379,
+      "referenceNumber": 82,
       "name": "w3m License",
       "licenseId": "w3m",
       "seeAlso": [
@@ -7971,7 +8132,7 @@
       "reference": "https://spdx.org/licenses/Watcom-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Watcom-1.0.json",
-      "referenceNumber": 612,
+      "referenceNumber": 322,
       "name": "Sybase Open Watcom Public License 1.0",
       "licenseId": "Watcom-1.0",
       "seeAlso": [
@@ -7984,7 +8145,7 @@
       "reference": "https://spdx.org/licenses/Widget-Workshop.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Widget-Workshop.json",
-      "referenceNumber": 256,
+      "referenceNumber": 647,
       "name": "Widget Workshop License",
       "licenseId": "Widget-Workshop",
       "seeAlso": [
@@ -7996,7 +8157,7 @@
       "reference": "https://spdx.org/licenses/Wsuipa.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Wsuipa.json",
-      "referenceNumber": 199,
+      "referenceNumber": 399,
       "name": "Wsuipa License",
       "licenseId": "Wsuipa",
       "seeAlso": [
@@ -8008,7 +8169,7 @@
       "reference": "https://spdx.org/licenses/WTFPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/WTFPL.json",
-      "referenceNumber": 173,
+      "referenceNumber": 234,
       "name": "Do What The F*ck You Want To Public License",
       "licenseId": "WTFPL",
       "seeAlso": [
@@ -8019,10 +8180,22 @@
       "isFsfLibre": true
     },
     {
+      "reference": "https://spdx.org/licenses/wwl.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/wwl.json",
+      "referenceNumber": 114,
+      "name": "WWL License",
+      "licenseId": "wwl",
+      "seeAlso": [
+        "http://www.db.net/downloads/wwl+db-1.3.tgz"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/wxWindows.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/wxWindows.json",
-      "referenceNumber": 350,
+      "referenceNumber": 147,
       "name": "wxWindows Library License",
       "licenseId": "wxWindows",
       "seeAlso": [
@@ -8034,7 +8207,7 @@
       "reference": "https://spdx.org/licenses/X11.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/X11.json",
-      "referenceNumber": 274,
+      "referenceNumber": 309,
       "name": "X11 License",
       "licenseId": "X11",
       "seeAlso": [
@@ -8047,7 +8220,7 @@
       "reference": "https://spdx.org/licenses/X11-distribute-modifications-variant.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/X11-distribute-modifications-variant.json",
-      "referenceNumber": 286,
+      "referenceNumber": 307,
       "name": "X11 License Distribution Modification Variant",
       "licenseId": "X11-distribute-modifications-variant",
       "seeAlso": [
@@ -8059,7 +8232,7 @@
       "reference": "https://spdx.org/licenses/X11-swapped.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/X11-swapped.json",
-      "referenceNumber": 7,
+      "referenceNumber": 158,
       "name": "X11 swapped final paragraphs",
       "licenseId": "X11-swapped",
       "seeAlso": [
@@ -8071,7 +8244,7 @@
       "reference": "https://spdx.org/licenses/Xdebug-1.03.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Xdebug-1.03.json",
-      "referenceNumber": 471,
+      "referenceNumber": 408,
       "name": "Xdebug License v 1.03",
       "licenseId": "Xdebug-1.03",
       "seeAlso": [
@@ -8083,7 +8256,7 @@
       "reference": "https://spdx.org/licenses/Xerox.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Xerox.json",
-      "referenceNumber": 417,
+      "referenceNumber": 577,
       "name": "Xerox License",
       "licenseId": "Xerox",
       "seeAlso": [
@@ -8095,7 +8268,7 @@
       "reference": "https://spdx.org/licenses/Xfig.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Xfig.json",
-      "referenceNumber": 63,
+      "referenceNumber": 426,
       "name": "Xfig License",
       "licenseId": "Xfig",
       "seeAlso": [
@@ -8109,7 +8282,7 @@
       "reference": "https://spdx.org/licenses/XFree86-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/XFree86-1.1.json",
-      "referenceNumber": 311,
+      "referenceNumber": 47,
       "name": "XFree86 License 1.1",
       "licenseId": "XFree86-1.1",
       "seeAlso": [
@@ -8122,7 +8295,7 @@
       "reference": "https://spdx.org/licenses/xinetd.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/xinetd.json",
-      "referenceNumber": 406,
+      "referenceNumber": 415,
       "name": "xinetd License",
       "licenseId": "xinetd",
       "seeAlso": [
@@ -8135,7 +8308,7 @@
       "reference": "https://spdx.org/licenses/xkeyboard-config-Zinoviev.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/xkeyboard-config-Zinoviev.json",
-      "referenceNumber": 55,
+      "referenceNumber": 451,
       "name": "xkeyboard-config Zinoviev License",
       "licenseId": "xkeyboard-config-Zinoviev",
       "seeAlso": [
@@ -8147,7 +8320,7 @@
       "reference": "https://spdx.org/licenses/xlock.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/xlock.json",
-      "referenceNumber": 140,
+      "referenceNumber": 516,
       "name": "xlock License",
       "licenseId": "xlock",
       "seeAlso": [
@@ -8159,7 +8332,7 @@
       "reference": "https://spdx.org/licenses/Xnet.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Xnet.json",
-      "referenceNumber": 639,
+      "referenceNumber": 367,
       "name": "X.Net License",
       "licenseId": "Xnet",
       "seeAlso": [
@@ -8171,7 +8344,7 @@
       "reference": "https://spdx.org/licenses/xpp.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/xpp.json",
-      "referenceNumber": 243,
+      "referenceNumber": 36,
       "name": "XPP License",
       "licenseId": "xpp",
       "seeAlso": [
@@ -8183,7 +8356,7 @@
       "reference": "https://spdx.org/licenses/XSkat.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/XSkat.json",
-      "referenceNumber": 535,
+      "referenceNumber": 145,
       "name": "XSkat License",
       "licenseId": "XSkat",
       "seeAlso": [
@@ -8195,7 +8368,7 @@
       "reference": "https://spdx.org/licenses/xzoom.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/xzoom.json",
-      "referenceNumber": 339,
+      "referenceNumber": 644,
       "name": "xzoom License",
       "licenseId": "xzoom",
       "seeAlso": [
@@ -8207,7 +8380,7 @@
       "reference": "https://spdx.org/licenses/YPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/YPL-1.0.json",
-      "referenceNumber": 506,
+      "referenceNumber": 549,
       "name": "Yahoo! Public License v1.0",
       "licenseId": "YPL-1.0",
       "seeAlso": [
@@ -8219,7 +8392,7 @@
       "reference": "https://spdx.org/licenses/YPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/YPL-1.1.json",
-      "referenceNumber": 538,
+      "referenceNumber": 654,
       "name": "Yahoo! Public License v1.1",
       "licenseId": "YPL-1.1",
       "seeAlso": [
@@ -8232,7 +8405,7 @@
       "reference": "https://spdx.org/licenses/Zed.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Zed.json",
-      "referenceNumber": 500,
+      "referenceNumber": 513,
       "name": "Zed License",
       "licenseId": "Zed",
       "seeAlso": [
@@ -8244,7 +8417,7 @@
       "reference": "https://spdx.org/licenses/Zeeff.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Zeeff.json",
-      "referenceNumber": 382,
+      "referenceNumber": 384,
       "name": "Zeeff License",
       "licenseId": "Zeeff",
       "seeAlso": [
@@ -8256,7 +8429,7 @@
       "reference": "https://spdx.org/licenses/Zend-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Zend-2.0.json",
-      "referenceNumber": 51,
+      "referenceNumber": 334,
       "name": "Zend License v2.0",
       "licenseId": "Zend-2.0",
       "seeAlso": [
@@ -8269,7 +8442,7 @@
       "reference": "https://spdx.org/licenses/Zimbra-1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Zimbra-1.3.json",
-      "referenceNumber": 555,
+      "referenceNumber": 450,
       "name": "Zimbra Public License v1.3",
       "licenseId": "Zimbra-1.3",
       "seeAlso": [
@@ -8282,7 +8455,7 @@
       "reference": "https://spdx.org/licenses/Zimbra-1.4.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Zimbra-1.4.json",
-      "referenceNumber": 227,
+      "referenceNumber": 257,
       "name": "Zimbra Public License v1.4",
       "licenseId": "Zimbra-1.4",
       "seeAlso": [
@@ -8294,7 +8467,7 @@
       "reference": "https://spdx.org/licenses/Zlib.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Zlib.json",
-      "referenceNumber": 74,
+      "referenceNumber": 567,
       "name": "zlib License",
       "licenseId": "Zlib",
       "seeAlso": [
@@ -8308,7 +8481,7 @@
       "reference": "https://spdx.org/licenses/zlib-acknowledgement.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/zlib-acknowledgement.json",
-      "referenceNumber": 371,
+      "referenceNumber": 12,
       "name": "zlib/libpng License with Acknowledgement",
       "licenseId": "zlib-acknowledgement",
       "seeAlso": [
@@ -8320,7 +8493,7 @@
       "reference": "https://spdx.org/licenses/ZPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ZPL-1.1.json",
-      "referenceNumber": 598,
+      "referenceNumber": 314,
       "name": "Zope Public License 1.1",
       "licenseId": "ZPL-1.1",
       "seeAlso": [
@@ -8332,7 +8505,7 @@
       "reference": "https://spdx.org/licenses/ZPL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ZPL-2.0.json",
-      "referenceNumber": 539,
+      "referenceNumber": 623,
       "name": "Zope Public License 2.0",
       "licenseId": "ZPL-2.0",
       "seeAlso": [
@@ -8346,7 +8519,7 @@
       "reference": "https://spdx.org/licenses/ZPL-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ZPL-2.1.json",
-      "referenceNumber": 638,
+      "referenceNumber": 110,
       "name": "Zope Public License 2.1",
       "licenseId": "ZPL-2.1",
       "seeAlso": [
@@ -8356,5 +8529,5 @@
       "isFsfLibre": true
     }
   ],
-  "releaseDate": "2024-08-19"
+  "releaseDate": "2024-12-30T00:00:00Z"
 }


### PR DESCRIPTION
ran:

```
~/work/reuse-tool on dev/kbroch/update-lic-resources:main                                                                                                            at 09:30:35 AM
❯ make update-resources
python .github/workflows/license_list_up_to_date.py --download
spdx-license-list-data latest version is v3.26.0
exceptions.json is not up-to-date, downloading newer release
licenses.json is not up-to-date, downloading newer release
```
- [x] My changes do not contradict
      [the current specification](https://reuse.software/spec/).
- [x] I agree to license my contribution under the licenses indicated in the
      changed files.
