### PR TITLE
Reduce Pijul version

### DIFF
--- a/.github/workflows/pijul.yaml
+++ b/.github/workflows/pijul.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Pijul
         run: |
           sudo apt install make libsodium-dev libclang-dev pkg-config libssl-dev libxxhash-dev libzstd-dev clang
-          cargo install --locked pijul --version "~1.0.0-beta"
+          cargo install --locked pijul --version "1.0.0-beta.6"
           pijul identity new --no-prompt --display-name 'Jane Doe' --email 'jdoe@example.com' 'jdoe'
       - name: Run tests with pytest
         run: |


### PR DESCRIPTION
I don't think the latest compiles with Ubuntu 24.04's Rust version.

<!--
Before submitting a PR, please read CONTRIBUTING.md. Non-trivial changes should
be discussed in an issue before committing to a PR.

Please succinctly describe your changes.
-->

<!-- Next, let's do a check list. Remove what doesn't apply. -->

- [ ] Added a change log entry in `changelog.d/<directory>/`.
- [ ] Added self to copyright blurb of touched files.
- [ ] Added self to `AUTHORS.rst`.
- [ ] Wrote tests.
- [ ] Documented my changes in `docs/man/` or elsewhere.
- [ ] My changes do not contradict
      [the current specification](https://reuse.software/spec/).
- [x] I agree to license my contribution under the licenses indicated in the
      changed files.
