### PR TITLE
Feed a frozenset instead of a list to ProcessPoolExecutor

### DIFF
--- a/src/reuse/report.py
+++ b/src/reuse/report.py
@@ -135,12 +135,12 @@ def _generate_file_reports(
         else project.all_files()
     )
     if multiprocessing and ENABLE_PARALLEL:
-        files_list = list(files)
+        files_set = frozenset(files)
         with ProcessPoolExecutor() as executor:
             yield from executor.map(
                 container,
-                files_list,
-                chunksize=max(1, int(len(files_list) / _CPU_COUNT / 4)),
+                files_set,
+                chunksize=max(1, int(len(files_set) / _CPU_COUNT / 4)),
             )
     else:
         yield from map(container, files)


### PR DESCRIPTION
For reasons that are beyond me, this is a significant speed-up. I suspect it's either because a guarantee about immutability allows some code to go swifter, or because the order of the set is effectively 'random', and inefficient files are no longer grouped together.

<!--
Before submitting a PR, please read CONTRIBUTING.md. Non-trivial changes should
be discussed in an issue before committing to a PR.

Please succinctly describe your changes.
-->

<!-- Next, let's do a check list. Remove what doesn't apply. -->

- [x] My changes do not contradict
      [the current specification](https://reuse.software/spec/).
- [x] I agree to license my contribution under the licenses indicated in the
      changed files.
