### PR TITLE
cli/supported_licenses: simplify the license list

### DIFF
--- a/src/reuse/cli/supported_licenses.py
+++ b/src/reuse/cli/supported_licenses.py
@@ -20,10 +20,15 @@ def supported_licenses() -> None:
     # pylint: disable=missing-function-docstring
     licenses = _load_license_list(_LICENSES)[1]
 
+    license_name_width = 0
     for license_id, license_info in licenses.items():
         license_name = license_info["name"]
-        license_reference = license_info["reference"]
-        click.echo(
-            f"{license_id: <40}\t{license_name: <80}\t"
-            f"{license_reference: <50}"
-        )
+
+        width = len(license_name)
+        if width > license_name_width:
+            license_name_width = width
+
+    for license_id, license_info in licenses.items():
+        license_name = license_info["name"]
+
+        click.echo(f"{license_name: <{license_name_width}}    {license_id}")


### PR DESCRIPTION
Remove the license reference, since it may not fit the terminal.

Move the license name before the license id, in order to improve the user experience.

Make the text width dynamic, in order to improve readability.

<!--
Before submitting a PR, please read CONTRIBUTING.md. Non-trivial changes should
be discussed in an issue before committing to a PR.

Please succinctly describe your changes.
-->

<!-- Next, let's do a check list. Remove what doesn't apply. -->

- [ ] Added a change log entry in `changelog.d/<directory>/`.
- [ ] Added self to copyright blurb of touched files.
- [ ] Added self to `AUTHORS.rst`.
- [ ] Wrote tests.
- [ ] Documented my changes in `docs/man/` or elsewhere.
- [ ] My changes do not contradict
      [the current specification](https://reuse.software/spec/).
- [x] I agree to license my contribution under the licenses indicated in the
      changed files.
