### PR TITLE
Fix and improve `reuse lint --lines`

### DIFF
--- a/changelog.d/fixed/fix-format-lines.md
+++ b/changelog.d/fixed/fix-format-lines.md
@@ -1,0 +1,3 @@
+- Fixed a bug where a newline would sometimes be missing from
+  `reuse lint --lines`. (#1251)
+- The output of `reuse lint --lines` is now sorted by path name. (#1251)

--- a/src/reuse/lint.py
+++ b/src/reuse/lint.py
@@ -275,13 +275,14 @@ def format_lines_subset(report: ProjectReportSubsetProtocol) -> str:
     output = StringIO()
 
     # Missing licenses
-    for lic, files in sorted(report.missing_licenses.items()):
-        for path in sorted(files):
-            output.write(
-                _("{path}: missing license '{lic}'\n").format(
-                    path=path, lic=lic
-                )
-            )
+    for path, lic in sorted(
+        (value, key)
+        for key, values in report.missing_licenses.items()
+        for value in values
+    ):
+        output.write(
+            _("{path}: missing license '{lic}'\n").format(path=path, lic=lic)
+        )
 
     # Read errors
     for path in sorted(report.read_errors):
@@ -296,11 +297,11 @@ def format_lines_subset(report: ProjectReportSubsetProtocol) -> str:
             )
 
     # Without licenses
-    for path in report.files_without_licenses:
+    for path in sorted(report.files_without_licenses):
         output.write(_("{path}: no license identifier\n").format(path=path))
 
     # Without copyright
-    for path in report.files_without_copyright:
+    for path in sorted(report.files_without_copyright):
         output.write(_("{path}: no copyright notice\n").format(path=path))
 
     return output.getvalue()
@@ -327,7 +328,7 @@ def format_lines(report: ProjectReport) -> str:
         # Bad licenses
         for lic, path in sorted(report.bad_licenses.items()):
             output.write(
-                _("{lic_path}: bad license {lic}\n").format(
+                _("{lic_path}: bad license '{lic}'\n").format(
                     lic_path=path, lic=lic
                 )
             )

--- a/src/reuse/lint.py
+++ b/src/reuse/lint.py
@@ -291,7 +291,7 @@ def format_lines_subset(report: ProjectReportSubsetProtocol) -> str:
         for expression in sorted(expressions):
             output.write(
                 _(
-                    "{path}: invalid SPDX License Expression '{expression}'"
+                    "{path}: invalid SPDX License Expression '{expression}'\n"
                 ).format(path=path, expression=expression)
             )
 

--- a/src/reuse/lint.py
+++ b/src/reuse/lint.py
@@ -10,6 +10,7 @@ the reports and printing some conclusions.
 """
 
 import json
+from collections import defaultdict
 from io import StringIO
 from itertools import chain
 from pathlib import Path
@@ -265,46 +266,61 @@ def format_json(report: ProjectReport) -> str:
     )
 
 
-def format_lines_subset(report: ProjectReportSubsetProtocol) -> str:
-    """Formats a subset of a report, namely missing licenses, read errors, files
-    without licenses, and files without copyright.
-
-    Args:
-        report: A populated report.
-    """
+def _output_lines_dict(format_dict: dict[str, list[str]]) -> str:
     output = StringIO()
+    for path, items in sorted(format_dict.items()):
+        for item in items:
+            output.write(f"{path}: {item}\n")
+    return output.getvalue()
+
+
+def _format_lines_subset_dict(
+    report: ProjectReportSubsetProtocol,
+) -> defaultdict[str, list[str]]:
+    result_dict = defaultdict(list)
 
     # Missing licenses
-    for path, lic in sorted(
-        (value, key)
-        for key, values in report.missing_licenses.items()
-        for value in values
-    ):
-        output.write(
-            _("{path}: missing license '{lic}'\n").format(path=path, lic=lic)
-        )
+    for lic, files in sorted(report.missing_licenses.items()):
+        for path in files:
+            result_dict[str(path)].append(
+                _("missing license '{lic}'").format(lic=lic)
+            )
 
     # Read errors
-    for path in sorted(report.read_errors):
-        output.write(_("{path}: read error\n").format(path=path))
+    for path in report.read_errors:
+        result_dict[str(path)].append(_("read error").format(path=path))
 
-    for path, expressions in sorted(report.invalid_spdx_expressions.items()):
+    for path, expressions in report.invalid_spdx_expressions.items():
         for expression in sorted(expressions):
-            output.write(
-                _(
-                    "{path}: invalid SPDX License Expression '{expression}'\n"
-                ).format(path=path, expression=expression)
+            result_dict[str(path)].append(
+                _("invalid SPDX License Expression '{expression}'").format(
+                    expression=expression
+                )
             )
 
     # Without licenses
-    for path in sorted(report.files_without_licenses):
-        output.write(_("{path}: no license identifier\n").format(path=path))
+    for path in report.files_without_licenses:
+        result_dict[str(path)].append(_("no license identifier"))
 
     # Without copyright
-    for path in sorted(report.files_without_copyright):
-        output.write(_("{path}: no copyright notice\n").format(path=path))
+    for path in report.files_without_copyright:
+        result_dict[str(path)].append(_("no copyright notice"))
 
-    return output.getvalue()
+    return result_dict
+
+
+def format_lines_subset(report: ProjectReportSubsetProtocol) -> str:
+    """Formats a subset of a report, namely missing licenses, read errors,
+    invalid SPDX License Expressions, files without licenses, and files without
+    copyright.
+
+    Args:
+        report: A populated report.
+
+    Returns:
+        String (in plaintext) that can be output to sys.stdout
+    """
+    return _output_lines_dict(_format_lines_subset_dict(report))
 
 
 def format_lines(report: ProjectReport) -> str:
@@ -317,46 +333,34 @@ def format_lines(report: ProjectReport) -> str:
     Returns:
         String (in plaintext) that can be output to sys.stdout
     """
-    output = StringIO()
 
-    def license_path(lic: str) -> Path | None:
+    def license_path(lic: str) -> str:
         """Resolve a license identifier to a license path."""
-        return report.licenses.get(lic)
+        return str(report.licenses.get(lic))
 
-    subset_output = ""
-    if not report.is_compliant:
-        # Bad licenses
-        for lic, path in sorted(report.bad_licenses.items()):
-            output.write(
-                _("{lic_path}: bad license '{lic}'\n").format(
-                    lic_path=path, lic=lic
-                )
-            )
+    result_dict: defaultdict[str, list[str]] = defaultdict(list)
 
-        # Deprecated licenses
-        for lic in sorted(report.deprecated_licenses):
-            lic_path = license_path(lic)
-            output.write(
-                _("{lic_path}: deprecated license\n").format(lic_path=lic_path)
-            )
+    # Bad licenses
+    for lic, path in report.bad_licenses.items():
+        result_dict[str(path)].append(_("bad license '{lic}'").format(lic=lic))
 
-        # Licenses without extension
-        for lic in sorted(report.licenses_without_extension):
-            lic_path = license_path(lic)
-            output.write(
-                _("{lic_path}: license without file extension\n").format(
-                    lic_path=lic_path
-                )
-            )
+    # Deprecated licenses
+    for lic in report.deprecated_licenses:
+        lic_path = license_path(lic)
+        result_dict[lic_path].append(_("deprecated license"))
 
-        # Unused licenses
-        for lic in sorted(report.unused_licenses):
-            lic_path = license_path(lic)
-            output.write(
-                _("{lic_path}: unused license\n").format(lic_path=lic_path)
-            )
+    # Licenses without extension
+    for lic in report.licenses_without_extension:
+        lic_path = license_path(lic)
+        result_dict[lic_path].append(_("license without file extension"))
 
-        # Everything else.
-        subset_output = format_lines_subset(report)
+    # Unused licenses
+    for lic in report.unused_licenses:
+        lic_path = license_path(lic)
+        result_dict[lic_path].append(_("unused license"))
 
-    return output.getvalue() + subset_output
+    subset_dict = _format_lines_subset_dict(report)
+    for key, value in subset_dict.items():
+        result_dict[key].extend(value)
+
+    return _output_lines_dict(result_dict)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,7 @@ finally:
     from reuse import extract, report
     from reuse._util import setup_logging
     from reuse.global_licensing import ReuseDep5
+    from reuse.lint import format_lines, format_lines_subset
     from reuse.vcs import GIT_EXE, HG_EXE, JUJUTSU_EXE, PIJUL_EXE
 
 try:
@@ -665,6 +666,15 @@ def mock_date_today(monkeypatch):
 def contributors(request):
     """Provide contributors for SPDX-FileContributor field generation"""
     yield request.param
+
+
+@pytest.fixture(params=["format_lines", "format_lines_subset"])
+def format_lines_func(request):
+    """Return format_lines or format_lines_subset."""
+    if request.param == "format_lines":
+        yield format_lines
+    elif request.param == "format_lines_subset":
+        yield format_lines_subset
 
 
 # REUSE-IgnoreEnd

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -6,12 +6,13 @@
 
 """All tests for reuse.lint."""
 
-import re
 import shutil
 from inspect import cleandoc
+from pathlib import PurePath
 
 from conftest import cpython, posix
 
+from reuse._util import cleandoc_nl
 from reuse.lint import format_lines, format_plain
 from reuse.project import Project
 from reuse.report import ProjectReport
@@ -234,70 +235,143 @@ def test_lint_json_output(fake_repository):
             assert test_file["spdx_expressions"][0]["is_valid"]
 
 
-def test_lint_lines_output(fake_repository):
-    """Complete test for lint with lines output."""
-    # Prepare a repository that includes all types of situations:
-    # missing_licenses, unused_licenses, bad_licenses, deprecated_licenses,
-    # licenses_without_extension, files_without_copyright,
-    # files_without_licenses, read_errors
-    (fake_repository / "invalid-license.py").write_text(
-        "SPDX-License-Identifier: invalid"
-    )
-    (fake_repository / "no-license.py").write_text(
-        "SPDX-FileCopyrightText: Jane Doe"
-    )
-    (fake_repository / "LICENSES" / "invalid-license-text").write_text(
-        "An invalid license text"
-    )
-    (fake_repository / "LICENSES" / "Nokia-Qt-exception-1.1.txt").write_text(
-        "Deprecated"
-    )
-    (fake_repository / "LICENSES" / "MIT").write_text("foo")
-    (fake_repository / "file with spaces.py").write_text("foo")
-    (fake_repository / "invalid-expression.py").write_text(
-        cleandoc(
+class TestFormatLines:
+    """Tests for format_lines."""
+
+    def test_missing_licenses(self, empty_directory):
+        """List missing licenses."""
+        (empty_directory / "foo.py").write_text(
+            cleandoc(
+                """
+                Copyright Jane Doe
+                SPDX-License-Identifier: MIT OR 0BSD
+                """
+            )
+        )
+        project = Project.from_directory(".")
+        report = ProjectReport.generate(project)
+        result = format_lines(report)
+        assert result == cleandoc_nl(
             """
-            Copyright Jane Doe
-            SPDX-License-Identifier: <invalid>"
+            foo.py: missing license '0BSD'
+            foo.py: missing license 'MIT'
             """
         )
-    )
 
-    project = Project.from_directory(fake_repository)
-    report = ProjectReport.generate(project)
+    @cpython
+    @posix
+    def test_read_errors(self, fake_repository):
+        """Check read error output"""
+        (fake_repository / "restricted.py").write_text("foo")
+        (fake_repository / "restricted.py").chmod(0o000)
+        project = Project.from_directory(".")
+        report = ProjectReport.generate(project)
+        result = format_lines(report)
 
-    lines_result = format_lines(report)
-    lines_result_lines = lines_result.splitlines()
+        assert result == "restricted.py: read error\n"
 
-    assert len(lines_result_lines) == 12
+    def test_invalid_spdx_expressions(self, empty_directory):
+        """List invalid SPDX License Expressions."""
+        (empty_directory / "foo.py").write_text(
+            cleandoc(
+                """
+                Copyright Jane Doe
+                SPDX-License-Identifier: MIT OR
+                SPDX-License-Identifier: <>
+                """
+            )
+        )
+        (empty_directory / "bar.py").write_text(
+            cleandoc(
+                """
+                Copyright John Doe
+                SPDX-License-Identifier: MIT OR
+                """
+            )
+        )
+        project = Project.from_directory(".")
+        report = ProjectReport.generate(project)
+        result = format_lines(report)
 
-    for line in lines_result_lines:
-        assert re.match(".+: [^:]+", line)
+        assert result == cleandoc_nl(
+            """
+            bar.py: missing license 'MIT OR'
+            foo.py: missing license '<>'
+            foo.py: missing license 'MIT OR'
+            bar.py: invalid SPDX License Expression 'MIT OR'
+            foo.py: invalid SPDX License Expression '<>'
+            foo.py: invalid SPDX License Expression 'MIT OR'
+            """
+        )
 
-    assert lines_result.count("invalid-license.py") == 2
-    assert lines_result.count("no-license.py") == 1
-    assert lines_result.count("LICENSES") == 6
-    assert lines_result.count("invalid-license-text") == 3
-    assert lines_result.count("Nokia-Qt-exception-1.1.txt") == 2
-    assert lines_result.count("MIT") == 2
-    assert lines_result.count("file with spaces.py") == 2
-    assert lines_result.count("invalid-expression.py") == 2
+    def test_no_copyright_or_licensing(self, empty_directory):
+        """List files without copyright or licensing."""
+        (empty_directory / "no_lic.py").write_text("Copyright Jane Doe")
+        (empty_directory / "no_copy.py").write_text(
+            "SPDX-License-Identifier: MIT"
+        )
+        (empty_directory / "none.py").write_text("Hello, world!")
+        project = Project.from_directory(".")
+        report = ProjectReport.generate(project)
+        result = format_lines(report)
 
+        assert result == cleandoc_nl(
+            """
+            no_copy.py: missing license 'MIT'
+            no_lic.py: no license identifier
+            none.py: no license identifier
+            no_copy.py: no copyright notice
+            none.py: no copyright notice
+            """
+        )
 
-@cpython
-@posix
-def test_lint_lines_read_errors(fake_repository):
-    """Check read error output"""
-    (fake_repository / "restricted.py").write_text("foo")
-    (fake_repository / "restricted.py").chmod(0o000)
-    project = Project.from_directory(fake_repository)
-    report = ProjectReport.generate(project)
-    result = format_lines(report)
-    print(result)
+    def test_bad_license(self, empty_directory):
+        """List bad licenses."""
+        (empty_directory / "LICENSES").mkdir()
+        (empty_directory / "LICENSES/bad.txt").write_text("Hello, world!")
+        project = Project.from_directory(".")
+        report = ProjectReport.generate(project)
+        result = format_lines(report)
 
-    assert len(result.splitlines()) == 1
-    assert "restricted.py" in result
-    assert "read error" in result
+        path = PurePath("LICENSES/bad.txt")
+        assert result == cleandoc_nl(
+            f"""
+            {path}: bad license 'bad'
+            {path}: unused license
+            """
+        )
+
+    def test_deprecated_license(self, empty_directory):
+        """List deprecated licenses."""
+        (empty_directory / "LICENSES").mkdir()
+        (empty_directory / "LICENSES/GPL-3.0.txt").write_text("Hello, world!")
+        project = Project.from_directory(".")
+        report = ProjectReport.generate(project)
+        result = format_lines(report)
+
+        path = PurePath("LICENSES/GPL-3.0.txt")
+        assert result == cleandoc_nl(
+            f"""
+            {path}: deprecated license
+            {path}: unused license
+            """
+        )
+
+    def test_licenses_without_extension(self, empty_directory):
+        """List licenses without extension."""
+        (empty_directory / "LICENSES").mkdir()
+        (empty_directory / "LICENSES/MIT").write_text("Hello, world!")
+        project = Project.from_directory(".")
+        report = ProjectReport.generate(project)
+        result = format_lines(report)
+
+        path = PurePath("LICENSES/MIT")
+        assert result == cleandoc_nl(
+            f"""
+            {path}: license without file extension
+            {path}: unused license
+            """
+        )
 
 
 # REUSE-IgnoreEnd


### PR DESCRIPTION
<!--
Before submitting a PR, please read CONTRIBUTING.md. Non-trivial changes should
be discussed in an issue before committing to a PR.

Please succinctly describe your changes.
-->

Fixes a bug mentioned in #1248 where a newline was missing.

I'd like to more universally sort by path.

<!-- Next, let's do a check list. Remove what doesn't apply. -->

- [x] Added a change log entry in `changelog.d/<directory>/`.
- [x] Added self to copyright blurb of touched files.
- [x] Added self to `AUTHORS.rst`.
- [x] Wrote tests.
- [ ] Documented my changes in `docs/man/` or elsewhere.
- [x] My changes do not contradict
      [the current specification](https://reuse.software/spec/).
- [x] I agree to license my contribution under the licenses indicated in the
      changed files.
