### PR TITLE
Fix shell completion in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ with `zsh` or `fish` as needed, or any other shells supported by the Python
 (e.g.`~/.bashrc`):
 
 ```bash
-eval "$(_REUSE__COMPLETE=bash_source reuse)"
+eval "$(_REUSE_COMPLETE=bash_source reuse)"
 ```
 
 Alternatively, you can place the generated completion script in


### PR DESCRIPTION
Remove double underscore from `_REUSE_COMPLETE` variable.

<!--
Before submitting a PR, please read CONTRIBUTING.md. Non-trivial changes should
be discussed in an issue before committing to a PR.

Please succinctly describe your changes.
-->

<!-- Next, let's do a check list. Remove what doesn't apply. -->

- [x] I agree to license my contribution under the licenses indicated in the
      changed files.
