### PR TITLE
Display sponsorship/donation options

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2025 Free Software Foundation Europe e.V. <https://fsfe.org>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+# These are supported funding model platforms
+github: [fsfe]
+custom:
+  ["https://my.fsfe.org/donate?referrer=https://github.com/fsfe/reuse-tool"]


### PR DESCRIPTION
This displays the sponsorship/donation options directly at the repo, not only the user.

- [x] I agree to license my contribution under the licenses indicated in the changed files.
