### PR TITLE
Correctly include all gettext strings in .pot file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,8 @@ dist: clean-build clean-pyc clean-docs ## builds source and wheel package
 
 .PHONY: create-pot
 create-pot:  ## generate .pot file
-	xgettext --add-comments --from-code=utf-8 --output=po/reuse.pot src/reuse/**/*.py
-	xgettext --add-comments --output=po/click.pot "${VIRTUAL_ENV}"/lib/python*/*-packages/click/**.py
+	xgettext --add-comments --from-code=utf-8 --output=po/reuse.pot $(shell find src/reuse -name '*.py')
+	xgettext --add-comments --output=po/click.pot $(shell find "${VIRTUAL_ENV}"/lib/python*/*-packages/click -name '*.py')
 	msgcat --output=po/reuse.pot po/reuse.pot po/click.pot
 	for name in po/*.po; do \
 		msgmerge --output=$${name} $${name} po/reuse.pot; \

--- a/changelog.d/fixed/translations.md
+++ b/changelog.d/fixed/translations.md
@@ -1,0 +1,3 @@
+- Fixed a bug that caused not all strings to be marked translatable. This bug
+  was introduced in v5.0.0. Strings that were already translated _before_ the
+  release of v5.0.0 are now translated again. (#1216)


### PR DESCRIPTION
Apparently globstar patterns ('**/*') are not supported in Make. Using `find` circumvents this problem.

Fixes #1214

<!--
Before submitting a PR, please read CONTRIBUTING.md. Non-trivial changes should
be discussed in an issue before committing to a PR.

Please succinctly describe your changes.
-->

<!-- Next, let's do a check list. Remove what doesn't apply. -->

- [x] Added a change log entry in `changelog.d/<directory>/`.
- [x] My changes do not contradict
      [the current specification](https://reuse.software/spec/).
- [x] I agree to license my contribution under the licenses indicated in the
      changed files.
