### PR TITLE
GitHub Actions: Run pytest on Python 3.14

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
       # do not abort the whole test job if one combination in the matrix fails
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.14t"]
+        python-version: ["3.10", "3.14"]
         os: [ubuntu-24.04]
         include:
           - python-version: "3.10"


### PR DESCRIPTION
https://www.python.org/downloads/release/python-3140/
* https://github.com/actions/checkout/releases
* https://github.com/actions/setup-python/releases

<!--
Before submitting a PR, please read CONTRIBUTING.md. Non-trivial changes should
be discussed in an issue before committing to a PR.

Please succinctly describe your changes.
-->

<!-- Next, let's do a check list. Remove what doesn't apply. -->

- [ ] Added a change log entry in `changelog.d/<directory>/`.
- [ ] Added self to copyright blurb of touched files.
- [ ] Added self to `AUTHORS.rst`.
- [ ] Wrote tests.
- [ ] Documented my changes in `docs/man/` or elsewhere.
- [ ] My changes do not contradict
      [the current specification](https://reuse.software/spec/).
- [x] I agree to license my contribution under the licenses indicated in the
      changed files.

---
> Created wheel for rapidfuzz: filename=rapidfuzz-3.14.1-cp314-cp314t-linux_x86_64.whl 

https://github.com/rapidfuzz/RapidFuzz/releases -- Release 3.14.1 is latest.
```
<frozen importlib._bootstrap>:491: RuntimeWarning: The global interpreter lock (GIL) has been enabled
    to load module 'rapidfuzz._feature_detector_cpp', which has not declared that it can run safely
    without the GIL. To override this behavior and keep the GIL disabled (at your own risk), run with
    PYTHON_GIL=0 or -Xgil=0.
```

---
`GitHub Actions: Run pytest on free threaded Python 3.14t`
--> `GitHub Actions: Run pytest on Python 3.14` because of
* rapidfuzz/RapidFuzz#460