### PR TITLE
Correct invocation for jujutsu file listing

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -150,3 +150,4 @@ Contributors
 - Kiko Fernandez-Reyes <kiko@erlang.org>
 - Charlie Jenkins <charlie@rivosinc.com>
 - Hatzka <hatzka@nezumi.studio>
+- Jonas Fierlings <fnoegip@gmail.com>

--- a/changelog.d/fixed/jujutsu-file-listing.md
+++ b/changelog.d/fixed/jujutsu-file-listing.md
@@ -1,0 +1,2 @@
+- Fixed repository file detection using jujutsu versions 0.19.0 or later.
+  (#1191)


### PR DESCRIPTION
The `jj files` command was deprecated in jujutsu 0.19.0, and removed in jujutsu 0.26.0 (released in february of 2025). The fix is to use the new `jj file list` command instead.

Before adding a note to the changelog I wanted to ask about backwards compatibility. This PR fixes use with jujutsu >= 0.26.0, but breaks users with jujutsu < 0.19.0 (which was released in july 2024). In theory the code in `vcs.py` could check which version of jujutsu is installed and then use the corresponding correct command, but I am not sure what the project policy is with regards to backwards compatibility vs maintainer burden, so the current fix breaks backwards compatibility with older versions in order to keep the code simple.

<!--
Before submitting a PR, please read CONTRIBUTING.md. Non-trivial changes should
be discussed in an issue before committing to a PR.

Please succinctly describe your changes.
-->

<!-- Next, let's do a check list. Remove what doesn't apply. -->

- [ ] Added a change log entry in `changelog.d/<directory>/`.
- [x] Added self to copyright blurb of touched files.
- [x] Added self to `AUTHORS.rst`.
- [ ] Wrote tests.
- [ ] Documented my changes in `docs/man/` or elsewhere.
- [x] My changes do not contradict
      [the current specification](https://reuse.software/spec/).
- [x] I agree to license my contribution under the licenses indicated in the
      changed files.

Fixes #1166.