### PR TITLE
Deprecate OTP linking exception

### DIFF
--- a/src/reuse/resources/exceptions.json
+++ b/src/reuse/resources/exceptions.json
@@ -192,7 +192,7 @@
     },
     {
       "reference": "./erlang-otp-linking-exception.json",
-      "isDeprecatedLicenseId": false,
+      "isDeprecatedLicenseId": true,
       "detailsUrl": "./erlang-otp-linking-exception.html",
       "referenceNumber": 46,
       "name": "Erlang/OTP Linking Exception",


### PR DESCRIPTION
Deprecates the Erlang/OTP linking exception. 

This exception refers to when Erlang/OTP had the Erlang Public License but Erlang/OTP has Apache 2.0 since 2016 or so. 
I thought that this exception should be considered deprecated, any recent and supported Erlang version (Erlang/OTP maintains the last three major releases) is not licensed under EPL.

If this exception should not be deprecated, please close this PR.

<!-- Next, let's do a check list. Remove what doesn't apply. -->

- [X] Added a change log entry in `changelog.d/<directory>/`.
- [X] My changes do not contradict
      [the current specification](https://reuse.software/spec/).
- [x] I agree to license my contribution under the licenses indicated in the
      changed files.
