### PR TITLE
Add support for uv.lock file

### DIFF
--- a/changelog.d/added/comment-uv-lock.md
+++ b/changelog.d/added/comment-uv-lock.md
@@ -1,0 +1,1 @@
+- Added `uv.lock` (UncommentableCommentStyle) as a recognised file type for comments.

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -20,6 +20,7 @@
 # SPDX-FileCopyrightText: 2024 Anthony Loiseau <anthony.loiseau@allcircuits.com>
 # SPDX-FileCopyrightText: 2025 Raphael Schlarb <info@raphael.schlarb.one>
 # SPDX-FileCopyrightText: 2025 Kiko Fernandez-Reyes <kiko@erlang.org>
+# SPDX-FileCopyrightText: 2025 Manlio Perillo <manlio.perillo@gmail.com>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -920,6 +921,7 @@ FILENAME_COMMENT_STYLE_MAP = {
     "requirements.txt": PythonCommentStyle,
     "ROOT": MlCommentStyle,
     "setup.cfg": PythonCommentStyle,
+    "uv.lock": UncommentableCommentStyle,
     "yarn.lock": UncommentableCommentStyle,
 }
 


### PR DESCRIPTION
Add support for `uv.lock` file.
`uv.lock` file is uncommentable.

<!--
Before submitting a PR, please read CONTRIBUTING.md. Non-trivial changes should
be discussed in an issue before committing to a PR.

Please succinctly describe your changes.
-->

<!-- Next, let's do a check list. Remove what doesn't apply. -->

- [x] Added a change log entry in `changelog.d/<directory>/`.
- [x] Added self to copyright blurb of touched files.
- [x] Added self to `AUTHORS.rst`.
- [ ] Wrote tests.
- [ ] Documented my changes in `docs/man/` or elsewhere.
- [x] My changes do not contradict
      [the current specification](https://reuse.software/spec/).
- [x] I agree to license my contribution under the licenses indicated in the
      changed files.
