### PR TITLE
Add helper script snippet for following renames

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -145,3 +145,4 @@ Contributors
 - Emil Velikov <emil.l.velikov@gmail.com>
 - Linnea Gräf <nea@nea.moe>
 - Raphael Schlarb <info@raphael.schlarb.one>
+- Matthias Schoettle <opensource@mattsch.com>

--- a/docs/scripts.rst
+++ b/docs/scripts.rst
@@ -1,5 +1,6 @@
 ..
   SPDX-FileCopyrightText: 2022 Nico Rikken <nico.rikken@fsfe.org>
+  SPDX-FileCopyrightText: 2025 Matthias Schoettle <opensource@mattsch.com>
 
   SPDX-License-Identifier: CC-BY-SA-4.0
 
@@ -55,6 +56,22 @@ This output is convenient for use in larger scripts.
 
   $ git log --reverse --date="format:%Y" --format="format:%cd" | head -n 1
   2017
+
+.. SPDX-SnippetEnd
+
+Year of first commit while following renames
+====================
+
+If you want to follow file renames in the Git history, you can use the `--follow` argument.
+This requires you to pass the file to `git log`.
+
+.. SPDX-SnippetBegin
+.. SPDX-Snippet-License-Identifier: CC0-1.0
+
+.. code-block:: console
+
+  $ git log --follow --date="format:%Y" --format="format:%cd" -- docs/scripts.rst | tail -n 1
+  2022
 
 .. SPDX-SnippetEnd
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read CONTRIBUTING.md. Non-trivial changes should
be discussed in an issue before committing to a PR.

Please succinctly describe your changes.
-->
The current example does not follow renames which I think should be included to know the very first time the file was introduced.
For some reason, `git log --reverse --follow` does not work properly. So reversed it to use `tail` instead of `head`.

I added an extra section but it might be worth to add it to the existing examples instead.

<!-- Next, let's do a check list. Remove what doesn't apply. -->

<!-- - [ ] Added a change log entry in `changelog.d/<directory>/`. -->
<!-- - [ ] Added self to copyright blurb of touched files. -->
- [x] Added self to `AUTHORS.rst`.
<!-- - [ ] Wrote tests.
- [ ] Documented my changes in `docs/man/` or elsewhere.
-->
- [x] My changes do not contradict
      [the current specification](https://reuse.software/spec/).
- [x] I agree to license my contribution under the licenses indicated in the
      changed files.


>  - [ ] Added a change log entry in `changelog.d/<directory>/`.

I feel that the changes are too small and do not affect the tool itself, so I did not add one. If you disagree, I'll be happy to add a changelog entry.

- [x] Added self to copyright blurb of touched files.