### PR TITLE
Fix lint subcommand's help message formatting

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -151,3 +151,4 @@ Contributors
 - Charlie Jenkins <charlie@rivosinc.com>
 - Hatzka <hatzka@nezumi.studio>
 - Jonas Fierlings <fnoegip@gmail.com>
+- ASCIIMoth <ascii@moth.contact>

--- a/changelog.d/fixed/lint-help.md
+++ b/changelog.d/fixed/lint-help.md
@@ -1,2 +1,1 @@
-- Fixed formatting in `lint` subcommand help message
-
+- Fixed formatting in `lint` subcommand help message. (#1212, #1236)

--- a/changelog.d/fixed/lint-help.md
+++ b/changelog.d/fixed/lint-help.md
@@ -1,0 +1,2 @@
+- Fixed formatting in `lint` subcommand help message
+

--- a/src/reuse/cli/lint.py
+++ b/src/reuse/cli/lint.py
@@ -33,31 +33,41 @@ _HELP = (
     + "\n\n"
     + _("Specifically, the following criteria are checked:")
     + "\n\n\b\n"
-    + _(
-        "- Are there any bad (unrecognised, not compliant with SPDX)"
-        " licenses in the project?"
+    + click.wrap_text(
+        _(
+            "- Are there any bad (unrecognised, not compliant with SPDX)"
+            " licenses in the project?"
+        )
     )
     + "\n"
-    + _("- Are there any deprecated licenses in the project?")
+    + click.wrap_text(_("- Are there any deprecated licenses in the project?"))
     + "\n"
-    + _(
-        "- Are there any license files in the LICENSES/ directory"
-        " without file extension?"
+    + click.wrap_text(
+        _(
+            "- Are there any license files in the LICENSES/ directory"
+            " without file extension?"
+        )
     )
     + "\n"
-    + _(
-        "- Are any licenses referred to inside of the project, but"
-        " not included in the LICENSES/ directory?"
+    + click.wrap_text(
+        _(
+            "- Are any licenses referred to inside of the project, but"
+            " not included in the LICENSES/ directory?"
+        )
     )
     + "\n"
-    + _(
-        "- Are any licenses included in the LICENSES/ directory that"
-        " are not used inside of the project?"
+    + click.wrap_text(
+        _(
+            "- Are any licenses included in the LICENSES/ directory that"
+            " are not used inside of the project?"
+        )
     )
     + "\n"
-    + _("- Are there any read errors?")
+    + click.wrap_text(_("- Are there any read errors?"))
     + "\n"
-    + _("- Do all files have valid copyright and licensing information?")
+    + click.wrap_text(
+        _("- Do all files have valid copyright and licensing information?")
+    )
 )
 
 

--- a/src/reuse/cli/lint.py
+++ b/src/reuse/cli/lint.py
@@ -31,7 +31,7 @@ _HELP = (
     ).format(reuse_version=__REUSE_version__)
     + "\n\n"
     + _("Specifically, the following criteria are checked:")
-    + "\n\n"
+    + "\n\n\b\n"
     + _(
         "- Are there any bad (unrecognised, not compliant with SPDX)"
         " licenses in the project?"

--- a/src/reuse/cli/lint.py
+++ b/src/reuse/cli/lint.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2022 Florian Snow <florian@familysnow.net>
 # SPDX-FileCopyrightText: 2023 DB Systel GmbH
 # SPDX-FileCopyrightText: 2024 Nico Rikken <nico@nicorikken.eu>
+# SPDX-FileCopyrightText: 2025 ASCIIMoth <ascii@moth.contact>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read CONTRIBUTING.md. Non-trivial changes should
be discussed in an issue before committing to a PR.

Please succinctly describe your changes.
-->

This is #1212, re-opened. I somehow messed up pushing to the branch, and irreperably closed the PR.

<!-- Next, let's do a check list. Remove what doesn't apply. -->

- [x] Added a change log entry in `changelog.d/<directory>/`.
- [x] Added self to copyright blurb of touched files.
- [x] Added self to `AUTHORS.rst`.
- [ ] Wrote tests.
- [ ] Documented my changes in `docs/man/` or elsewhere.
- [x] My changes do not contradict
      [the current specification](https://reuse.software/spec/).
- [x] I agree to license my contribution under the licenses indicated in the
      changed files.
