### PR TITLE
feat: Add `.zon` file support

### DIFF
--- a/changelog.d/added/zon.md
+++ b/changelog.d/added/zon.md
@@ -1,0 +1,1 @@
+- Added support for `.zon` file. (#1271)

--- a/src/reuse/comment.py
+++ b/src/reuse/comment.py
@@ -879,6 +879,7 @@ EXTENSION_COMMENT_STYLE_MAP = {
     ".yml": PythonCommentStyle,
     ".yrl": TexCommentStyle,
     ".zig": CppSingleCommentStyle,
+    ".zon": CppSingleCommentStyle,
     ".zsh": PythonCommentStyle,
 }
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read CONTRIBUTING.md. Non-trivial changes should
be discussed in an issue before committing to a PR.

Please succinctly describe your changes.
-->

This adds support for Zig Object Notation (ZON).[^1] This is primarily used in `build.zig.zon`, which is used to declare package information in the Zig's official package manager.[^2][^3] However, it can also be used for other purposes.


[^1]: <https://ziglang.org/documentation/0.15.2/std/#std.zon>
[^2]: <https://github.com/ziglang/zig/blob/0.15.2/doc/build.zig.zon.md>
[^3]: <https://ziglang.org/download/0.11.0/release-notes.html#Package-Management>

<!-- Next, let's do a check list. Remove what doesn't apply. -->

- [x] Added a change log entry in `changelog.d/<directory>/`.
- [x] I agree to license my contribution under the licenses indicated in the
      changed files.
