### PR TITLE
Add issue chooser redirect to Codeberg tracker

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: false
+contact_links:
+  - name: REUSE issue tracker at Codeberg
+    url: https://codeberg.org/fsfe/reuse-tool/issues/new
+    about: Please file issues in the Codeberg repo issue tracker
+


### PR DESCRIPTION
This config, installed into the repo here, will modify the "New Issue" button on the Issues tab to show this popup, instead of allowing users to create issues:

<img width="834" height="183" alt="image" src="https://github.com/user-attachments/assets/e26f48c4-4c35-47a8-8c05-8f5dea49f29d" />

cc: @carmenbianca 