### PR TITLE
Move license below h1-header in Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
+# reuse
+
 <!--
 SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
 
 SPDX-License-Identifier: CC-BY-SA-4.0
 -->
-
-# reuse
 
 [![The latest version of reuse can be found on PyPI.](https://img.shields.io/pypi/v/reuse.svg)](https://pypi.python.org/pypi/reuse)
 [![Information on what versions of Python reuse supports can be found on PyPI.](https://img.shields.io/pypi/pyversions/reuse.svg)](https://pypi.python.org/pypi/reuse)


### PR DESCRIPTION
Linters like [PyMarkdown](https://pypi.org/project/pymarkdownlnt/) complain about the license comment starting Markdown documents.

```
README.md:1:1: MD041: First line in file should be a top level heading (first-line-heading,first-line-h1)
```

While the `reuse` tool still puts the license comment in line 1, we can showcase in this repository how to handle this situation through manual editing to both please the linter and stay REUSE-compliant.

This change relates to the discussion in issue #868.

<!--
Before submitting a PR, please read CONTRIBUTING.md. Non-trivial changes should
be discussed in an issue before committing to a PR.

Please succinctly describe your changes.
-->

<!-- Next, let's do a check list. Remove what doesn't apply. -->

- [ ] Added a change log entry in `changelog.d/<directory>/`.
- [ ] Added self to copyright blurb of touched files.
- [ ] Added self to `AUTHORS.rst`. **\*\*)**
- [ ] Wrote tests.
- [ ] Documented my changes in `docs/man/` or elsewhere.
- [x] My changes do not contradict
      [the current specification](https://reuse.software/spec/).
- [x] I agree to license my contribution under the licenses indicated in the
      changed files.

**\*\*)** As this is a trivial change, I waive my right to be credited as an author.
