### PR TITLE
Fix a regex that was occasionally very slow

### DIFF
--- a/changelog.d/fixed/performance-regex.md
+++ b/changelog.d/fixed/performance-regex.md
@@ -1,0 +1,2 @@
+- Fixed a performance regression introduced in v6.1.1 that would cause some
+  copyright notices to take incredibly long to parse. (#1252)

--- a/src/reuse/extract.py
+++ b/src/reuse/extract.py
@@ -119,7 +119,7 @@ REUSE_IGNORE_END = "REUSE-IgnoreEnd"
 SPDX_SNIPPET_INDICATOR = b"SPDX-SnippetBegin"
 
 _START_PATTERN = r"(?:^.*?)"
-_END_PATTERN = r"(?:\s*(?:{})?\s*)*$".format(
+_END_PATTERN = r"\s*(?:{})*\s*$".format(
     "|".join(
         set(
             chain(


### PR DESCRIPTION
For reasons that are a little beyond me at the moment, but which are probably very obvious, the following line in the Linux kernel took 9 seconds to match:

```
* Portions Copyright (C) 2004-2005 Christoph Hellwig              *
```

The altered regex is sufficiently swift.

<!--
Before submitting a PR, please read CONTRIBUTING.md. Non-trivial changes should
be discussed in an issue before committing to a PR.

Please succinctly describe your changes.
-->

<!-- Next, let's do a check list. Remove what doesn't apply. -->

- [x] Added a change log entry in `changelog.d/<directory>/`.
- [x] Added self to copyright blurb of touched files.
- [x] Added self to `AUTHORS.rst`.
- [ ] Wrote tests.
- [ ] Documented my changes in `docs/man/` or elsewhere.
- [x] My changes do not contradict
      [the current specification](https://reuse.software/spec/).
- [x] I agree to license my contribution under the licenses indicated in the
      changed files.
