### PR TITLE
Add Github action for closing stale issues

### DIFF
--- a/.github/workflows/close_inactive_issues.yaml
+++ b/.github/workflows/close_inactive_issues.yaml
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: 2025 Free Software Foundation Europe e.V. <https://fsfe.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "22 2 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-issue-stale: 360
+          days-before-issue-close: 30
+          operations-per-run: 5
+          remove-stale-when-updated: false
+          exempt-all-issue-assignees: true
+          stale-issue-label: "stale"
+          close-issue-label: "unresolved"
+          stale-issue-message:
+            "Thank you for your time and contributions! Unfortunately, this
+            issue has been inactive for quite a while which means we probably
+            can't manage the time to deal with it. That's why we're marking it
+            as stale. We want to keep things tidy and focus on active
+            discussions, but we’re always happy to revisit if this is still
+            relevant!\n\nIf you’d like to keep this open, please add a comment
+            to let us know and remove the label stale. Otherwise, this issue
+            will most likely be automatically closed soon."
+          close-issue-message:
+            "Since there hasn't been any recent activity after the last message,
+            we're going to go ahead and close this issue. Feel free to reopen
+            this and remove the labels stale and unresolved if it's
+            urgent.\n\nWe truly appreciate your contributions and
+            engagement!\n\nThank you and happy hacking!"
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          stale-pr-label: "stale"
+          close-pr-label: "unresolved"
+          stale-pr-message:
+            "Thank you so much for your contribution! We really appreciate your
+            time and effort on this! However, this pull request has been
+            inactive for a while, which means we have not been able to
+            prioritize it. It also means there are most likely merge conflicts
+            or required updates to bring it in line with the latest changes. To
+            keep things organized and focus on active contributions, we're
+            marking this as stale.\n\nIf this is still relevant and you'd like
+            to keep it open, please update the branch and remove the label
+            stale. Otherwise, this PR may be automatically closed soon. We're
+            always happy to revisit if needed!"
+          close-pr-message:
+            "Since there hasn't been any recent activity after the last message,
+            we're going to go ahead and close this pull request. If this is
+            still relevant to you, feel free to reopen it and update the branch
+            to resolve any conflicts. In that case, please also remove the
+            labels stale and unresolved.\n\nWe truly appreciate your
+            contributions and engagement!\n\nThank you and happy hacking!"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This will help with keeping the repo in a healthy state. Note that while this does contain a message for marking PRs as stale and closing them, it doesn't currently do so because the timeframes for that are set to -1. I just added the text to make activating it as painless as possible if we ever decide to do so.

Also, this will only touch 5 issues per run, so the pings will get spread out nicely. We can increase the number once it's handled all issues once or we can leave it as is until we notice a bottleneck.
