### PR TITLE
Add codespell support with configuration and fixes

### DIFF
--- a/.forgejo/workflows/codespell.yml
+++ b/.forgejo/workflows/codespell.yml
@@ -1,0 +1,21 @@
+# Codespell configuration is within pyproject.toml
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: docker
+    container:
+      image: ghcr.io/codespell-project/actions-codespell/master:latest
+    steps:
+      - name: Checkout
+        uses: https://code.forgejo.org/actions/checkout@v4
+      - name: Codespell
+        run: codespell .

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,23 @@
+# Codespell configuration is within pyproject.toml
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Codespell
+        uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579  # v2.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,3 +44,9 @@ repos:
             "-rn", # Only display messages
             "-sn", # Don't display the score
           ]
+  
+  - repo: https://github.com/codespell-project/codespell
+    # Configuration for codespell is in .pre-commit-config.yaml
+    rev: v2.4.1
+    hooks:
+    - id: codespell

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,3 +194,10 @@ module = [
     "pkg_resources",
 ]
 ignore_missing_imports = true
+
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git,.gitignore,.gitattributes,*.svg,*.lock'
+check-hidden = true
+# ignore-regex = ''
+# ignore-words-list = ''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,7 +197,12 @@ ignore_missing_imports = true
 
 [tool.codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = '.git,.gitignore,.gitattributes,*.svg,*.lock'
+# po/ - translation files in foreign languages (cs, de, eo, es, fi, fr, gl, it,
+#       nl, pt, sv, tr) trigger many false positives against English dictionary
+skip = '.git,.gitignore,.gitattributes,*.svg,*.lock,po'
 check-hidden = true
-# ignore-regex = ''
-# ignore-words-list = ''
+# uery - part of regex `.xq(l|m|y|uery|)` listing XQuery file extensions
+# useable, unparseable - alternative valid English spellings used in historical
+#   CHANGELOG entries
+# vie - French word used in a poem in tests/test_extract.py fixture
+ignore-words-list = 'uery,useable,unparseable,vie'

--- a/src/reuse/copyright.py
+++ b/src/reuse/copyright.py
@@ -320,7 +320,7 @@ class YearRange:
     @classmethod
     def compact(cls, ranges: Iterable["YearRange"]) -> tuple["YearRange", ...]:
         """Given an iterable of :class:`YearRange`, compact them such that a new
-        more concise list is returne without losing information. This process
+        more concise list is returned without losing information. This process
         also sorts the ranges, such that ranges with lower starts come before
         ranges with higher starts.
 


### PR DESCRIPTION
Add codespell configuration, CI workflow, pre-commit hook, and fix one
existing typo.

More about codespell: https://github.com/codespell-project/codespell

I personally introduced it to over a hundred of projects already mostly
with positive feedback (see the
["improveit-dashboard"](https://github.com/yarikoptic/improveit-dashboard/blob/master/READMEs/yarikoptic.md)).

## Changes

### Configuration & Infrastructure

- Added `[tool.codespell]` section in `pyproject.toml` with skip list
  and ignore-words-list. The `po/` directory is skipped because the
  translation files there are in foreign languages (cs, de, eo, es, fi,
  fr, gl, it, nl, pt, sv, tr) and trigger ~540 false positives against
  codespell's English dictionary.
- Added GitHub Actions workflow (`.github/workflows/codespell.yml`) to
  check spelling on push and PRs to `main`. The workflow has
  `permissions: contents: read` so it is safe.
- Added Forgejo Actions workflow (`.forgejo/workflows/codespell.yml`)
  for completeness if the project is mirrored on a Forgejo instance. (or should it be submitted there separately?)
- Added pre-commit hook entry for codespell in  `.pre-commit-config.yaml`.

### Domain-Specific Whitelist

Added `ignore-words-list` for legitimate hits that codespell would
otherwise flag:

- `uery` is part of the regex `.xq(l|m|y|uery|)` enumerating XQuery
  file extensions in `CHANGELOG.md`
- `useable` and `unparseable` are alternative valid English spellings
  appearing in historical `CHANGELOG.md` entries — left unchanged to
  preserve the historical record
- `vie` is a French word (meaning "life") used in a poem fixture in
  `tests/test_extract.py`

### Typo Fixes

One genuine typo found and fixed:

- b072c63 `Fix typo in copyright.py docstring: returne -> returned`

### Historical Context

`git log --grep=typo -i` on `main` shows **23 prior commits** fixing
typos manually. Automated spell-checking on push / PR / pre-commit
should reduce that follow-up churn.

## Testing

- `uvx codespell` passes with zero errors after these changes
- The new config, workflows, and pre-commit hook are minimal and only
  add spell-checking — no functional behavior changes

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) and love to typos free code
