### PR TITLE
Prepare test_cli_main.py for click 8.2

### DIFF
--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -19,7 +19,9 @@ class TestMain:
         without_help = CliRunner().invoke(main, [])
         with_help = CliRunner().invoke(main, ["--help"])
         assert without_help.output == with_help.output
-        assert without_help.exit_code == with_help.exit_code == 0
+        # click changed the return value in 8.2
+        assert without_help.exit_code in {0, 2}
+        assert with_help.exit_code == 0
         assert with_help.output.startswith("Usage: reuse")
 
     def test_version(self):


### PR DESCRIPTION
In click version 8.2.0, when displaying the help because no sub-command or option was specified, the exit code changed from 0 to 2 ([relevant PR][]).

[relevant PR]: https://github.com/pallets/click/pull/1489

---

This is the smallest patch I could come up with. I tried to toy with `importlib.metadata` and adjusting the test based on which click version was installed, but I found that maybe unnecessarily wordy.

We run into this issue when trying to update click to 8.2.1 in Fedora. I did not submit the update itself here, because it would raise minimal supported python to 3.10 from 3.9 (according to regenerated `poetry.lock`).

---

<!-- Next, let's do a check list. Remove what doesn't apply. -->

- [ ] Added a change log entry in `changelog.d/<directory>/`.
- [ ] Added self to copyright blurb of touched files.
- [ ] Added self to `AUTHORS.rst`.
- [ ] Wrote tests.
- [ ] Documented my changes in `docs/man/` or elsewhere.
- [x] My changes do not contradict
      [the current specification](https://reuse.software/spec/).
- [x] I agree to license my contribution under the licenses indicated in the
      changed files.
